### PR TITLE
fix: add rel="noopener" to external links in index.html (#85)

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -736,6 +736,7 @@
                 <a
                   href="https://github.com/kubestellar/kubestellar"
                   target="_blank"
+                  rel="noopener"
                   class="flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-emerald-900/30 rounded transition-all duration-200 hover:text-emerald-300 hover:shadow-md"
                 >
                   <svg
@@ -757,6 +758,7 @@
                 <a
                   href="https://github.com/kubestellar/kubestellar/fork"
                   target="_blank"
+                  rel="noopener"
                   class="flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-emerald-900/30 rounded transition-all duration-200 hover:text-emerald-300 hover:shadow-md"
                 >
                   <svg
@@ -777,6 +779,7 @@
                 <a
                   href="https://github.com/kubestellar/kubestellar/watchers"
                   target="_blank"
+                  rel="noopener"
                   class="flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-emerald-900/30 rounded transition-all duration-200 hover:text-emerald-300 hover:shadow-md"
                 >
                   <svg


### PR DESCRIPTION
Description:
Adds rel="noopener" to all external links with target="_blank" in `index.html` o resolve security warning reported in issue #85.

Fixes #85 