### PR TITLE
Add Accessible Text to Mobile Menu and Back-to-Top Buttons

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -800,9 +800,9 @@
             <!-- Mobile menu button -->
             <button
               class="md:hidden p-2 rounded focus:outline-none hover:bg-gray-100 dark:hover:bg-gray-700"
-              aria-label="Open navigation menu"
+              aria-label="Open menu"
             >
-              <span class="sr-only">Open navigation menu</span>
+              <span class="sr-only">Open menu</span>
               <svg
                 class="h-6 w-6 text-gray-700 dark:text-gray-300"
                 fill="none"
@@ -4987,7 +4987,9 @@ kubectl apply -f https://github.com/kubestellar/kubestellar/releases/latest/down
       <button
         id="back-to-top"
         class="fixed bottom-8 right-8 p-2 rounded-full bg-blue-600 text-white shadow-lg z-50 transition-all duration-300 opacity-0 translate-y-10"
+        aria-label="Back to top"
       >
+        <span class="sr-only">Back to top</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-6 w-6"

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -800,8 +800,9 @@
             <!-- Mobile menu button -->
             <button
               class="md:hidden p-2 rounded focus:outline-none hover:bg-gray-100 dark:hover:bg-gray-700"
-              aria-label="Open menu"
+              aria-label="Open navigation menu"
             >
+              <span class="sr-only">Open navigation menu</span>
               <svg
                 class="h-6 w-6 text-gray-700 dark:text-gray-300"
                 fill="none"


### PR DESCRIPTION
## Summary 
Add accessible text to mobile menu and back-to-top buttons for screen readers.

Fixes #86 