### PR TITLE
patch: major/minor/patch label workflow

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,6 +1,6 @@
 name: Auto Label on PR Title
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
### Description

The concerned workflow should now assign labels properly.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #104 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

The workflow was previously failing with a “Resource not accessible by integration” error because it used the `pull_request` event, which runs in the context of the forked repo for PRs from forks. The default GITHUB_TOKEN cannot write to the base repo in that context. I changed the workflow to use `pull_request_target`, which runs in the base repository context, giving the token proper permissions. Now, the workflow can safely assign labels to PRs from forks based on the PR title.

