### PR TITLE
minor: using link instead of anchor, docs and blog opens in new tab

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -179,7 +179,8 @@ export default function Navigation() {
             <div className="flex items-center space-x-8">
               {/* Docs Link */}
               <div className="relative group">
-                <a
+                <Link
+                  target="_blank"
                   href="#docs"
                   className="text-sm font-medium text-gray-300 hover:text-blue-400 transition-all duration-300 flex items-center space-x-1 px-3 py-2 rounded-lg hover:bg-blue-500/10 hover:shadow-lg hover:shadow-blue-500/20 nav-link-hover"
                 >
@@ -199,12 +200,13 @@ export default function Navigation() {
                     </svg>
                   </div>
                   <span>Docs</span>
-                </a>
+                </Link>
               </div>
 
               {/* Blog Link */}
               <div className="relative group">
-                <a
+                <Link
+                  target="_blank"
                   href="https://kubestellar.medium.com/list/predefined:e785a0675051:READING_LIST"
                   className="text-sm font-medium text-gray-300 hover:text-purple-400 transition-all duration-300 flex items-center space-x-1 px-3 py-2 rounded-lg hover:bg-purple-500/10 hover:shadow-lg hover:shadow-purple-500/20 transform nav-link-hover"
                 >
@@ -231,7 +233,7 @@ export default function Navigation() {
                     </svg>
                   </div>
                   <span>Blog</span>
-                </a>
+                </Link>
               </div>
 
               {/* Contribute Dropdown */}


### PR DESCRIPTION
### Description

Using link tag with target="_blank" to open links in new tabs.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #106 

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
