### PR TITLE
update the slack link

### DIFF
--- a/src/components/master-page/GetStartedSection.tsx
+++ b/src/components/master-page/GetStartedSection.tsx
@@ -209,7 +209,7 @@ export default function GetStartedSection() {
               </p>
               <div className="mt-4 grid grid-cols-2 gap-2">
                 <a
-                  href="#"
+                  href="https://kubestellar.io/slack"
                   className="flex items-center justify-center p-2 rounded bg-blue-600 hover:bg-blue-700 text-white text-sm"
                 >
                   <svg


### PR DESCRIPTION
### Description

Broken Slack link is preventing users from accessing the intended workspace or channel.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #110 