### PR TITLE
update the github link

### DIFF
--- a/src/components/master-page/GetStartedSection.tsx
+++ b/src/components/master-page/GetStartedSection.tsx
@@ -222,7 +222,7 @@ export default function GetStartedSection() {
                   Slack
                 </a>
                 <a
-                  href="#"
+                  href="https://github.com/kubestellar/kubestellar"
                   className="flex items-center justify-center p-2 rounded bg-gray-700 hover:bg-gray-800 text-white text-sm"
                 >
                   <svg


### PR DESCRIPTION
### Description

Broken github link is preventing users from accessing the intended workspace or channel.

### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #112