### PR TITLE
Fixes the broken Link of Community Chat in Get in Touch Section

### DIFF
--- a/src/components/master-page/ContactSection.tsx
+++ b/src/components/master-page/ContactSection.tsx
@@ -174,7 +174,7 @@ Google Groups: https://groups.google.com/g/kubestellar-dev`
 
             {/* Contact card 2 */}
             <a
-              href="https://kubestellar.slack.com"
+              href="https://kubestellar.io/slack"
               target="_blank"
               rel="noopener noreferrer"
               className="block bg-gray-800/50 backdrop-blur-md rounded-xl shadow-sm border border-transparent p-4 sm:p-6 transform transition-all duration-300 hover:shadow-md hover:-translate-y-1 hover:border-purple-500/70 cursor-pointer"


### PR DESCRIPTION
### Description

The **Community Chat** link in the **Get in Touch** section is currently redirecting to the wrong URL (**[https://kubestellar.slack.com/](https://kubestellar.slack.com/)**). It should instead redirect to **[https://kubestellar.io/slack](https://kubestellar.io/slack)**.


<!--
**IMPORTANT: The first two lines of your description will be used as a summary in the progress log.**
Please provide a concise, user-facing summary of the changes within the first two lines. Do not add a heading.
You can add more detailed context, implementation details, or other notes below the summary.
-->

### Screenshots or Logs (if applicable)

**Before :** 

[Screencast from 2025-10-10 06-04-58.webm](https://github.com/user-attachments/assets/eb5b7a80-fef8-4f60-a13b-da99ba64acb5)


**After :**

[Screencast from 2025-10-10 06-11-27.webm](https://github.com/user-attachments/assets/e8313e79-8dbb-4961-a546-9173de2aae29)


<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
