### PR TITLE
added link in navabr

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -58,6 +58,7 @@
     "contribute": "Contribute",
     "joinIn": "Join In",
     "contributeHandbook": "Contribute Handbook",
+    "quickInstallation": "Quick Installation",
     "security": "Security",
     "community": "Community",
     "getInvolved": "Get Involved",

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -344,6 +344,25 @@ export default function Navigation() {
                     </svg>
                     {t("contributeHandbook")}
                   </Link>
+                  <Link
+                    href="/quick-installation"
+                    className="flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-emerald-900/30 rounded transition-all duration-200 hover:text-emerald-300 hover:shadow-md"
+                  >
+                    <svg
+                      className="w-4 h-4 mr-3"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M13 10V3L4 14h7v7l9-11h-7z"
+                      ></path>
+                    </svg>
+                    {t("quickInstallation")}
+                  </Link>
                   <a
                     href="#security"
                     className="flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-emerald-900/30 rounded transition-all duration-200 hover:text-emerald-300 hover:shadow-md"


### PR DESCRIPTION
Fixes: #167

- adding this in contribute handbook is the abd idea it would be better to add a separete card for this in contribute handbook but it would break symmetery in contribute handbook so i didn't add this in contribute handbook 

This pull request adds a new "Quick Installation" navigation link to the main menu, making it easier for users to access installation instructions. The update includes both the user interface and the translation file.

**Navigation improvements:**

* Added a new `Link` to `/quick-installation` in the `Navigation` component, including a custom icon and localized label for "Quick Installation".

**Localization updates:**

* Added the `quickInstallation` entry to the English translation file `messages/en.json` to support the new navigation label.