### PR TITLE
Fix get started section in contribution ladder

### DIFF
--- a/src/app/[locale]/ladder/page.tsx
+++ b/src/app/[locale]/ladder/page.tsx
@@ -424,10 +424,8 @@ export default function MaintainerLadderPage() {
             </div>
           </div>
         </section>
-
         {/* Ready To Get Started Section */}
         <GetStartedSection />
-        
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
Fixes : #165 

This pull request refactors the "Call to Action" section on the `MaintainerLadderPage` by replacing its inline implementation with a reusable component, improving maintainability and consistency across the codebase.

Component refactoring:

* Removed the inline "Call to Action" section from `src/app/[locale]/ladder/page.tsx` and replaced it with the new `GetStartedSection` component for better reusability and cleaner code. ([src/app/[locale]/ladder/page.tsxL426-R430](diffhunk://#diff-7bc4c1c73f9293d388d74839f0cf2dd06d77d92b91b692d7868c90be59954c0fL426-R430))
* Added an import for `GetStartedSection` from `@/components/master-page/GetStartedSection` to support the new component usage. ([src/app/[locale]/ladder/page.tsxR7](diffhunk://#diff-7bc4c1c73f9293d388d74839f0cf2dd06d77d92b91b692d7868c90be59954c0fR7))