### PR TITLE
Fixed the images link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KubeStellar Documentation
 
 <p align="center">
-  <img src="public/KubeStellar-with-Logo-transparent.png" alt="KubeStellar Logo" width="72"/>
+  <img src="public/KubeStellar-with-Logo-transparent.png" alt="KubeStellar Logo" width="200"/>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Earlier, the images in the readme were not rendering and showing only alt text. I have fixed the link to make sure they render properly.