### PR TITLE
fix: Add styling for the banner in light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,6 +71,21 @@ html:not(.dark) .nextra-docs-theme .nextra-sidebar-container {
   background: #ffffff;
 }
 
+html:not(.dark) .nextra-banner {
+  background: #eff6ff !important; /* bg-blue-50 */
+  color: #1f2937 !important; /* gray-800 */
+}
+
+html:not(.dark) .nextra-banner button {
+  background: transparent !important;
+  color: #1f2937 !important; /* gray-800 */
+}
+
+html:not(.dark) .nextra-banner button:hover {
+  background: rgba(0, 0, 0, 0.05) !important;
+  opacity: 1 !important;
+}
+
 /* Custom Tailwind utilities */
 .text-gradient {
   background: linear-gradient(to right, rgb(147, 51, 234), rgb(59, 130, 246));


### PR DESCRIPTION
### 📌 Fixes

Fixes #306

---

### 📝 Summary of Changes

- Fixed Nextra Banner component displaying dark mode styles (dark background on left/right sides and close button) when in light mode
- Added CSS overrides to ensure banner container and close button properly adapt to light mode theme

---

### Changes Made

- [x] Added CSS overrides in `globals.css` to fix Nextra Banner light mode styling
- [x] Override banner container background color in light mode (`#eff6ff` / bg-blue-50)
- [x] Override close button styling in light mode (transparent background with dark text)
- [x] Added hover state styling for close button in light mode

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<img width="1470" height="126" alt="Screenshot 2025-11-23 at 11 22 35 PM" src="https://github.com/user-attachments/assets/1a7b77a9-ebff-438f-be1e-e2c12fb3db69" />


---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_