### PR TITLE
fix: update kubectl-multi repository URL

### DIFF
--- a/src/app/[locale]/marketplace/plugins.tsx
+++ b/src/app/[locale]/marketplace/plugins.tsx
@@ -73,7 +73,7 @@ Perfect for DevOps teams managing edge deployments, hybrid clouds, or geographic
       compatibility: ["Linux", "macOS", "Windows"],
       screenshots: [],
       documentation: "https://docs.kubestellar.io/plugins/kubectl-multi",
-      github: "https://github.com/kubestellar/kubectl-multi",
+      github: "https://github.com/kubestellar/kubectl-multi-plugin",
       tags: ["kubectl", "multi-cluster", "cli", "automation", "productivity"],
     },
     {

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -59,7 +59,7 @@ export default function ProductsPage() {
     {
       id: "kubectl-multi",
       logo: "/products/kubectl-multi.png",
-      website: "https://github.com/kubestellar/kubectl-multi",
+      website: "https://github.com/kubestellar/kubectl-multi-plugin",
       repository: "https://github.com/kubestellar/kubectl-multi-plugin",
       name: t("products.kubectlMulti.name"),
       fullName: t("products.kubectlMulti.fullName"),


### PR DESCRIPTION
### 📌 Fixes

Fixes #336 



---

### 📝 Summary of Changes
This pull request makes a small update to the `ProductsPage` component. The change corrects the `repository` URL for the `kubectl-multi` product to point to the proper GitHub repository.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

https://github.com/user-attachments/assets/f3a43b37-f19c-4734-a88b-8c665e345f0f




---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
