### PR TITLE
Size fix

### DIFF
--- a/src/components/docs/DocsNavbar.tsx
+++ b/src/components/docs/DocsNavbar.tsx
@@ -475,21 +475,21 @@ export default function DocsNavbar() {
             onMouseLeave={handleMouseLeave}
           >
             <button
-              className={`text-xs font-mono transition-colors px-2 py-1.5 rounded-md flex items-center gap-1.5 cursor-pointer ${
-                isDark 
-                  ? 'text-gray-300 hover:text-gray-100 hover:bg-neutral-800'
-                  : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
-              }`}
+              className={`${buttonClasses} cursor-pointer font-mono`}
               aria-haspopup="true"
               aria-expanded={openDropdown === "version"}
             >
               <span>{currentVersion}</span>
+<<<<<<< Updated upstream
               <svg
                 className={`w-3 h-3 transition-transform duration-200 ${openDropdown === "version" ? "rotate-180" : ""}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
               >
+=======
+              <svg className={`w-5 h-5 transition-transform duration-200 ${openDropdown === "version" ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+>>>>>>> Stashed changes
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </button>
@@ -543,20 +543,28 @@ export default function DocsNavbar() {
             onMouseLeave={handleMouseLeave}
           >
             <button
+<<<<<<< Updated upstream
               className={`text-sm transition-colors p-1.5 rounded-md flex items-center gap-1 cursor-pointer ${
                 isDark 
                   ? 'text-gray-300 hover:text-gray-100 hover:bg-neutral-800'
                   : 'text-gray-700 hover:text-gray-900 hover:bg-gray-100'
               }`}
+=======
+              className={`${buttonClasses} cursor-pointer`}
+>>>>>>> Stashed changes
               aria-label="GitHub"
               aria-haspopup="true"
               aria-expanded={openDropdown === "github"}
             >
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.300 24 12c0-6.627-5.373-12-12-12z" />
               </svg>
               <svg
+<<<<<<< Updated upstream
                 className={`w-3 h-3 transition-transform duration-200 ${openDropdown === "github" ? "rotate-180" : ""}`}
+=======
+                className={`w-5 h-5 transition-transform duration-200 ${openDropdown === "github" ? "rotate-180" : ""}`}
+>>>>>>> Stashed changes
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"


### PR DESCRIPTION
Fixes #360
Before 

<img width="556" height="191" alt="image" src="https://github.com/user-attachments/assets/b57b64c4-a719-41fa-93de-574c2a683d44" />
After

<img width="559" height="230" alt="image" src="https://github.com/user-attachments/assets/94c3cb5d-0449-4071-97c8-ccfe768f9385" />

Changes in size of the github and version button on the navbar