### PR TITLE
feat(ui): unify primary CTA button styles

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import Image from "next/image";
+import { primaryLandingCtaClasses } from "./ctaStyles";
 import { GridLines, StarField } from "./index";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
@@ -315,12 +316,12 @@ export default function Footer() {
                     />
                   </div>
 
-                  <button
-                    type="submit"
-                    className="w-full sm:w-auto px-6 py-3 text-sm font-medium text-white bg-gradient-to-r from-blue-600 to-purple-600 border border-transparent rounded-lg shadow-sm hover:from-blue-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-all duration-200 transform hover:-translate-y-0.5 whitespace-nowrap"
-                  >
-                    <span>{t("subscribe")}</span>
-                  </button>
+                    <button
+                      type="submit"
+                      className={`${primaryLandingCtaClasses} w-full sm:w-auto`}
+                    >
+                      <span>{t("subscribe")}</span>
+                    </button>
                 </form>
               </div>
             </div>

--- a/src/components/ctaStyles.ts
+++ b/src/components/ctaStyles.ts
@@ -1,0 +1,7 @@
+export const primaryLandingCtaClasses =
+  "inline-flex items-center justify-center px-6 py-3 text-sm sm:text-base font-semibold rounded-xl text-white " +
+  "bg-gradient-to-r from-blue-600 via-blue-700 to-blue-600 hover:from-blue-700 hover:via-blue-800 hover:to-blue-700 " +
+  "border border-blue-500/60 hover:border-blue-400 shadow-lg hover:shadow-xl " +
+  "transition-all duration-300 transform hover:-translate-y-0.5 " +
+  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 " +
+  "disabled:opacity-60 disabled:cursor-not-allowed whitespace-nowrap";

--- a/src/components/master-page/ContactSection.tsx
+++ b/src/components/master-page/ContactSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { primaryLandingCtaClasses } from "../ctaStyles";
 import { GridLines, StarField } from "../index";
 import { useTranslations } from "next-intl";
 import { getLocalizedUrl } from "@/lib/url";
@@ -491,7 +492,7 @@ export default function ContactSection() {
                     <button
                       type="submit"
                       disabled={isSubmitting}
-                      className="w-full py-2 sm:py-3 px-4 sm:px-6 bg-gradient-to-r from-blue-600 via-purple-600 to-blue-700 hover:from-blue-700 hover:via-purple-700 hover:to-blue-800 disabled:from-gray-600 disabled:to-gray-700 rounded-xl font-bold text-white shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 text-sm sm:text-base"
+                      className={`w-full ${primaryLandingCtaClasses}`}
                     >
                       {isSubmitting ? (
                         <div className="flex items-center justify-center space-x-2">

--- a/src/components/master-page/HeroSection.tsx
+++ b/src/components/master-page/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { primaryLandingCtaClasses } from "../ctaStyles";
 import { Link as IntlLink } from "@/i18n/navigation";
 import { GridLines, StarField, GlobeAnimation } from "../index";
 import { useTranslations } from "next-intl";
@@ -312,12 +313,7 @@ export default function HeroSection() {
                 {/* Local Development Button */}
                 <IntlLink
                   href="/quick-installation"
-                  className="primary-action-btn group relative overflow-hidden inline-flex items-center justify-center px-6 py-4 text-base font-bold rounded-xl text-white 
-                            bg-gradient-to-r from-blue-600 via-blue-700 to-blue-600 
-                            hover:from-blue-700 hover:via-blue-800 hover:to-blue-700 
-                            transition-all duration-500 transform hover:-translate-y-1 
-                            hover:shadow-xl hover:shadow-blue-500/40 
-                            animate-btn-float border-2 border-blue-500/50 hover:border-blue-400"
+                  className={`${primaryLandingCtaClasses} animate-btn-float`}
                 >
                   <span className="relative z-10 flex items-center gap-2">
                     <span className="text-xl">🚀</span>
@@ -340,12 +336,7 @@ export default function HeroSection() {
                 {/* AWS EKS Cloud Button */}
                 <Link
                   href="/docs/getting-started/aws-eks"
-                  className="primary-action-btn group relative overflow-hidden inline-flex items-center justify-center px-6 py-4 text-base font-bold rounded-xl text-white 
-                            bg-gradient-to-r from-orange-600 via-orange-700 to-orange-600 
-                            hover:from-orange-700 hover:via-orange-800 hover:to-orange-700 
-                            transition-all duration-500 transform hover:-translate-y-1 
-                            hover:shadow-xl hover:shadow-orange-500/40 
-                            animate-btn-float border-2 border-orange-500/50 hover:border-orange-400"
+                  className={`${primaryLandingCtaClasses} bg-gradient-to-r from-orange-600 via-orange-700 to-orange-600 hover:from-orange-700 hover:via-orange-800 hover:to-orange-700 border-orange-500/60 hover:border-orange-400 animate-btn-float`}
                   style={{ animationDelay: "0.1s" }}
                 >
                   <span className="relative z-10 flex items-center gap-2">

--- a/src/components/master-page/HowToUseSection.tsx
+++ b/src/components/master-page/HowToUseSection.tsx
@@ -2,6 +2,7 @@
 
 import { GridLines, StarField } from "../index";
 import { useTranslations } from "next-intl";
+import { primaryLandingCtaClasses } from "../ctaStyles";
 import { useState, useEffect, useRef } from "react";
 
 export default function HowToUseSection() {
@@ -492,7 +493,7 @@ export default function HowToUseSection() {
               <div className="absolute inset-x-0 bottom-0 h-60 bg-gradient-to-t from-slate-900 via-slate-900/95 to-transparent pointer-events-none z-40 flex items-end justify-center pb-12">
                 <button
                   onClick={() => setShowAllSteps(true)}
-                  className="pointer-events-auto px-8 py-4 bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold rounded-lg shadow-xl hover:from-purple-700 hover:to-blue-700 transition-all duration-300 transform hover:scale-105 flex items-center gap-3 border border-purple-400/30 animate-bounce-slow"
+                  className={`pointer-events-auto ${primaryLandingCtaClasses} px-8 py-4 animate-bounce-slow`}
                 >
                   <span className="text-lg">Show More Steps</span>
                   <svg


### PR DESCRIPTION
Fixes #404 
Buttons in the Hero, How to Use KubeStellar, Get in Touch, and Footer sections use inconsistent styles.
- Align all CTA buttons to a unified design (size, radius, typography, colors, states).
- Update Hero, How to Use, Get in Touch, and Footer buttons to match the landing page’s primary CTA style.
- Ensure consistent hover/focus states and spacing.


<img width="738" height="174" alt="Screenshot 2025-12-13 at 3 45 35 AM" src="https://github.com/user-attachments/assets/ce9ae5d6-cb38-4cff-bb69-69efc44063c8" />
<img width="680" height="244" alt="Screenshot 2025-12-13 at 3 45 45 AM" src="https://github.com/user-attachments/assets/fda35f71-5af2-4060-8b68-01d90e912001" />
<img width="858" height="243" alt="Screenshot 2025-12-13 at 3 46 01 AM" src="https://github.com/user-attachments/assets/5ddb95d1-6a43-4601-8e91-2edf924ea873" />
