### PR TITLE
Add the missing Simplified Chinese translation for 'Marketplace'

### DIFF
--- a/messages/SC.json
+++ b/messages/SC.json
@@ -3,6 +3,7 @@
     "docs": "文档",
     "blog": "博客",
     "playground": "游乐场",
+    "marketplace": "插件市场",
     "contribute": "贡献",
     "joinIn": "加入我们",
     "contributeHandbook": "贡献手册",


### PR DESCRIPTION
### 📝 Summary of Changes
On the new homepage, the translation of 'Marketplace' into simplified Chinese is somehow missing:
<img width="1344" height="62" alt="image" src="https://github.com/user-attachments/assets/77a6dfee-297f-45ae-8695-e4b1cd1b9903" />

This PR tries to add the translation.