### PR TITLE
🐛 fix setup instructions to point at docs repo, fix typo in 'cd docd' c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ node --version
 1. **Clone the repository:**
 
    ```bash
-   git clone https://github.com/kubestellar/kubestellar.git
-   cd docd
+   git clone https://github.com/kubestellar/docs.git
+   cd docs
    ```
 
 2. **Install dependencies:**


### PR DESCRIPTION
…ommand to 'cd docs'

### 📌 Fixes

The README for this repository included a link to download the kubestellar/kubestellar repository, not the kubstellar/docs repository. This fixes that link and also a typo from `cd docd` to the correct `cd doc` command.
