### PR TITLE
fix: add localStorage check to prevent SSR errors

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -49,8 +49,10 @@ export default async function RootLayout({ children, params }: Props) {
           dangerouslySetInnerHTML={{
             __html: `
               try {
-                const theme = localStorage.getItem('theme') || 'dark';
-                document.documentElement.classList.toggle('dark', theme === 'dark');
+                if (typeof localStorage !== 'undefined') {
+                  const theme = localStorage.getItem('theme') || 'dark';
+                  document.documentElement.classList.toggle('dark', theme === 'dark');
+                }
               } catch (e) {}
             `,
           }}


### PR DESCRIPTION
**The fix I applied should resolve the `localStorage.getItem is not a function `error. The issue was that the inline script was trying to access localStorage without checking if it exists first (which happens during server-side rendering).**

**The fix adds a check `if (typeof localStorage !== 'undefined')` before accessing localStorage, so it only runs in the browser environment where localStorage is available.**