### PR TITLE
Added ThemeProvider to both root layouts

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { getMessages } from "next-intl/server";
 import type { ReactNode } from "react";
 import { notFound } from "next/navigation";
 import { locales, type Locale } from "@/i18n/settings";
+import { ThemeProvider } from "next-themes";
 import "../globals.css";
 
 const inter = Inter({
@@ -44,26 +45,14 @@ export default async function RootLayout({ children, params }: Props) {
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              try {
-                if (typeof localStorage !== 'undefined') {
-                  const theme = localStorage.getItem('theme') || 'dark';
-                  document.documentElement.classList.toggle('dark', theme === 'dark');
-                }
-              } catch (e) {}
-            `,
-          }}
-        />
-      </head>
       <body
         className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >
-        <NextIntlClientProvider messages={messages}>
-          {children}
-        </NextIntlClientProvider>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          <NextIntlClientProvider messages={messages}>
+            {children}
+          </NextIntlClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -3,6 +3,7 @@ import 'nextra-theme-docs/style.css'
 import { DocsNavbar, DocsFooter, DocsBanner } from '@/components/docs/index'
 import { Inter, JetBrains_Mono } from "next/font/google"
 import { Suspense } from 'react'
+import { ThemeProvider } from "next-themes"
 import "../globals.css"
 import { buildPageMapForBranch } from './page-map'
 import { getDefaultVersion, getBranchForVersion } from '@/config/versions'
@@ -47,24 +48,26 @@ export default async function DocsLayout({ children }: Props) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
-        <Layout
-          banner={banner}
-          navbar={navbar}
-          pageMap={pageMap}
-          docsRepositoryBase="https://github.com/kubestellar/kubestellar/edit/main/docs/content"
-          footer={footer}
-          darkMode={true}
-          sidebar={{
-            defaultMenuCollapseLevel: 1,
-            toggleButton: true
-          }}
-          toc={{
-            float: true,
-            title: "On This Page"
-          }}
-        >
-          {children}
-        </Layout>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          <Layout
+            banner={banner}
+            navbar={navbar}
+            pageMap={pageMap}
+            docsRepositoryBase="https://github.com/kubestellar/kubestellar/edit/main/docs/content"
+            footer={footer}
+            darkMode={true}
+            sidebar={{
+              defaultMenuCollapseLevel: 1,
+              toggleButton: true
+            }}
+            toc={{
+              float: true,
+              title: "On This Page"
+            }}
+          >
+            {children}
+          </Layout>
+        </ThemeProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
1. Added ThemeProvider to both root layouts (main app and docs)
2. Removed manual localStorage script from layout head
3. Leveraged next-themes automatic localStorage handling

### The `ThemeProvider` from next-themes:

- Only accesses` localStorage` on the client-side
- Prevents SSR hydration mismatches
- Automatically syncs theme with localStorage
- Provides theme context to all useTheme hooks