### PR TITLE
📖 added banner pointing to legacy docs on gh-pages

### DIFF
--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -9,7 +9,7 @@ KubeStellar simplifies multi-cluster Kubernetes management, enabling you to depl
     <h3 style={{ marginTop: 0, color: '#3b82f6', fontSize: '1.25rem' }}>Legacy Documentation</h3>
     <p style={{ fontSize: '0.9rem', marginBottom: '1rem' }}>If you experience issues with the new Nextra-based site</p>
     <p> We are aware that some of the imported KubeStellar documentation from our github repositories is not rendering properly 
-        on the new site; in particular some of the mkdocs variables are not being parsed and so code blocks are missing key syntax.</p>
+        on the new site. In particular, some of the mkdocs variables for version numbers are not parsed during the import and as a result code blocks displayed on some pages are missing key elements.</p>
     <p> <a href="https://kubestellar.github.io/kubestellar/" style={{ display: 'inline-block', padding: '0.5rem 1rem', background: '#3b82f6', color: 'white', borderRadius: '6px', textDecoration: 'none', fontSize: '0.9rem', fontWeight: '500' }}>The Legacy (MKDocs) version of the site may still be viewed via this github-pages link.</a></p>
   </div>
 </div>


### PR DESCRIPTION
### 📌 Fixes

This adds a pointer to the mkdocs version of the documentation on gh-pages.

---

### 📝 Summary of Changes

- Div added to top of kubestellar.io/docs (welcome page to new docs) with link to legacy site on gh-pages


