### PR TITLE
fix: add sidebar highlighting for direct route URLs

### DIFF
--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,6 +1,6 @@
 import { Layout } from 'nextra-theme-docs'
 import 'nextra-theme-docs/style.css'
-import { DocsNavbar, DocsFooter, DocsBanner } from '@/components/docs/index'
+import { DocsNavbar, DocsFooter, DocsBanner, DirectRouteHighlighter } from '@/components/docs/index'
 import { Inter, JetBrains_Mono } from "next/font/google"
 import { Suspense } from 'react'
 import { ThemeProvider } from "next-themes"
@@ -43,7 +43,7 @@ export default async function DocsLayout({ children }: Props) {
   const branch = getBranchForVersion(defaultVersion)
   
   // Build page map for the default version
-  const { pageMap } = await buildPageMapForBranch(branch)
+  const { pageMap, directRouteMap } = await buildPageMapForBranch(branch)
   
   return (
     <html lang="en" suppressHydrationWarning>
@@ -65,6 +65,7 @@ export default async function DocsLayout({ children }: Props) {
               title: "On This Page"
             }}
           >
+            <DirectRouteHighlighter directRouteMap={directRouteMap || {}} />
             {children}
           </Layout>
         </ThemeProvider>

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -84,7 +84,7 @@ type FolderNode = { kind: 'Folder'; name: string; route: string; children: PageM
       { file: 'release-notes.md' }
     ]],
     ['Install & Configure', [
-      // { file: 'get-started.md' },  
+      { file: 'get-started.md' },  
       { file: 'pre-reqs.md' },
       { file: 'start-from-ocm.md' },
       { file: 'setup-limitations.md' },
@@ -346,5 +346,14 @@ type FolderNode = { kind: 'Folder'; name: string; route: string; children: PageM
   // normalizePageMap has compatible types now; remove stale suppressor
   const pageMap = normalizePageMap(_pageMap)
 
-  return { pageMap, routeMap, filePaths: allDocFiles, branch }
+  // Build a map of direct routes to their canonical category routes
+  const directRouteMap: Record<string, string> = {}
+  for (const { alias, fp } of aliases) {
+    if (DIRECT_ROOT && fp.startsWith(`${DIRECT_ROOT}/`)) {
+      const fileName = fp.split('/').pop()!.replace(/\.(md|mdx)$/i, '')
+      directRouteMap[`/docs/direct/${fileName}`] = `/docs/${alias}`
+    }
+  }
+
+  return { pageMap, routeMap, filePaths: allDocFiles, branch, directRouteMap }
 }

--- a/src/components/docs/DirectRouteHighlighter.tsx
+++ b/src/components/docs/DirectRouteHighlighter.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+
+type DirectRouteHighlighterProps = {
+  directRouteMap: Record<string, string>
+}
+
+export function DirectRouteHighlighter({ directRouteMap }: DirectRouteHighlighterProps) {
+  const pathname = usePathname()
+  
+  useEffect(() => {
+    // If current path is a direct route, find its canonical route
+    const canonicalRoute = directRouteMap[pathname]
+    
+    if (canonicalRoute) {
+      
+      const activateLink = () => {
+        // Find ALL links in the page
+        const allLinks = document.querySelectorAll('a')
+        
+        allLinks.forEach(link => {
+          const href = link.getAttribute('href')
+          
+          if (href === canonicalRoute) {
+            // Remove inactive state classes
+            link.classList.remove(
+              'x:text-gray-600',
+              'x:dark:text-neutral-400',
+              'x:hover:text-gray-900',
+              'x:dark:hover:text-gray-50',
+              'x:contrast-more:text-gray-900',
+              'x:contrast-more:dark:text-gray-50',
+              'x:hover:bg-gray-100',
+              'x:dark:hover:bg-primary-100/5',
+              'x:contrast-more:border-transparent',
+              'x:contrast-more:hover:border-gray-900',
+              'x:contrast-more:dark:hover:border-gray-50'
+            )
+            
+            // Add Nextra's active state classes
+            link.classList.add(
+              'x:bg-primary-100',
+              'x:font-semibold',
+              'x:text-primary-800',
+              'x:dark:bg-primary-400/10',
+              'x:dark:text-primary-600',
+              'x:contrast-more:border-primary-500'
+            )
+            link.setAttribute('aria-current', 'page')
+            link.setAttribute('data-active', 'true')
+            
+            // Expand all parent folders
+            let parent = link.parentElement
+            while (parent) {
+              // Look for the collapse container div (has x:overflow-hidden class)
+              if (parent.classList.contains('x:overflow-hidden')) {
+                // Expand this folder by removing collapsed styles
+                parent.classList.remove('x:opacity-0')
+                parent.classList.add('x:opacity-100')
+                parent.style.height = 'auto'
+                
+                // Find the previous sibling button (the folder toggle)
+                const prevButton = parent.previousElementSibling
+                if (prevButton?.tagName === 'BUTTON') {
+                  prevButton.setAttribute('aria-expanded', 'true')
+                  
+                  // Add 'open' class to parent <li>
+                  const parentLi = parent.parentElement
+                  if (parentLi?.tagName === 'LI') {
+                    parentLi.classList.add('open')
+                  }
+                  
+                  // Rotate the SVG arrow
+                  const svg = prevButton.querySelector('svg')
+                  if (svg) {
+                    svg.classList.remove('x:ltr:rotate-0', 'x:rtl:-rotate-180')
+                    svg.classList.add('x:ltr:rotate-90', 'x:rtl:-rotate-270')
+                  }
+                }
+              }
+              
+              // Move up the DOM tree
+              parent = parent.parentElement
+              
+              // Stop at the sidebar container
+              if (parent?.tagName === 'ASIDE' || parent?.tagName === 'NAV') break
+            }
+          }
+        })
+      }
+      
+      // Try multiple times with increasing delays
+      setTimeout(activateLink, 0)
+      setTimeout(activateLink, 100)
+      setTimeout(activateLink, 300)
+      setTimeout(activateLink, 500)
+      
+      // Watch for DOM changes
+      const observer = new MutationObserver(activateLink)
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true
+      })
+      
+      return () => observer.disconnect()
+    }
+  }, [pathname, directRouteMap])
+  
+  return null
+}

--- a/src/components/docs/index.tsx
+++ b/src/components/docs/index.tsx
@@ -2,3 +2,4 @@ export { default as DocsNavbar } from './DocsNavbar';
 export { default as DocsFooter } from './DocsFooter';
 export { DocsBanner } from './DocsBanner';
 export { default as EditViewSourceButtons } from './EditViewSourceButtons';
+export { DirectRouteHighlighter } from './DirectRouteHighlighter';


### PR DESCRIPTION
📌 Fixes
Fixes [#3579](https://github.com/kubestellar/kubestellar/issues/3579)

📝 Summary of Changes
Implemented sidebar highlighting and folder expansion for direct route URLs (/docs/direct/*) to match the behavior of canonical category routes.

**Changes Made**
- [x] Added `DirectRouteHighlighter` component to handle client-side route highlighting
- [x] Extended `page-map.ts` to export `directRouteMap` mapping direct routes to canonical routes
- [x] Updated docs `layout.tsx` to integrate the highlighter component
- [x] Added barrel export in `components/docs/index.tsx` for consistency
- [x] Implemented automatic parent folder expansion for direct links
- [x] Applied Nextra's exact active state CSS classes for visual consistency

**Checklist**
Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable). *(N/A - client-side UI component)*
- [x] I have updated the documentation (if applicable). *(N/A - internal framework change)*
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

**Screenshots or Logs (if applicable)**

**Before:**
<img width="1910" height="1010" alt="2025-12-25_10-39" src="https://github.com/user-attachments/assets/803251c1-ae6f-4ddf-852a-74d2db0fd3c7" />
- Visiting `/docs/direct/get-started` showed no sidebar entry
- Parent folders remained collapsed

**After:**
<img width="1898" height="1009" alt="2025-12-25_10-41" src="https://github.com/user-attachments/assets/34a2f1c2-4e7d-4bdb-b901-02ef133d5dd3" />
- Visiting `/docs/direct/get-started` highlights "Get started" in the sidebar
- "Install & Configure" parent folder automatically expands
- Visual styling matches native Nextra behavior for `/docs/install-configure/get-started`

👀 **Reviewer Notes**

**Why This Approach?**

I explored several alternatives before settling on client-side DOM manipulation:

1. **❌ Adding duplicate links to pageMap**: Would create duplicate navigation entries in the sidebar, causing UI clutter and confusing users with two identical links.

2. **❌ Using Next.js route aliases/rewrites**: Nextra's sidebar highlighting is deeply tied to the `pageMap` structure. Route aliases would serve the same content but wouldn't help Nextra recognize which sidebar item to highlight since the route doesn't exist in the pageMap.

3. **❌ Modifying Nextra's core route matching**: Would require forking or monkey-patching Nextra's internal navigation logic, making upgrades difficult and breaking compatibility.

4. **✅ Client-side highlighting (chosen approach)**: 
   - **Non-invasive**: Works alongside Nextra without modifying its core
   - **Maintainable**: Isolated in a single component, easy to update or remove
   - **Zero breaking changes**: Existing routes continue to work normally
   - **User-friendly**: Direct links now provide the same UX as canonical links
   - **Future-proof**: When users navigate away, Nextra's native behavior takes over seamlessly

**Technical Details:**
- Maps direct routes (`/docs/direct/file`) to canonical routes (`/docs/category/file`)
- Uses MutationObserver to handle dynamic sidebar rendering
- Applies exact Nextra CSS classes (`x:bg-primary-100`, `x:font-semibold`, etc.) for visual consistency
- Manipulates collapse containers and ARIA attributes to expand parent folders
- Multiple timeout attempts ensure reliability with async sidebar loading

**💬 Open to Feedback**
If this approach doesn't align with the project's architecture or preferences, I'm happy to refactor using any alternative solution the maintainers suggest. Please let me know if you'd prefer:
- A different technical approach
- Changes to the implementation
- Alternative architectural patterns
