### PR TITLE
fix: correct Code of Conduct contact text

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ Project maintainers who do not follow or enforce the Code of Conduct may be temp
 
 ## Reporting
 
-For incidents occurring in the KubeStellar community, contact the [KubeStellar Code of Conduct Committee of Conduct Committee](mailto:kubestellar-dev-private@googlegroups.com). You can expect a response within three business days.
+For incidents occurring in the KubeStellar community, contact the [KubeStellar Code of Conduct Committee](mailto:kubestellar-dev-private@googlegroups.com). You can expect a response within three business days.
 
 For other projects, or for incidents that are project-agnostic or impact multiple CNCF projects, please contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) via [`conduct@cncf.io`](mailto:conduct@cncf.io). Alternatively, you can contact any of the individual members of the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) to submit your report. For more detailed instructions on how to submit a report, including how to submit a report anonymously, please see our [Incident Resolution Procedures](https://www.cncf.io/conduct/procedures/). You can expect a response within three business days.
 


### PR DESCRIPTION
### 📝 Summary of Changes

This PR fixes minor issues identified during review, including a typo in the Code of Conduct contact information and a small correction in the navigation component.


### Changes

Fixed a typo in the Code of Conduct contact section where the committee name was duplicated. Updated the text to correctly reference the “KubeStellar Code of Conduct Committee” without changing the contact details or response expectations.

