### PR TITLE
fix: resolve broken links in Footer section

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -344,7 +344,7 @@ export default function Footer() {
             {/* Right side - policy links */}
             <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 md:gap-6 lg:gap-8 order-1 md:order-2">
               <a
-                href="#"
+                href="/docs/contribution-guidelines/license-inc"
                 className="text-gray-400 hover:text-white transition-colors duration-300 text-xs sm:text-sm whitespace-nowrap"
               >
                 {t("privacyPolicy")}

--- a/src/components/master-page/GetStartedSection.tsx
+++ b/src/components/master-page/GetStartedSection.tsx
@@ -464,7 +464,7 @@ export default function GetStartedSection() {
                   {t("card3Link2")}
                 </Link>
                 <Link
-                  href="docs/use-integrate/kubestellar-api/control"
+                  href="/docs/use-integrate/kubestellar-api/control"
                   className="block p-2 rounded bg-white/20 hover:bg-white/30 text-white text-sm pl-5"
                 >
                   {t("card3Link3")}


### PR DESCRIPTION
## Description
Fixes two broken links in the documentation website that were preventing proper navigation.

## Changes
- **Footer.tsx**: Fixed Privacy Policy link from placeholder `href="#"` to actual documentation path `/docs/contribution-guidelines/license-inc`
- **GetStartedSection.tsx**: Fixed API Reference link by adding leading slash (`/docs/use-integrate/kubestellar-api/control`) to ensure it works as an absolute path from any route