### PR TITLE
fix: resolve broken links in GetStartedSection

### DIFF
--- a/src/components/master-page/GetStartedSection.tsx
+++ b/src/components/master-page/GetStartedSection.tsx
@@ -464,7 +464,7 @@ export default function GetStartedSection() {
                   {t("card3Link2")}
                 </Link>
                 <Link
-                  href="docs/use-integrate/kubestellar-api/control"
+                  href="/docs/use-integrate/kubestellar-api/control"
                   className="block p-2 rounded bg-white/20 hover:bg-white/30 text-white text-sm pl-5"
                 >
                   {t("card3Link3")}


### PR DESCRIPTION
### 📌 Fixes

Fixes #<issue-number> (Use "Fixes", "Closes", or "Resolves" for automatic closing)

---

### 📝 Summary of Changes

Fixes two broken links in the documentation website that were preventing proper navigation.

---

### Changes Made

GetStartedSection.tsx: Fixed API Reference link by adding leading slash (/docs/use-integrate/kubestellar-api/control) to ensure it works as an absolute path from any route

---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
