### PR TITLE
📖 more legible link color in text link to legacy docs

### DIFF
--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -7,7 +7,7 @@ KubeStellar simplifies multi-cluster Kubernetes management, enabling you to depl
   <div style={{ border: '2px solid #3b82f6', borderRadius: '12px', padding: '1.5rem', background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(147, 51, 234, 0.05))' }}>
     <h3 style={{ marginTop: 0, color: '#3b82f6', fontSize: '1.25rem' }}><a href='https://kubestellar.github.io/kubestellar'>📖 Looking for Legacy Docs?</a></h3>
     <p style={{ fontSize: '0.9rem', marginBottom: '1rem' }}>This unified site currently only includes docs for the version of KubeStellar tagged <em>Latest</em>. For other versions you may visit the <a 
-     href="https://kubestellar.github.io/kubestellar" style={{  textDecoration: 'underline', color: 'blue', fontWeight: '999' }}>Legacy Docs Site</a> hosted via GitHub Pages and mkdocs.</p>
+     href="https://kubestellar.github.io/kubestellar" style={{  textDecoration: 'underline', color: '#3b82f6', fontWeight: '999' }}>Legacy Docs Site</a> hosted via GitHub Pages and mkdocs.</p>
   </div>
 </div>
 


### PR DESCRIPTION
### 📌 Fixes

PR 509 merged before I could update the link text color to the legacy docs. This fixes that one line.

