### PR TITLE
📖 docs: document E2E workaround for kubeflex context issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,6 @@ To ensure consistent and reliable test execution, the E2E test setup removes kub
 
 This workaround is limited to the E2E test infrastructure and does not affect normal user workflows. It is intended to be temporary and will be removed once the underlying context-handling issue is resolved.
 
-
 ### Caution With AI-Generated Code
 
 > AI tools (like GitHub Copilot or ChatGPT) are helpful but **not always context-aware**.  


### PR DESCRIPTION
📝 Summary of Changes

- Documented the temporary E2E test workaround for a kubeflex context-selection issue.
- Explained why kubeflex-specific kubeconfig extensions are removed during E2E test execution.
- Clarified that the workaround is limited to E2E tests and does not affect normal user workflows.
- Related issue: kubestellar/kubeflex#597 (tracked via docs issue #512)

**Fixes #512** 