### PR TITLE
📖 : add BindingPolicy in Action Killercoda tutorial

### DIFF
--- a/docs/content/direct/binding.md
+++ b/docs/content/direct/binding.md
@@ -91,5 +91,5 @@ In the tutorial, you will:
 This tutorial serves as a hands-on complement to the concepts described above and illustrates how intent changes drive placement behavior in KubeStellar.
 
 Try the interactive tutorial on Killercoda:  
-**BindingPolicy in Action (Scenario 2)**
+[**BindingPolicy in Action (Scenario 2)**](https://killercoda.com/kubestellar/scenario/bindingpolicy-in-action-scenario-2)
 


### PR DESCRIPTION
### **Fixes #533**
---

### 📝 Summary of Changes

- Added a documentation reference to the new **“BindingPolicy in Action”** Killercoda interactive tutorial.
- Highlighted how the tutorial demonstrates intent-driven workload placement using `BindingPolicy`.
- Improved discoverability of the new Killercoda scenario from the BindingPolicy documentation.

---

### Changes Made

- [x] Added a new **BindingPolicy in Action (Interactive Tutorial)** section to `docs/content/direct/binding.md`
- [x] Linked the conceptual BindingPolicy documentation to the corresponding Killercoda scenario
- [x] Scoped changes to documentation only (no code or behavior changes)

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have updated the documentation (this PR is documentation-only).
- [x] I have tested the documentation changes locally.
- [x] My changes are minimal, scoped, and follow the existing documentation style.

---

### Reviewer Notes

This PR connects the existing BindingPolicy documentation with the newly added Killercoda **“BindingPolicy in Action”** scenario, providing readers with an interactive, hands-on way to explore intent-driven workload placement.  
No existing content or behavior is modified.

