### PR TITLE
🐛 Fix Feedback Wanted workflow permissions

### DIFF
--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   feedback:


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to feedback.yml

The reusable workflow needs this permission to post comments on merged PRs. Without it, the job is skipped with "No jobs were run".

## Test plan
- [x] Verify reusable-feedback.yml requires pull-requests: write

🤖 Generated with [Claude Code](https://claude.com/claude-code)