### PR TITLE
🐛 fix: resolve additional 404 errors in footer and homepage components

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -161,7 +161,7 @@ export default function Footer() {
                 <li>
                   <Link
                     href={getLocalizedUrl(
-                      "https://kubestellar.io/docs/user-guide-support/user-guide-intro"
+                      "https://kubestellar.io/docs/user-guide/guide-overview"
                     )}
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >
@@ -181,7 +181,7 @@ export default function Footer() {
                 <li>
                   <Link
                     href={getLocalizedUrl(
-                      "https://kubestellar.io/docs/contribution-guidelines/release-notes"
+                      "https://kubestellar.io/docs/what-is-kubestellar/release-notes"
                     )}
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >

--- a/src/components/docs/DocsFooter.tsx
+++ b/src/components/docs/DocsFooter.tsx
@@ -242,7 +242,7 @@ export default function Footer() {
                 </li>
                 <li>
                   <Link
-                    href="/docs/user-guide-support/user-guide-intro"
+                    href="/docs/user-guide/guide-overview"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'
@@ -266,7 +266,7 @@ export default function Footer() {
                 </li>
                 <li>
                   <Link
-                    href="/docs/contribution-guidelines/release-notes"
+                    href="/docs/what-is-kubestellar/release-notes"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'

--- a/src/components/master-page/GetStartedSection.tsx
+++ b/src/components/master-page/GetStartedSection.tsx
@@ -483,7 +483,7 @@ export default function GetStartedSection() {
                   {t("card3Link2")}
                 </Link>
                 <Link
-                  href="/docs/use-integrate/kubestellar-api/control"
+                  href="/docs/user-guide/usage/kubestellar-api/overview"
                   className="block p-2 rounded bg-white/20 hover:bg-white/30 text-white text-sm pl-5"
                 >
                   {t("card3Link3")}


### PR DESCRIPTION
## Summary
Fix additional broken links found by lychee link checker on kubestellar.io homepage and footer components.

## Problem
Running `lychee https://kubestellar.io` found 3 broken links:
- `/docs/contribution-guidelines/release-notes` → 404
- `/docs/use-integrate/kubestellar-api/control` → 404
- `/docs/user-guide-support/user-guide-intro` → 404

## Changes
| File | Old Link | New Link |
|------|----------|----------|
| GetStartedSection.tsx | `/docs/use-integrate/kubestellar-api/control` | `/docs/user-guide/usage/kubestellar-api/overview` |
| DocsFooter.tsx | `/docs/user-guide-support/user-guide-intro` | `/docs/user-guide/guide-overview` |
| DocsFooter.tsx | `/docs/contribution-guidelines/release-notes` | `/docs/what-is-kubestellar/release-notes` |
| Footer.tsx | Same as DocsFooter.tsx | Same as DocsFooter.tsx |

## Test plan
- [ ] Run `lychee https://kubestellar.io` - should show 0 errors for these URLs
- [ ] Verify footer links work on deploy preview
- [ ] Verify homepage "Get Started" card links work

Generated with [Claude Code](https://claude.com/claude-code)