### PR TITLE
🐛 fix: make GitHub icon clickable to open GitHub repo

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -786,19 +786,27 @@ export default function Navbar() {
                 className="hidden lg:flex relative group"
                 data-dropdown="github"
               >
-                <button
+                <div
                   data-dropdown-button
                   className="hidden lg:flex text-sm font-medium text-gray-300 hover:text-green-400 transition-all duration-300 items-center space-x-1 px-3 py-2 rounded-lg hover:bg-green-500/10 hover:shadow-lg hover:shadow-green-500/20 hover:scale-100 transform nav-link-hover"
                 >
-                  <svg
-                    className="w-4 h-4 mr-2"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
+                  <a
+                    href="https://github.com/kubestellar/kubestellar"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center"
+                    onClick={(e) => e.stopPropagation()}
                   >
-                    <path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.300 24 12c0-6.627-5.373-12-12-12z" />
-                  </svg>
+                    <svg
+                      className="w-4 h-4"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.300 24 12c0-6.627-5.373-12-12-12z" />
+                    </svg>
+                  </a>
                   <svg
-                    className={`w-4 h-4 ml-1 transition-transform duration-200 ${isGithubOpen ? "rotate-180" : ""}`}
+                    className={`w-4 h-4 ml-2 transition-transform duration-200 ${isGithubOpen ? "rotate-180" : ""}`}
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -810,7 +818,7 @@ export default function Navbar() {
                       d="M19 9l-7 7-7-7"
                     />
                   </svg>
-                </button>
+                </div>
                 <div
                   data-dropdown-menu
                   className="absolute hidden lg:flex right-0 mt-1 w-48 bg-gray-800/95 backdrop-blur-sm rounded-md shadow-lg border border-gray-700 before:content-[''] before:absolute before:bottom-full before:left-0 before:right-0 before:h-2 before:bg-transparent"


### PR DESCRIPTION
## Summary
- Fixed the GitHub icon in the navbar to be directly clickable
- Clicking the GitHub icon now opens https://github.com/kubestellar/kubestellar in a new tab
- The dropdown arrow still works to show Star/Fork/Watch/Create Issue options

## Problem
The GitHub icon in the navbar header was only a dropdown trigger. Clicking the icon itself did nothing - you had to hover and then select a dropdown item to go anywhere.

## Solution
Split the button into:
1. **GitHub icon** - Now wrapped in an `<a>` tag that links directly to the repo
2. **Dropdown arrow** - Still triggers the dropdown menu on hover

## Test plan
- [ ] Click the GitHub icon - should open https://github.com/kubestellar/kubestellar in new tab
- [ ] Hover over the GitHub area - dropdown should still appear
- [ ] Click dropdown items - should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)