### PR TITLE
✨feat: Add Meeting Agenda button to landing page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -171,6 +171,7 @@
     "card2Button3": "Projects",
     "card2Button4": "Handbook",
     "card2Button5": "YouTube",
+    "card2Button6": "Meeting Agenda",
     "card3Title": "Explore Documentation",
     "card3Description": "Comprehensive guides, tutorials, and API references to help you master KubeStellar's capabilities.",
     "card3Link1": "Getting Started",

--- a/src/components/master-page/GetStartedSection.tsx
+++ b/src/components/master-page/GetStartedSection.tsx
@@ -452,6 +452,27 @@ export default function GetStartedSection() {
                       </svg>
                     {t("card2Button5")}
                   </Link>
+                  <a
+                    href={getLocalizedUrl("https://kubestellar.io/agenda")}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-center px-3 py-2.5 rounded-lg bg-gradient-to-r from-cyan-600/80 to-cyan-700/80 hover:from-cyan-600 hover:to-cyan-700 text-white text-sm font-medium transition-all duration-200 border border-cyan-500/30"
+                  >
+                    <svg
+                      className="h-4 w-4 mr-2"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                      />
+                    </svg>
+                    {t("card2Button6")}
+                  </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### 📌 Fixes

Fixes #661

---

### 📝 Summary of Changes

Added "Meeting Agenda" button to the "Explore Use Cases & Community" card in GetStartedSection, positioned beside YouTube button for optimal 2-column layout.

---

### Changes Made

- [x] Added `card2Button6: "Meeting Agenda"` translation to `messages/en.json`
- [x] Added Meeting Agenda button (`<a>` tag) in `GetStartedSection.tsx` 
- [x] Used cyan gradient styling matching KubeStellar design system
- [x] Included calendar icon (SVG) for visual clarity
- [x] Linked to `https://kubestellar.io/agenda` (external link with `target="_blank"`)

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).

---

### Screenshots or Logs (if applicable)

<img width="772" height="518" alt="Screenshot 2026-01-14 215135" src="https://github.com/user-attachments/assets/c6edb697-eba5-44d6-a3c7-f5833f22b012" />

✅ Build successful: `npm run build` completed without errors
✅ Button visible at `localhost:3000` in "Ready to Get Started?" section
✅ Responsive 2-column layout beside YouTube button
✅ External link opens `https://kubestellar.io/agenda` in new tab

---

### 👀 Reviewer Notes

- Used `<a>` tag (not `<Link>`) for external URL following existing pattern (Slack/GitHub buttons)
- Matches existing cyan gradient color scheme and button styling
- Translation key follows `card2Button#` naming convention
