### PR TITLE
📖 docs: Add reference to wantMultiWECReportedState example scenario

### DIFF
--- a/docs/content/direct/example-scenarios.md
+++ b/docs/content/direct/example-scenarios.md
@@ -115,6 +115,8 @@ kubectl --context "$wds_context" delete ns nginx
 kubectl --context "$wds_context" delete bindingpolicies nginx-bpolicy
 ```
 
+For an example using the `wantMultiWECReportedState` feature for multi-cluster status aggregation, see [Multi-WEC Aggregated Status](multi-wec-aggregated-status.md).
+
 ## Scenario 2: Out-of-Tree Workload
 
 This scenario is like the previous one but involves a workload whose


### PR DESCRIPTION
### 📌 Fixes
Fixes #662 
Fixes kubestellar/kubestellar#3586

---

### 📝 Summary of Changes

- Added a reference link in `example-scenarios.md` pointing to the existing `multi-wec-aggregated-status.md` documentation
- This provides users with a clear path to learn about the `wantMultiWECReportedState` feature after completing Scenario 1

The comprehensive documentation for this feature already exists in `multi-wec-aggregated-status.md`. Rather than duplicating content, this PR simply adds a contextual reference link where users naturally progress through the examples.

---

### Changes Made

- [x] Updated `docs/content/direct/example-scenarios.md` to include reference link to multi-WEC aggregated status documentation

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable). _N/A - documentation only_
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

not required!

---

### 👀 Reviewer Notes

This is a minimal change (1 line added) that addresses the issue by linking to existing comprehensive documentation rather than duplicating content. The placement is strategic - right after Scenario 1, so users naturally discover the multi-WEC feature as a next step.