### PR TITLE
✨ Add main (dev) versions and release automation

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -1,0 +1,207 @@
+name: Create Version Branch
+
+on:
+  repository_dispatch:
+    types: [create-version-branch]
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin)'
+        required: true
+        type: choice
+        options:
+          - kubestellar
+          - a2a
+          - kubeflex
+          - multi-plugin
+      version:
+        description: 'Version number (e.g., 0.30.0)'
+        required: true
+      source_repo:
+        description: 'Source repo (e.g., kubestellar/kubestellar)'
+        required: true
+      source_branch:
+        description: 'Source branch/tag (e.g., release-0.30.0 or v0.30.0)'
+        required: true
+      set_as_latest:
+        description: 'Set as latest version'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
+
+      - name: Set variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+            echo "project=${{ github.event.client_payload.project }}" >> $GITHUB_OUTPUT
+            echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+            echo "source_repo=${{ github.event.client_payload.source_repo }}" >> $GITHUB_OUTPUT
+            echo "source_branch=${{ github.event.client_payload.source_branch }}" >> $GITHUB_OUTPUT
+            echo "set_latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "project=${{ inputs.project }}" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "source_repo=${{ inputs.source_repo }}" >> $GITHUB_OUTPUT
+            echo "source_branch=${{ inputs.source_branch }}" >> $GITHUB_OUTPUT
+            echo "set_latest=${{ inputs.set_as_latest }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine branch name
+        id: branch
+        run: |
+          PROJECT="${{ steps.vars.outputs.project }}"
+          VERSION="${{ steps.vars.outputs.version }}"
+          VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+
+          case "$PROJECT" in
+            kubestellar) BRANCH="docs/${VERSION}" ;;
+            a2a) BRANCH="docs/a2a/${VERSION}" ;;
+            kubeflex) BRANCH="docs/kubeflex/${VERSION}" ;;
+            multi-plugin) BRANCH="docs/multi-plugin/${VERSION}" ;;
+            *) echo "Unknown project: $PROJECT"; exit 1 ;;
+          esac
+          echo "name=$BRANCH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Branch name: $BRANCH"
+
+      - name: Check if branch exists
+        id: check-branch
+        run: |
+          if git ls-remote --heads origin "${{ steps.branch.outputs.name }}" | grep -q "${{ steps.branch.outputs.name }}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Branch ${{ steps.branch.outputs.name }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Clone source docs
+        if: steps.check-branch.outputs.exists != 'true'
+        run: |
+          echo "Cloning ${{ steps.vars.outputs.source_repo }} at ${{ steps.vars.outputs.source_branch }}..."
+          git clone --branch "${{ steps.vars.outputs.source_branch }}" --depth 1 \
+            "https://github.com/${{ steps.vars.outputs.source_repo }}.git" /tmp/source
+
+      - name: Create version branch
+        if: steps.check-branch.outputs.exists != 'true'
+        run: |
+          git checkout -b "${{ steps.branch.outputs.name }}"
+
+          # Copy docs based on project
+          PROJECT="${{ steps.vars.outputs.project }}"
+          echo "Copying docs for project: $PROJECT"
+
+          case "$PROJECT" in
+            kubestellar)
+              if [ -d "/tmp/source/docs/content" ]; then
+                rm -rf docs/content/direct/*
+                cp -r /tmp/source/docs/content/* docs/content/direct/
+                echo "Copied KubeStellar docs from docs/content/"
+              else
+                echo "Warning: /tmp/source/docs/content not found"
+              fi
+              ;;
+            a2a)
+              rm -rf docs/content/a2a/*
+              if [ -d "/tmp/source/docs-site/docs" ]; then
+                cp -r /tmp/source/docs-site/docs/* docs/content/a2a/
+                echo "Copied A2A docs from docs-site/docs/"
+              elif [ -d "/tmp/source/docs" ]; then
+                cp -r /tmp/source/docs/* docs/content/a2a/
+                echo "Copied A2A docs from docs/"
+              else
+                echo "Warning: No docs directory found in A2A source"
+              fi
+              ;;
+            kubeflex)
+              rm -rf docs/content/kubeflex/*
+              if [ -d "/tmp/source/docs" ]; then
+                cp -r /tmp/source/docs/* docs/content/kubeflex/
+                echo "Copied KubeFlex docs from docs/"
+              else
+                echo "Warning: /tmp/source/docs not found"
+              fi
+              ;;
+            multi-plugin)
+              rm -rf docs/content/multi-plugin/*
+              if [ -d "/tmp/source/docs" ]; then
+                cp -r /tmp/source/docs/* docs/content/multi-plugin/
+                echo "Copied Multi-Plugin docs from docs/"
+              else
+                echo "Warning: /tmp/source/docs not found"
+              fi
+              ;;
+          esac
+
+      - name: Commit and push branch
+        if: steps.check-branch.outputs.exists != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -s -m "docs: add ${{ steps.vars.outputs.project }} ${{ steps.branch.outputs.version }} docs
+
+          Source: ${{ steps.vars.outputs.source_repo }}@${{ steps.vars.outputs.source_branch }}
+
+          Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+          git push origin "${{ steps.branch.outputs.name }}"
+          echo "✅ Pushed branch ${{ steps.branch.outputs.name }}"
+
+      - name: Setup Node.js
+        if: steps.vars.outputs.set_latest == 'true'
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+
+      - name: Create PR to update versions.ts
+        if: steps.vars.outputs.set_latest == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
+        run: |
+          # Go back to main for the PR
+          git checkout main
+          git pull origin main
+
+          PR_BRANCH="update-${{ steps.vars.outputs.project }}-${{ steps.branch.outputs.version }}"
+          git checkout -b "$PR_BRANCH"
+
+          # Update versions.ts using node script
+          node scripts/update-version.js \
+            --project "${{ steps.vars.outputs.project }}" \
+            --version "${{ steps.branch.outputs.version }}" \
+            --branch "${{ steps.branch.outputs.name }}" \
+            --set-latest
+
+          git add src/config/versions.ts
+          git commit -s -m "chore: update ${{ steps.vars.outputs.project }} to v${{ steps.branch.outputs.version }}
+
+          Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+          git push origin "$PR_BRANCH"
+
+          # Create PR
+          gh pr create \
+            --title "📖 Update ${{ steps.vars.outputs.project }} docs to v${{ steps.branch.outputs.version }}" \
+            --body "## Summary
+          Automated update for ${{ steps.vars.outputs.project }} release v${{ steps.branch.outputs.version }}.
+
+          - Created branch: \`${{ steps.branch.outputs.name }}\`
+          - Source: ${{ steps.vars.outputs.source_repo }}@${{ steps.vars.outputs.source_branch }}
+
+          ## Checklist
+          - [ ] Verify branch deploys correctly on Netlify
+          - [ ] Verify version appears in dropdown
+
+          🤖 Generated automatically on release"
+          echo "✅ Created PR to update versions.ts"

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Updates versions.ts with a new version entry
+ *
+ * Usage:
+ *   node scripts/update-version.js --project kubestellar --version 0.30.0 --branch docs/0.30.0 [--set-latest]
+ *
+ * Options:
+ *   --project      Project ID (kubestellar, a2a, kubeflex, multi-plugin)
+ *   --version      Version number (e.g., 0.30.0)
+ *   --branch       Branch name for this version (e.g., docs/0.30.0)
+ *   --set-latest   If provided, updates the "latest" label and currentVersion
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const getArg = (name) => {
+  const idx = args.indexOf(`--${name}`);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : null;
+};
+
+const project = getArg('project');
+const version = getArg('version');
+const branch = getArg('branch');
+const setLatest = args.includes('--set-latest');
+
+// Validate required arguments
+if (!project || !version || !branch) {
+  console.error('Usage: node update-version.js --project <project> --version <version> --branch <branch> [--set-latest]');
+  console.error('');
+  console.error('Required arguments:');
+  console.error('  --project     Project ID (kubestellar, a2a, kubeflex, multi-plugin)');
+  console.error('  --version     Version number (e.g., 0.30.0)');
+  console.error('  --branch      Branch name (e.g., docs/0.30.0)');
+  console.error('');
+  console.error('Optional:');
+  console.error('  --set-latest  Update "latest" label and currentVersion');
+  process.exit(1);
+}
+
+// Project-specific version constant names
+const versionConstants = {
+  'kubestellar': 'KUBESTELLAR_VERSIONS',
+  'a2a': 'A2A_VERSIONS',
+  'kubeflex': 'KUBEFLEX_VERSIONS',
+  'multi-plugin': 'MULTI_PLUGIN_VERSIONS'
+};
+
+const constName = versionConstants[project];
+if (!constName) {
+  console.error(`Unknown project: ${project}`);
+  console.error(`Valid projects: ${Object.keys(versionConstants).join(', ')}`);
+  process.exit(1);
+}
+
+// Escape special regex characters to prevent regex injection
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Read versions.ts
+const versionsPath = path.join(__dirname, '../src/config/versions.ts');
+if (!fs.existsSync(versionsPath)) {
+  console.error(`File not found: ${versionsPath}`);
+  process.exit(1);
+}
+
+let content = fs.readFileSync(versionsPath, 'utf8');
+const originalContent = content;
+
+console.log(`Updating ${project} to v${version}...`);
+console.log(`  Branch: ${branch}`);
+console.log(`  Set as latest: ${setLatest}`);
+
+// Update latest label if setting as latest
+if (setLatest) {
+  // Update the "latest" entry's label to show the new version
+  const latestRegex = new RegExp(
+    `(const ${constName}[\\s\\S]*?latest:\\s*\\{[\\s\\S]*?label:\\s*")v[\\d.]+( \\(Latest\\)")`,
+    ''
+  );
+
+  if (latestRegex.test(content)) {
+    content = content.replace(latestRegex, `$1v${version}$2`);
+    console.log(`  Updated latest label to v${version}`);
+  } else {
+    console.warn(`  Warning: Could not find latest label pattern in ${constName}`);
+  }
+
+  // Update currentVersion in the project config
+  // Match the project section and update currentVersion
+  const projectKey = project === 'multi-plugin' ? '"multi-plugin"' : project;
+  const currentVersionRegex = new RegExp(
+    `(${escapeRegex(projectKey)}:\\s*\\{[\\s\\S]*?currentVersion:\\s*")([^"]+)(")`,
+    ''
+  );
+
+  if (currentVersionRegex.test(content)) {
+    content = content.replace(currentVersionRegex, `$1${version}$3`);
+    console.log(`  Updated currentVersion to ${version}`);
+  } else {
+    console.warn(`  Warning: Could not find currentVersion for ${project}`);
+  }
+}
+
+// Check if version entry already exists
+const versionEntryRegex = new RegExp(`"${escapeRegex(version)}":\\s*\\{`, '');
+if (versionEntryRegex.test(content)) {
+  console.log(`  Version ${version} already exists in ${constName}, skipping addition`);
+} else {
+  // Add new version entry after 'main' entry
+  const newEntry = `  "${version}": {
+    label: "v${version}",
+    branch: "${branch}",
+    isDefault: false,
+  },`;
+
+  // Find the main entry in the specific version constant and add after it
+  const mainEntryRegex = new RegExp(
+    `(const ${constName}[\\s\\S]*?main:\\s*\\{[^}]+\\},)`,
+    ''
+  );
+
+  if (mainEntryRegex.test(content)) {
+    content = content.replace(mainEntryRegex, `$1\n${newEntry}`);
+    console.log(`  Added version entry for ${version}`);
+  } else {
+    // Fallback: try to add after latest entry
+    const latestEntryRegex = new RegExp(
+      `(const ${constName}[\\s\\S]*?latest:\\s*\\{[^}]+\\},)`,
+      ''
+    );
+
+    if (latestEntryRegex.test(content)) {
+      content = content.replace(latestEntryRegex, `$1\n${newEntry}`);
+      console.log(`  Added version entry after latest for ${version}`);
+    } else {
+      console.error(`  Error: Could not find insertion point for new version`);
+      process.exit(1);
+    }
+  }
+}
+
+// Write updated content
+if (content !== originalContent) {
+  fs.writeFileSync(versionsPath, content);
+  console.log(`\n✅ Updated ${versionsPath}`);
+} else {
+  console.log(`\nNo changes needed for ${versionsPath}`);
+}

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -24,6 +24,7 @@ export interface VersionInfo {
   branch: string
   isDefault: boolean
   externalUrl?: string
+  isDev?: boolean // marks development/unreleased versions
 }
 
 // Project configuration
@@ -42,6 +43,12 @@ const KUBESTELLAR_VERSIONS: Record<string, VersionInfo> = {
     label: "v0.29.0 (Latest)",
     branch: "main",
     isDefault: true,
+  },
+  main: {
+    label: "main (dev)",
+    branch: "main",
+    isDefault: false,
+    isDev: true,
   },
   "0.28.0": {
     label: "v0.28.0",
@@ -128,6 +135,12 @@ const A2A_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: true,
   },
+  main: {
+    label: "main (dev)",
+    branch: "main",
+    isDefault: false,
+    isDev: true,
+  },
 }
 
 // kubeflex versions
@@ -136,6 +149,12 @@ const KUBEFLEX_VERSIONS: Record<string, VersionInfo> = {
     label: "v0.9.3 (Latest)",
     branch: "main",
     isDefault: true,
+  },
+  main: {
+    label: "main (dev)",
+    branch: "main",
+    isDefault: false,
+    isDev: true,
   },
   "0.8.0": {
     label: "v0.8.0",
@@ -155,6 +174,12 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
     label: "v0.1.0 (Latest)",
     branch: "main",
     isDefault: true,
+  },
+  main: {
+    label: "main (dev)",
+    branch: "main",
+    isDefault: false,
+    isDev: true,
   },
 }
 


### PR DESCRIPTION
## Summary

This PR adds two features:

### 1. "main (dev)" in Version Dropdown
- Adds `isDev` flag to version configuration
- Adds "main (dev)" entry to all project version dropdowns (KubeStellar, A2A, KubeFlex, Multi-Plugin)
- Updates VersionSelector to sort: Latest → main (dev) → older versions
- Shows unreleased documentation from the main branch

### 2. Release Automation Workflow
Creates `create-version-branch.yml` workflow that:
- Can be triggered automatically via `repository_dispatch` from source repos on release
- Can be triggered manually via `workflow_dispatch` with project/version inputs
- Creates version branch (e.g., `docs/0.30.0`)
- Creates PR to update versions.ts

### Files Changed
- `src/config/versions.ts` - Add isDev flag and main entries
- `src/components/docs/VersionSelector.tsx` - Add version sorting
- `.github/workflows/create-version-branch.yml` - New release automation workflow
- `scripts/update-version.js` - Helper script for updating versions.ts

## Test Plan
- [ ] Verify "main (dev)" appears in version dropdown for all projects
- [ ] Verify version ordering: Latest → main (dev) → 0.28.0 → ...
- [ ] Test manual workflow_dispatch for create-version-branch
- [ ] Verify Netlify preview shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)