### PR TITLE
✨ Add kubectl-claude to docs release automation

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       project:
-        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin)'
+        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin, kubectl-claude)'
         required: true
         type: choice
         options:
@@ -14,6 +14,7 @@ on:
           - a2a
           - kubeflex
           - multi-plugin
+          - kubectl-claude
       version:
         description: 'Version number (e.g., 0.30.0)'
         required: true
@@ -71,6 +72,7 @@ jobs:
             a2a) BRANCH="docs/a2a/${VERSION}" ;;
             kubeflex) BRANCH="docs/kubeflex/${VERSION}" ;;
             multi-plugin) BRANCH="docs/multi-plugin/${VERSION}" ;;
+            kubectl-claude) BRANCH="docs/kubectl-claude/${VERSION}" ;;
             *) echo "Unknown project: $PROJECT"; exit 1 ;;
           esac
           echo "name=$BRANCH" >> $GITHUB_OUTPUT
@@ -138,6 +140,15 @@ jobs:
               if [ -d "/tmp/source/docs" ]; then
                 cp -r /tmp/source/docs/* docs/content/multi-plugin/
                 echo "Copied Multi-Plugin docs from docs/"
+              else
+                echo "Warning: /tmp/source/docs not found"
+              fi
+              ;;
+            kubectl-claude)
+              rm -rf docs/content/kubectl-claude/*
+              if [ -d "/tmp/source/docs" ]; then
+                cp -r /tmp/source/docs/* docs/content/kubectl-claude/
+                echo "Copied kubectl-claude docs from docs/"
               else
                 echo "Warning: /tmp/source/docs not found"
               fi

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -46,7 +46,8 @@ const versionConstants = {
   'kubestellar': 'KUBESTELLAR_VERSIONS',
   'a2a': 'A2A_VERSIONS',
   'kubeflex': 'KUBEFLEX_VERSIONS',
-  'multi-plugin': 'MULTI_PLUGIN_VERSIONS'
+  'multi-plugin': 'MULTI_PLUGIN_VERSIONS',
+  'kubectl-claude': 'KUBECTL_CLAUDE_VERSIONS'
 };
 
 const constName = versionConstants[project];

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -16,7 +16,7 @@ export const NETLIFY_SITE_NAME = "kubestellar-docs"
 export const PRODUCTION_URL = "https://kubestellar.io"
 
 // Project identifiers
-export type ProjectId = "kubestellar" | "a2a" | "kubeflex" | "multi-plugin"
+export type ProjectId = "kubestellar" | "a2a" | "kubeflex" | "multi-plugin" | "kubectl-claude"
 
 // Version info structure
 export interface VersionInfo {
@@ -183,6 +183,21 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
   },
 }
 
+// kubectl-claude versions
+const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
+  latest: {
+    label: "v0.3.0 (Latest)",
+    branch: "main",
+    isDefault: true,
+  },
+  main: {
+    label: "main (dev)",
+    branch: "main",
+    isDefault: false,
+    isDev: true,
+  },
+}
+
 // All projects configuration
 export const PROJECTS: Record<ProjectId, ProjectConfig> = {
   kubestellar: {
@@ -217,6 +232,14 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     contentPath: "docs/content/multi-plugin",
     versions: MULTI_PLUGIN_VERSIONS,
   },
+  "kubectl-claude": {
+    id: "kubectl-claude",
+    name: "kubectl-claude",
+    basePath: "kubectl-claude",
+    currentVersion: "0.3.0",
+    contentPath: "docs/content/kubectl-claude",
+    versions: KUBECTL_CLAUDE_VERSIONS,
+  },
 }
 
 // Get project from URL pathname
@@ -229,6 +252,9 @@ export function getProjectFromPath(pathname: string): ProjectConfig {
   }
   if (pathname.startsWith("/docs/multi-plugin")) {
     return PROJECTS["multi-plugin"]
+  }
+  if (pathname.startsWith("/docs/kubectl-claude")) {
+    return PROJECTS["kubectl-claude"]
   }
   return PROJECTS.kubestellar
 }


### PR DESCRIPTION
## Summary
Adds kubectl-claude project support to the docs release automation workflow.

## Changes
- Add kubectl-claude to workflow project options
- Add branch naming for kubectl-claude (`docs/kubectl-claude/{version}`)
- Add doc copy logic for kubectl-claude
- Add `KUBECTL_CLAUDE_VERSIONS` to versions.ts
- Add kubectl-claude to `PROJECTS` config
- Add URL path detection for kubectl-claude docs

## Related
- kubestellar/kubectl-claude#8 - adds the trigger workflow to kubectl-claude repo

🤖 Generated with [Claude Code](https://claude.ai/code)