### PR TITLE
🐛 Fix: Point latest v0.29.0 to docs/0.29.0 branch

### DIFF
--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -41,7 +41,7 @@ export interface ProjectConfig {
 const KUBESTELLAR_VERSIONS: Record<string, VersionInfo> = {
   latest: {
     label: "v0.29.0 (Latest)",
-    branch: "main",
+    branch: "docs/0.29.0",
     isDefault: true,
   },
   main: {


### PR DESCRIPTION
## Summary
- Latest release v0.29.0 now points to its frozen `docs/0.29.0` branch instead of `main`
- This ensures the v0.29.0 documentation remains stable and doesn't change with ongoing development

## Background
v0.29.0 was released on 2025-11-06 but the docs were pointing to `main` which constantly changes. Created `docs/0.29.0` branch to freeze the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)