### PR TITLE
🐛 Fix kubectl-claude version selector detection

### DIFF
--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -253,7 +253,7 @@ export function getProjectFromPath(pathname: string): ProjectConfig {
   if (pathname.startsWith("/docs/multi-plugin")) {
     return PROJECTS["multi-plugin"]
   }
-  if (pathname.startsWith("/docs/kubectl-claude")) {
+  if (pathname.startsWith("/docs/kubectl-claude") || pathname.startsWith("/docs/related-projects/kubectl-claude")) {
     return PROJECTS["kubectl-claude"]
   }
   return PROJECTS.kubestellar


### PR DESCRIPTION
## Summary
The version selector was showing KubeStellar versions (v0.29.0) on kubectl-claude docs pages instead of kubectl-claude versions (v0.3.0).

## Root Cause
The `getProjectFromPath` function checked for `/docs/kubectl-claude` but the actual URL is `/docs/related-projects/kubectl-claude`.

## Fix
Added path check for `/docs/related-projects/kubectl-claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)