### PR TITLE
📖 Add kubectl-claude docs content directory

### DIFF
--- a/docs/content/kubectl-claude/index.md
+++ b/docs/content/kubectl-claude/index.md
@@ -1,0 +1,8 @@
+---
+title: kubectl-claude
+description: AI-powered kubectl plugin for multi-cluster Kubernetes management
+---
+
+# kubectl-claude
+
+Documentation coming soon. See [GitHub](https://github.com/kubestellar/kubectl-claude) for details.


### PR DESCRIPTION
## Summary

Create placeholder `docs/content/kubectl-claude/` directory to enable versioned docs automation.

The `create-version-branch.yml` workflow fails for kubectl-claude because this directory doesn't exist.

## Changes

- Add `docs/content/kubectl-claude/index.md` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)