### PR TITLE
📖 Update kubectl-claude docs to v0.4.0

### DIFF
--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -186,7 +186,7 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubectl-claude versions
 const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.3.0 (Latest)",
+    label: "v0.4.0 (Latest)",
     branch: "main",
     isDefault: true,
   },
@@ -195,6 +195,11 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.4.0": {
+    label: "v0.4.0",
+    branch: "docs/kubectl-claude/0.4.0",
+    isDefault: false,
   },
 }
 


### PR DESCRIPTION
## Summary
Automated update for kubectl-claude release v0.4.0.

- Created branch: `docs/kubectl-claude/0.4.0`
- Source: kubestellar/kubectl-claude@main

## Checklist
- [ ] Verify branch deploys correctly on Netlify
- [ ] Verify version appears in dropdown

🤖 Generated automatically on release