### PR TITLE
📖 Update kubectl-claude docs to v0.4.3

### DIFF
--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -186,7 +186,7 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubectl-claude versions
 const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.4.0 (Latest)",
+    label: "v0.4.3 (Latest)",
     branch: "main",
     isDefault: true,
   },
@@ -195,6 +195,11 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.4.3": {
+    label: "v0.4.3",
+    branch: "docs/kubectl-claude/0.4.3",
+    isDefault: false,
   },
   "0.4.0": {
     label: "v0.4.0",


### PR DESCRIPTION
## Summary
Automated update for kubectl-claude release v0.4.3.

- Created branch: `docs/kubectl-claude/0.4.3`
- Source: kubestellar/kubectl-claude@main

## Checklist
- [ ] Verify branch deploys correctly on Netlify
- [ ] Verify version appears in dropdown

🤖 Generated automatically on release