### PR TITLE
🐛 Fix kubectl-claude latest to point to frozen branch

### DIFF
--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -187,7 +187,7 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
     label: "v0.4.3 (Latest)",
-    branch: "main",
+    branch: "docs/kubectl-claude/0.4.3",
     isDefault: true,
   },
   main: {


### PR DESCRIPTION
## Summary
Point kubectl-claude latest to `docs/kubectl-claude/0.4.3` instead of `main`.

Same fix applied to KubeStellar earlier - released versions should point to frozen branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)