### PR TITLE
🐛 Fix update-version.js to update latest branch

### DIFF
--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -9,7 +9,7 @@
  *   --project      Project ID (kubestellar, a2a, kubeflex, multi-plugin)
  *   --version      Version number (e.g., 0.30.0)
  *   --branch       Branch name for this version (e.g., docs/0.30.0)
- *   --set-latest   If provided, updates the "latest" label and currentVersion
+ *   --set-latest   If provided, updates the "latest" label, branch, and currentVersion
  */
 
 const fs = require('fs');
@@ -89,6 +89,18 @@ if (setLatest) {
     console.log(`  Updated latest label to v${version}`);
   } else {
     console.warn(`  Warning: Could not find latest label pattern in ${constName}`);
+  }
+
+  // Update the "latest" entry's branch to point to the frozen version branch
+  const latestBranchRegex = new RegExp(
+    `(const ${constName}[\\s\\S]*?latest:\\s*\\{[\\s\\S]*?branch:\\s*")[^"]+(")`
+  );
+
+  if (latestBranchRegex.test(content)) {
+    content = content.replace(latestBranchRegex, `$1${branch}$2`);
+    console.log(`  Updated latest branch to ${branch}`);
+  } else {
+    console.warn(`  Warning: Could not find latest branch pattern in ${constName}`);
   }
 
   // Update currentVersion in the project config


### PR DESCRIPTION
## Summary
When `--set-latest` is used, the script now also updates the `latest` entry's branch to point to the frozen version branch instead of keeping it as `main`.

## Changes
- Added regex to update the `branch` field in the `latest` entry
- Updated help text to reflect new behavior

## Before
```
latest: {
  label: "v0.4.3 (Latest)",
  branch: "main",  // <-- stayed as main
  ...
}
```

## After
```
latest: {
  label: "v0.4.3 (Latest)",
  branch: "docs/kubectl-claude/0.4.3",  // <-- now updated
  ...
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)