### PR TITLE
🐛 Fix shared.json latest.branch update in release automation

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -194,7 +194,7 @@ jobs:
             --branch "${{ steps.branch.outputs.name }}" \
             --set-latest
 
-          git add src/config/versions.ts
+          git add src/config/versions.ts public/config/shared.json
           git commit -s -m "chore: update ${{ steps.vars.outputs.project }} to v${{ steps.branch.outputs.version }}
 
           Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -34,8 +34,10 @@
       "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true }
     },
     "kubectl-claude": {
-      "latest": { "label": "v0.4.3 (Latest)", "branch": "main", "isDefault": true },
-      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true }
+      "latest": { "label": "v0.4.3 (Latest)", "branch": "docs/kubectl-claude/0.4.3", "isDefault": true },
+      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true },
+      "0.4.3": { "label": "v0.4.3", "branch": "docs/kubectl-claude/0.4.3", "isDefault": false },
+      "0.4.0": { "label": "v0.4.0", "branch": "docs/kubectl-claude/0.4.0", "isDefault": false }
     }
   },
   "projects": {

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -176,10 +176,12 @@ if (fs.existsSync(sharedJsonPath)) {
     sharedConfig.versions[project] = {};
   }
 
-  // Update latest label if setting as latest
+  // Update latest label and branch if setting as latest
   if (setLatest && sharedConfig.versions[project].latest) {
     sharedConfig.versions[project].latest.label = `v${version} (Latest)`;
+    sharedConfig.versions[project].latest.branch = branch;
     console.log(`  Updated latest label to v${version}`);
+    console.log(`  Updated latest branch to ${branch}`);
   }
 
   // Update currentVersion in projects


### PR DESCRIPTION
## Summary

- Add `latest.branch` update to shared.json section of `update-version.js` when `--set-latest` is used
- Add `public/config/shared.json` to git add in `create-version-branch.yml` workflow  
- Fix kubectl-claude shared.json data to match versions.ts (add missing version entries and correct `latest.branch` from `main` to `docs/kubectl-claude/0.4.3`)

## Problem

PR 713 (merged) introduced `shared.json` for dynamic version loading, but the `update-version.js` script only updates `latest.label` in shared.json - it was missing the `latest.branch` update. This caused a mismatch between `versions.ts` and `shared.json`.

## Test plan

- [ ] Run `node scripts/update-version.js --project kubectl-claude --version 0.5.0 --branch docs/kubectl-claude/0.5.0 --set-latest`
- [ ] Verify both `versions.ts` and `shared.json` have `latest.branch = "docs/kubectl-claude/0.5.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)