### PR TITLE
📖 Update kubectl-claude docs to v0.4.4

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -1,58 +1,225 @@
 {
   "versions": {
     "kubestellar": {
-      "latest": { "label": "v0.29.0 (Latest)", "branch": "docs/0.29.0", "isDefault": true },
-      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true },
-      "0.28.0": { "label": "v0.28.0", "branch": "docs/0.28.0", "isDefault": false },
-      "0.27.2": { "label": "v0.27.2", "branch": "docs/0.27.2", "isDefault": false },
-      "0.27.1": { "label": "v0.27.1", "branch": "docs/0.27.1", "isDefault": false },
-      "0.27.0": { "label": "v0.27.0", "branch": "docs/0.27.0", "isDefault": false },
-      "0.26.0": { "label": "v0.26.0", "branch": "docs/0.26.0", "isDefault": false },
-      "0.25.1": { "label": "v0.25.1", "branch": "docs/0.25.1", "isDefault": false },
-      "0.25.0": { "label": "v0.25.0", "branch": "docs/0.25.0", "isDefault": false },
-      "0.24.0": { "label": "v0.24.0", "branch": "docs/0.24.0", "isDefault": false },
-      "0.23.1": { "label": "v0.23.1", "branch": "docs/0.23.1", "isDefault": false },
-      "0.23.0": { "label": "v0.23.0", "branch": "docs/0.23.0", "isDefault": false },
-      "0.22.0": { "label": "v0.22.0", "branch": "docs/0.22.0", "isDefault": false },
-      "0.21.2": { "label": "v0.21.2", "branch": "docs/0.21.2", "isDefault": false },
-      "0.21.1": { "label": "v0.21.1", "branch": "docs/0.21.1", "isDefault": false },
-      "0.21.0": { "label": "v0.21.0", "branch": "docs/0.21.0", "isDefault": false },
-      "legacy": { "label": "Older Versions", "branch": "legacy", "isDefault": false, "externalUrl": "https://kubestellar.github.io/kubestellar" }
+      "latest": {
+        "label": "v0.29.0 (Latest)",
+        "branch": "docs/0.29.0",
+        "isDefault": true
+      },
+      "main": {
+        "label": "main (dev)",
+        "branch": "main",
+        "isDefault": false,
+        "isDev": true
+      },
+      "0.28.0": {
+        "label": "v0.28.0",
+        "branch": "docs/0.28.0",
+        "isDefault": false
+      },
+      "0.27.2": {
+        "label": "v0.27.2",
+        "branch": "docs/0.27.2",
+        "isDefault": false
+      },
+      "0.27.1": {
+        "label": "v0.27.1",
+        "branch": "docs/0.27.1",
+        "isDefault": false
+      },
+      "0.27.0": {
+        "label": "v0.27.0",
+        "branch": "docs/0.27.0",
+        "isDefault": false
+      },
+      "0.26.0": {
+        "label": "v0.26.0",
+        "branch": "docs/0.26.0",
+        "isDefault": false
+      },
+      "0.25.1": {
+        "label": "v0.25.1",
+        "branch": "docs/0.25.1",
+        "isDefault": false
+      },
+      "0.25.0": {
+        "label": "v0.25.0",
+        "branch": "docs/0.25.0",
+        "isDefault": false
+      },
+      "0.24.0": {
+        "label": "v0.24.0",
+        "branch": "docs/0.24.0",
+        "isDefault": false
+      },
+      "0.23.1": {
+        "label": "v0.23.1",
+        "branch": "docs/0.23.1",
+        "isDefault": false
+      },
+      "0.23.0": {
+        "label": "v0.23.0",
+        "branch": "docs/0.23.0",
+        "isDefault": false
+      },
+      "0.22.0": {
+        "label": "v0.22.0",
+        "branch": "docs/0.22.0",
+        "isDefault": false
+      },
+      "0.21.2": {
+        "label": "v0.21.2",
+        "branch": "docs/0.21.2",
+        "isDefault": false
+      },
+      "0.21.1": {
+        "label": "v0.21.1",
+        "branch": "docs/0.21.1",
+        "isDefault": false
+      },
+      "0.21.0": {
+        "label": "v0.21.0",
+        "branch": "docs/0.21.0",
+        "isDefault": false
+      },
+      "legacy": {
+        "label": "Older Versions",
+        "branch": "legacy",
+        "isDefault": false,
+        "externalUrl": "https://kubestellar.github.io/kubestellar"
+      }
     },
     "a2a": {
-      "latest": { "label": "v0.1.0 (Latest)", "branch": "main", "isDefault": true },
-      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true }
+      "latest": {
+        "label": "v0.1.0 (Latest)",
+        "branch": "main",
+        "isDefault": true
+      },
+      "main": {
+        "label": "main (dev)",
+        "branch": "main",
+        "isDefault": false,
+        "isDev": true
+      }
     },
     "kubeflex": {
-      "latest": { "label": "v0.9.3 (Latest)", "branch": "main", "isDefault": true },
-      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true },
-      "0.8.0": { "label": "v0.8.0", "branch": "docs/kubeflex/0.8.0", "isDefault": false },
-      "0.7.0": { "label": "v0.7.0", "branch": "docs/kubeflex/0.7.0", "isDefault": false }
+      "latest": {
+        "label": "v0.9.3 (Latest)",
+        "branch": "main",
+        "isDefault": true
+      },
+      "main": {
+        "label": "main (dev)",
+        "branch": "main",
+        "isDefault": false,
+        "isDev": true
+      },
+      "0.8.0": {
+        "label": "v0.8.0",
+        "branch": "docs/kubeflex/0.8.0",
+        "isDefault": false
+      },
+      "0.7.0": {
+        "label": "v0.7.0",
+        "branch": "docs/kubeflex/0.7.0",
+        "isDefault": false
+      }
     },
     "multi-plugin": {
-      "latest": { "label": "v0.1.0 (Latest)", "branch": "main", "isDefault": true },
-      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true }
+      "latest": {
+        "label": "v0.1.0 (Latest)",
+        "branch": "main",
+        "isDefault": true
+      },
+      "main": {
+        "label": "main (dev)",
+        "branch": "main",
+        "isDefault": false,
+        "isDev": true
+      }
     },
     "kubectl-claude": {
-      "latest": { "label": "v0.4.3 (Latest)", "branch": "docs/kubectl-claude/0.4.3", "isDefault": true },
-      "main": { "label": "main (dev)", "branch": "main", "isDefault": false, "isDev": true },
-      "0.4.3": { "label": "v0.4.3", "branch": "docs/kubectl-claude/0.4.3", "isDefault": false },
-      "0.4.0": { "label": "v0.4.0", "branch": "docs/kubectl-claude/0.4.0", "isDefault": false }
+      "latest": {
+        "label": "v0.4.4 (Latest)",
+        "branch": "docs/kubectl-claude/0.4.4",
+        "isDefault": true
+      },
+      "main": {
+        "label": "main (dev)",
+        "branch": "main",
+        "isDefault": false,
+        "isDev": true
+      },
+      "0.4.3": {
+        "label": "v0.4.3",
+        "branch": "docs/kubectl-claude/0.4.3",
+        "isDefault": false
+      },
+      "0.4.0": {
+        "label": "v0.4.0",
+        "branch": "docs/kubectl-claude/0.4.0",
+        "isDefault": false
+      },
+      "0.4.4": {
+        "label": "v0.4.4",
+        "branch": "docs/kubectl-claude/0.4.4",
+        "isDefault": false
+      }
     }
   },
   "projects": {
-    "kubestellar": { "name": "KubeStellar", "basePath": "", "currentVersion": "0.29.0" },
-    "a2a": { "name": "A2A", "basePath": "a2a", "currentVersion": "0.1.0" },
-    "kubeflex": { "name": "KubeFlex", "basePath": "kubeflex", "currentVersion": "0.9.3" },
-    "multi-plugin": { "name": "Multi Plugin", "basePath": "multi-plugin", "currentVersion": "0.1.0" },
-    "kubectl-claude": { "name": "kubectl-claude", "basePath": "kubectl-claude", "currentVersion": "0.4.3" }
+    "kubestellar": {
+      "name": "KubeStellar",
+      "basePath": "",
+      "currentVersion": "0.29.0"
+    },
+    "a2a": {
+      "name": "A2A",
+      "basePath": "a2a",
+      "currentVersion": "0.1.0"
+    },
+    "kubeflex": {
+      "name": "KubeFlex",
+      "basePath": "kubeflex",
+      "currentVersion": "0.9.3"
+    },
+    "multi-plugin": {
+      "name": "Multi Plugin",
+      "basePath": "multi-plugin",
+      "currentVersion": "0.1.0"
+    },
+    "kubectl-claude": {
+      "name": "kubectl-claude",
+      "basePath": "kubectl-claude",
+      "currentVersion": "0.4.4"
+    }
   },
   "relatedProjects": [
-    { "title": "KubeStellar", "href": "/docs/what-is-kubestellar/overview", "description": "Multi-cluster configuration management" },
-    { "title": "kubectl-claude", "href": "/docs/kubectl-claude/overview/introduction", "description": "AI-powered kubectl plugin" },
-    { "title": "KubeFlex", "href": "/docs/kubeflex/overview/introduction", "description": "Lightweight Kubernetes control planes" },
-    { "title": "A2A", "href": "/docs/a2a/overview/introduction", "description": "Agent-to-Agent protocol" },
-    { "title": "Multi Plugin", "href": "/docs/multi-plugin/overview/introduction", "description": "Multi-cluster kubectl plugin" }
+    {
+      "title": "KubeStellar",
+      "href": "/docs/what-is-kubestellar/overview",
+      "description": "Multi-cluster configuration management"
+    },
+    {
+      "title": "kubectl-claude",
+      "href": "/docs/kubectl-claude/overview/introduction",
+      "description": "AI-powered kubectl plugin"
+    },
+    {
+      "title": "KubeFlex",
+      "href": "/docs/kubeflex/overview/introduction",
+      "description": "Lightweight Kubernetes control planes"
+    },
+    {
+      "title": "A2A",
+      "href": "/docs/a2a/overview/introduction",
+      "description": "Agent-to-Agent protocol"
+    },
+    {
+      "title": "Multi Plugin",
+      "href": "/docs/multi-plugin/overview/introduction",
+      "description": "Multi-cluster kubectl plugin"
+    }
   ],
   "editBaseUrls": {
     "kubestellar": "https://github.com/kubestellar/docs/edit/main/docs/content",
@@ -61,5 +228,5 @@
     "multi-plugin": "https://github.com/kubestellar/kubectl-multi-plugin/edit/main/docs",
     "kubectl-claude": "https://github.com/kubestellar/kubectl-claude/edit/main/docs"
   },
-  "updatedAt": "2026-01-15T01:45:00Z"
+  "updatedAt": "2026-01-15T06:21:14.796Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -187,8 +187,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // Note: Only latest/main for now - older versions don't have docs structure
 const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.4.3 (Latest)",
-    branch: "docs/kubectl-claude/0.4.3",
+    label: "v0.4.4 (Latest)",
+    branch: "docs/kubectl-claude/0.4.4",
     isDefault: true,
   },
   main: {
@@ -196,6 +196,11 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.4.4": {
+    label: "v0.4.4",
+    branch: "docs/kubectl-claude/0.4.4",
+    isDefault: false,
   },
 }
 


### PR DESCRIPTION
## Summary
Automated update for kubectl-claude release v0.4.4.

- Created branch: `docs/kubectl-claude/0.4.4`
- Source: kubestellar/kubectl-claude@main

## Checklist
- [ ] Verify branch deploys correctly on Netlify
- [ ] Verify version appears in dropdown

🤖 Generated automatically on release