### PR TITLE
🐛 Fix duplicate version entries in selector

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -159,11 +159,6 @@
         "label": "v0.4.0",
         "branch": "docs/kubectl-claude/0.4.0",
         "isDefault": false
-      },
-      "0.4.4": {
-        "label": "v0.4.4",
-        "branch": "docs/kubectl-claude/0.4.4",
-        "isDefault": false
       }
     }
   },

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -119,9 +119,11 @@ if (setLatest) {
   }
 }
 
-// Check if version entry already exists
+// Check if version entry already exists or if we're setting as latest (no duplicate needed)
 const versionEntryRegex = new RegExp(`"${escapeRegex(version)}":\\s*\\{`, '');
-if (versionEntryRegex.test(content)) {
+if (setLatest) {
+  console.log(`  Skipping version entry (latest already points to ${version})`);
+} else if (versionEntryRegex.test(content)) {
   console.log(`  Version ${version} already exists in ${constName}, skipping addition`);
 } else {
   // Add new version entry after 'main' entry
@@ -190,8 +192,10 @@ if (fs.existsSync(sharedJsonPath)) {
     console.log(`  Updated currentVersion to ${version}`);
   }
 
-  // Add new version entry if it doesn't exist
-  if (!sharedConfig.versions[project][version]) {
+  // Add new version entry if it doesn't exist (skip if setting as latest - no duplicate needed)
+  if (setLatest) {
+    console.log(`  Skipping version entry (latest already points to ${version})`);
+  } else if (!sharedConfig.versions[project][version]) {
     sharedConfig.versions[project][version] = {
       label: `v${version}`,
       branch: branch,

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -197,11 +197,6 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     isDefault: false,
     isDev: true,
   },
-  "0.4.4": {
-    label: "v0.4.4",
-    branch: "docs/kubectl-claude/0.4.4",
-    isDefault: false,
-  },
 }
 
 // All projects configuration


### PR DESCRIPTION
## Summary

- Skip adding version entry when `--set-latest` is used (latest already points to it)
- Remove duplicate "0.4.4" entry from kubectl-claude (latest is sufficient)

## Problem

The version selector was showing both "v0.4.4 (Latest)" and "v0.4.4" for kubectl-claude. The "v0.4.4" entry fails because it tries to construct a branch deploy URL, while "v0.4.4 (Latest)" works because it uses the production URL.

When `--set-latest` is used, we only need the "latest" entry - adding a separate numbered entry creates a confusing duplicate that doesn't work correctly.

## Test plan

- [ ] Check version selector no longer shows duplicate entries
- [ ] Run `node scripts/update-version.js --project kubectl-claude --version 0.5.0 --branch docs/kubectl-claude/0.5.0 --set-latest` and verify only latest is updated (no "0.5.0" entry added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)