### PR TITLE
🐛 Preserve previous latest version when setting new latest

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -150,6 +150,11 @@
         "isDefault": false,
         "isDev": true
       },
+      "0.4.4": {
+        "label": "v0.4.4",
+        "branch": "docs/kubectl-claude/0.4.4",
+        "isDefault": false
+      },
       "0.4.3": {
         "label": "v0.4.3",
         "branch": "docs/kubectl-claude/0.4.3",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -77,7 +77,33 @@ console.log(`  Branch: ${branch}`);
 console.log(`  Set as latest: ${setLatest}`);
 
 // Update latest label if setting as latest
+let previousLatestVersion = null;
+let previousLatestBranch = null;
+
 if (setLatest) {
+  // Extract current latest version before updating (to preserve as historical entry)
+  const extractLabelRegex = new RegExp(
+    `const ${constName}[\\s\\S]*?latest:\\s*\\{[\\s\\S]*?label:\\s*"v([\\d.]+) \\(Latest\\)"`
+  );
+  const extractBranchRegex = new RegExp(
+    `const ${constName}[\\s\\S]*?latest:\\s*\\{[\\s\\S]*?branch:\\s*"([^"]+)"`
+  );
+
+  const labelMatch = content.match(extractLabelRegex);
+  const branchMatch = content.match(extractBranchRegex);
+
+  if (labelMatch && branchMatch) {
+    previousLatestVersion = labelMatch[1];
+    previousLatestBranch = branchMatch[1];
+    // Only preserve if it's different from main (actual release)
+    if (previousLatestBranch !== 'main' && previousLatestVersion !== version) {
+      console.log(`  Previous latest: v${previousLatestVersion} (${previousLatestBranch})`);
+    } else {
+      previousLatestVersion = null;
+      previousLatestBranch = null;
+    }
+  }
+
   // Update the "latest" entry's label to show the new version
   const latestRegex = new RegExp(
     `(const ${constName}[\\s\\S]*?latest:\\s*\\{[\\s\\S]*?label:\\s*")v[\\d.]+( \\(Latest\\)")`,
@@ -119,10 +145,32 @@ if (setLatest) {
   }
 }
 
-// Check if version entry already exists or if we're setting as latest (no duplicate needed)
+// Add version entry for previous latest (when setting new latest) or for non-latest versions
 const versionEntryRegex = new RegExp(`"${escapeRegex(version)}":\\s*\\{`, '');
-if (setLatest) {
-  console.log(`  Skipping version entry (latest already points to ${version})`);
+if (setLatest && previousLatestVersion) {
+  // Add entry for the PREVIOUS latest version (so it remains accessible)
+  const prevVersionEntryRegex = new RegExp(`"${escapeRegex(previousLatestVersion)}":\\s*\\{`, '');
+  if (!prevVersionEntryRegex.test(content)) {
+    const prevEntry = `  "${previousLatestVersion}": {
+    label: "v${previousLatestVersion}",
+    branch: "${previousLatestBranch}",
+    isDefault: false,
+  },`;
+
+    const mainEntryRegex = new RegExp(
+      `(const ${constName}[\\s\\S]*?main:\\s*\\{[^}]+\\},)`,
+      ''
+    );
+
+    if (mainEntryRegex.test(content)) {
+      content = content.replace(mainEntryRegex, `$1\n${prevEntry}`);
+      console.log(`  Added historical entry for previous latest v${previousLatestVersion}`);
+    }
+  } else {
+    console.log(`  Previous latest v${previousLatestVersion} already has an entry`);
+  }
+} else if (setLatest) {
+  console.log(`  No previous latest to preserve (was pointing to main)`);
 } else if (versionEntryRegex.test(content)) {
   console.log(`  Version ${version} already exists in ${constName}, skipping addition`);
 } else {
@@ -178,6 +226,20 @@ if (fs.existsSync(sharedJsonPath)) {
     sharedConfig.versions[project] = {};
   }
 
+  // Capture previous latest before updating (for shared.json)
+  let sharedPrevVersion = null;
+  let sharedPrevBranch = null;
+  if (setLatest && sharedConfig.versions[project].latest) {
+    const prevLabel = sharedConfig.versions[project].latest.label;
+    sharedPrevBranch = sharedConfig.versions[project].latest.branch;
+    // Extract version from label like "v0.4.4 (Latest)"
+    const match = prevLabel.match(/^v([\d.]+)/);
+    if (match && sharedPrevBranch !== 'main' && match[1] !== version) {
+      sharedPrevVersion = match[1];
+      console.log(`  Previous latest: v${sharedPrevVersion} (${sharedPrevBranch})`);
+    }
+  }
+
   // Update latest label and branch if setting as latest
   if (setLatest && sharedConfig.versions[project].latest) {
     sharedConfig.versions[project].latest.label = `v${version} (Latest)`;
@@ -192,9 +254,19 @@ if (fs.existsSync(sharedJsonPath)) {
     console.log(`  Updated currentVersion to ${version}`);
   }
 
-  // Add new version entry if it doesn't exist (skip if setting as latest - no duplicate needed)
-  if (setLatest) {
-    console.log(`  Skipping version entry (latest already points to ${version})`);
+  // Add entry for previous latest (when setting new latest) or for non-latest versions
+  if (setLatest && sharedPrevVersion && !sharedConfig.versions[project][sharedPrevVersion]) {
+    // Add entry for the PREVIOUS latest version (so it remains accessible)
+    sharedConfig.versions[project][sharedPrevVersion] = {
+      label: `v${sharedPrevVersion}`,
+      branch: sharedPrevBranch,
+      isDefault: false
+    };
+    console.log(`  Added historical entry for previous latest v${sharedPrevVersion}`);
+  } else if (setLatest && sharedPrevVersion) {
+    console.log(`  Previous latest v${sharedPrevVersion} already has an entry`);
+  } else if (setLatest) {
+    console.log(`  No previous latest to preserve (was pointing to main)`);
   } else if (!sharedConfig.versions[project][version]) {
     sharedConfig.versions[project][version] = {
       label: `v${version}`,

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -197,6 +197,11 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     isDefault: false,
     isDev: true,
   },
+  "0.4.4": {
+    label: "v0.4.4",
+    branch: "docs/kubectl-claude/0.4.4",
+    isDefault: false,
+  },
 }
 
 // All projects configuration


### PR DESCRIPTION
## Summary

- Extract previous latest version/branch before updating
- Add historical entry for previous latest so it remains accessible
- Adds missing 0.4.4 entry back to kubectl-claude

## Problem

When releasing v0.4.5 as latest, v0.4.4 disappeared from the version selector because the script wasn't preserving the previous latest as a historical entry.

## Test plan

- [ ] Trigger workflow with v0.4.6 --set-latest
- [ ] Verify v0.4.5 is added as historical entry
- [ ] Verify version selector shows: v0.4.6 (Latest), main (dev), v0.4.5, v0.4.4, v0.4.3, v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)