### PR TITLE
📖 Update kubectl-claude docs to v0.4.6

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -140,8 +140,8 @@
     },
     "kubectl-claude": {
       "latest": {
-        "label": "v0.4.5 (Latest)",
-        "branch": "docs/kubectl-claude/0.4.5",
+        "label": "v0.4.6 (Latest)",
+        "branch": "docs/kubectl-claude/0.4.6",
         "isDefault": true
       },
       "main": {
@@ -163,6 +163,11 @@
       "0.4.0": {
         "label": "v0.4.0",
         "branch": "docs/kubectl-claude/0.4.0",
+        "isDefault": false
+      },
+      "0.4.5": {
+        "label": "v0.4.5",
+        "branch": "docs/kubectl-claude/0.4.5",
         "isDefault": false
       }
     }
@@ -191,7 +196,7 @@
     "kubectl-claude": {
       "name": "kubectl-claude",
       "basePath": "kubectl-claude",
-      "currentVersion": "0.4.5"
+      "currentVersion": "0.4.6"
     }
   },
   "relatedProjects": [
@@ -228,5 +233,5 @@
     "multi-plugin": "https://github.com/kubestellar/kubectl-multi-plugin/edit/main/docs",
     "kubectl-claude": "https://github.com/kubestellar/kubectl-claude/edit/main/docs"
   },
-  "updatedAt": "2026-01-15T06:30:48.358Z"
+  "updatedAt": "2026-01-15T06:36:06.391Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -187,8 +187,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // Note: Only latest/main for now - older versions don't have docs structure
 const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.4.5 (Latest)",
-    branch: "docs/kubectl-claude/0.4.5",
+    label: "v0.4.6 (Latest)",
+    branch: "docs/kubectl-claude/0.4.6",
     isDefault: true,
   },
   main: {
@@ -196,6 +196,11 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.4.5": {
+    label: "v0.4.5",
+    branch: "docs/kubectl-claude/0.4.5",
+    isDefault: false,
   },
   "0.4.4": {
     label: "v0.4.4",


### PR DESCRIPTION
## Summary
Automated update for kubectl-claude release v0.4.6.

- Created branch: `docs/kubectl-claude/0.4.6`
- Source: kubestellar/kubectl-claude@main

## Checklist
- [ ] Verify branch deploys correctly on Netlify
- [ ] Verify version appears in dropdown

🤖 Generated automatically on release