### PR TITLE
✨ Rename kubectl-claude to klaude

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       project:
-        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin, kubectl-claude)'
+        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin, klaude)'
         required: true
         type: choice
         options:
@@ -14,7 +14,7 @@ on:
           - a2a
           - kubeflex
           - multi-plugin
-          - kubectl-claude
+          - klaude
       version:
         description: 'Version number (e.g., 0.30.0)'
         required: true
@@ -72,7 +72,7 @@ jobs:
             a2a) BRANCH="docs/a2a/${VERSION}" ;;
             kubeflex) BRANCH="docs/kubeflex/${VERSION}" ;;
             multi-plugin) BRANCH="docs/multi-plugin/${VERSION}" ;;
-            kubectl-claude) BRANCH="docs/kubectl-claude/${VERSION}" ;;
+            klaude) BRANCH="docs/klaude/${VERSION}" ;;
             *) echo "Unknown project: $PROJECT"; exit 1 ;;
           esac
           echo "name=$BRANCH" >> $GITHUB_OUTPUT

--- a/docs/content/direct/claude-code.md
+++ b/docs/content/direct/claude-code.md
@@ -4,7 +4,7 @@ Use Claude Code's AI capabilities to manage multiple Kubernetes clusters simulta
 
 ## Overview
 
-kubectl-claude is an AI-powered kubectl plugin designed for **managing multiple clusters simultaneously**. It integrates with Claude Code, enabling you to:
+klaude is an AI-powered kubectl plugin designed for **managing multiple clusters simultaneously**. It integrates with Claude Code, enabling you to:
 
 - Query Kubernetes resources across multiple clusters using natural language
 - Diagnose pod issues (CrashLoopBackOff, OOMKilled, pending pods)
@@ -18,7 +18,7 @@ kubectl-claude is an AI-powered kubectl plugin designed for **managing multiple 
 
 ```bash
 brew tap kubestellar/tap
-brew install kubectl-claude
+brew install klaude
 ```
 
 ### Option 2: Claude Code Plugin Marketplace
@@ -29,14 +29,14 @@ In Claude Code, run:
 /plugin marketplace add kubestellar/claude-plugins
 ```
 
-Then go to `/plugin` → **Discover** tab and install **kubectl-claude**.
+Then go to `/plugin` → **Discover** tab and install **klaude**.
 
 ### Verify Installation
 
 Run `/mcp` in Claude Code to see connected MCP servers:
 
 ```
-plugin:kubectl-claude:kubectl-claude · ✓ connected
+plugin:klaude:klaude · ✓ connected
 ```
 
 ## Configuration
@@ -49,7 +49,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 {
   "permissions": {
     "allow": [
-      "mcp__plugin_kubectl-claude_kubectl-claude__*"
+      "mcp__plugin_klaude_klaude__*"
     ]
   }
 }
@@ -58,12 +58,12 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 Or run in Claude Code:
 
 ```
-/allowed-tools add mcp__plugin_kubectl-claude_kubectl-claude__*
+/allowed-tools add mcp__plugin_klaude_klaude__*
 ```
 
 ## Slash Commands
 
-The kubectl-claude plugin provides specialized slash commands for common Kubernetes operations:
+The klaude plugin provides specialized slash commands for common Kubernetes operations:
 
 ### /k8s-health
 
@@ -231,21 +231,21 @@ Once installed, ask Claude questions like:
 
 ## CLI Usage
 
-kubectl-claude also works as a standalone kubectl plugin:
+klaude also works as a standalone kubectl plugin:
 
 ```bash
 # List all clusters
-kubectl claude clusters list
+kubectl klaude clusters list
 
 # Check cluster health
-kubectl claude clusters health
+kubectl klaude clusters health
 
 # Natural language queries (requires ANTHROPIC_API_KEY)
-kubectl claude "show me failing pods"
+kubectl klaude "show me failing pods"
 ```
 
 ## Links
 
-- [kubectl-claude on GitHub](https://github.com/kubestellar/kubectl-claude)
+- [klaude on GitHub](https://github.com/kubestellar/klaude)
 - [Claude Plugins Marketplace](https://github.com/kubestellar/claude-plugins)
 - [Homebrew Tap](https://github.com/kubestellar/homebrew-tap)

--- a/docs/content/klaude/index.md
+++ b/docs/content/klaude/index.md
@@ -1,0 +1,8 @@
+---
+title: klaude
+description: AI-powered kubectl plugin for multi-cluster Kubernetes management
+---
+
+# klaude
+
+Documentation coming soon. See [GitHub](https://github.com/kubestellar/klaude) for details.

--- a/docs/content/klaude/overview/intro.md
+++ b/docs/content/klaude/overview/intro.md
@@ -3,13 +3,13 @@ title: Introduction
 description: AI-powered kubectl plugin for multi-cluster Kubernetes management
 ---
 
-# kubectl-claude
+# klaude
 
 AI-powered kubectl plugin for multi-cluster Kubernetes management, with built-in diagnostic tools.
 
 ## Overview
 
-kubectl-claude provides two main interfaces:
+klaude provides two main interfaces:
 
 1. **Claude Code Plugin** - Use natural language to query and manage Kubernetes clusters directly in Claude Code
 2. **CLI Tool** - Traditional kubectl plugin with AI-powered natural language queries
@@ -31,20 +31,20 @@ kubectl-claude provides two main interfaces:
 
 ```bash
 brew tap kubestellar/tap
-brew install kubectl-claude
+brew install klaude
 ```
 
 #### From Releases
 
-Download from [GitHub Releases](https://github.com/kubestellar/kubectl-claude/releases).
+Download from [GitHub Releases](https://github.com/kubestellar/klaude/releases).
 
 #### From Source
 
 ```bash
-git clone https://github.com/kubestellar/kubectl-claude.git
-cd kubectl-claude
-go build -o kubectl-claude ./cmd/kubectl-claude
-sudo mv kubectl-claude /usr/local/bin/
+git clone https://github.com/kubestellar/klaude.git
+cd klaude
+go build -o klaude ./cmd/klaude
+sudo mv klaude /usr/local/bin/
 ```
 
 ### Claude Code Plugin Setup
@@ -54,13 +54,13 @@ sudo mv kubectl-claude /usr/local/bin/
    /plugin marketplace add kubestellar/claude-plugins
    ```
 2. Go to `/plugin` → **Discover** tab
-3. Install **kubectl-claude**
+3. Install **klaude**
 
 #### Verify Installation
 
 Run `/mcp` in Claude Code - you should see:
 ```
-plugin:kubectl-claude:kubectl-claude · ✓ connected
+plugin:klaude:klaude · ✓ connected
 ```
 
 #### Allow Tools Without Prompts
@@ -71,7 +71,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 {
   "permissions": {
     "allow": [
-      "mcp__plugin_kubectl-claude_kubectl-claude__*"
+      "mcp__plugin_klaude_klaude__*"
     ]
   }
 }
@@ -79,7 +79,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 
 Or run in Claude Code:
 ```
-/allowed-tools add mcp__plugin_kubectl-claude_kubectl-claude__*
+/allowed-tools add mcp__plugin_klaude_klaude__*
 ```
 
 ### Usage in Claude Code
@@ -158,7 +158,7 @@ Once installed, ask questions like:
 
 ## Slash Commands
 
-When using kubectl-claude as a Claude Code plugin, these slash commands provide guided workflows for common tasks:
+When using klaude as a Claude Code plugin, these slash commands provide guided workflows for common tasks:
 
 | Command | Description |
 |---------|-------------|
@@ -194,20 +194,20 @@ When using kubectl-claude as a Claude Code plugin, these slash commands provide 
 
 ```bash
 # List all clusters
-kubectl claude clusters list
+kubectl klaude clusters list
 
 # Check cluster health
-kubectl claude clusters health
+kubectl klaude clusters health
 
 # Natural language queries (requires ANTHROPIC_API_KEY)
-kubectl claude "show me failing pods"
+kubectl klaude "show me failing pods"
 ```
 
 ### As MCP Server
 
 ```bash
 # Start MCP server (used by Claude Code)
-kubectl-claude --mcp-server
+klaude --mcp-server
 ```
 
 ## Environment Variables
@@ -219,8 +219,8 @@ kubectl-claude --mcp-server
 
 ## Contributing
 
-Contributions are welcome! Please read our [contributing guidelines](https://github.com/kubestellar/kubectl-claude/blob/main/CONTRIBUTING.md).
+Contributions are welcome! Please read our [contributing guidelines](https://github.com/kubestellar/klaude/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Apache License 2.0 - see [LICENSE](https://github.com/kubestellar/kubectl-claude/blob/main/LICENSE) for details.
+Apache License 2.0 - see [LICENSE](https://github.com/kubestellar/klaude/blob/main/LICENSE) for details.

--- a/docs/content/kubectl-claude/index.md
+++ b/docs/content/kubectl-claude/index.md
@@ -1,8 +1,0 @@
----
-title: kubectl-claude
-description: AI-powered kubectl plugin for multi-cluster Kubernetes management
----
-
-# kubectl-claude
-
-Documentation coming soon. See [GitHub](https://github.com/kubestellar/kubectl-claude) for details.

--- a/netlify.toml
+++ b/netlify.toml
@@ -179,16 +179,16 @@
   status = 301
   force = true
 
-# Redirect claude.kubestellar.io to kubestellar.io/docs/kubectl-claude
+# Redirect claude.kubestellar.io to kubestellar.io/docs/klaude
 [[redirects]]
   from = "https://claude.kubestellar.io/*"
-  to = "https://kubestellar.io/docs/kubectl-claude/:splat"
+  to = "https://kubestellar.io/docs/klaude/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "https://claude.kubestellar.io"
-  to = "https://kubestellar.io/docs/kubectl-claude/overview/introduction"
+  to = "https://kubestellar.io/docs/klaude/overview/introduction"
   status = 301
   force = true
 

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -138,10 +138,10 @@
         "isDev": true
       }
     },
-    "kubectl-claude": {
+    "klaude": {
       "latest": {
-        "label": "v0.5.0 (Latest)",
-        "branch": "docs/kubectl-claude/0.5.0",
+        "label": "v0.6.0 (Latest)",
+        "branch": "docs/klaude/0.6.0",
         "isDefault": true
       },
       "main": {
@@ -150,29 +150,9 @@
         "isDefault": false,
         "isDev": true
       },
-      "0.4.4": {
-        "label": "v0.4.4",
-        "branch": "docs/kubectl-claude/0.4.4",
-        "isDefault": false
-      },
-      "0.4.3": {
-        "label": "v0.4.3",
-        "branch": "docs/kubectl-claude/0.4.3",
-        "isDefault": false
-      },
-      "0.4.0": {
-        "label": "v0.4.0",
-        "branch": "docs/kubectl-claude/0.4.0",
-        "isDefault": false
-      },
-      "0.4.5": {
-        "label": "v0.4.5",
-        "branch": "docs/kubectl-claude/0.4.5",
-        "isDefault": false
-      },
-      "0.4.6": {
-        "label": "v0.4.6",
-        "branch": "docs/kubectl-claude/0.4.6",
+      "0.5.0": {
+        "label": "v0.5.0",
+        "branch": "docs/klaude/0.5.0",
         "isDefault": false
       }
     }
@@ -198,10 +178,10 @@
       "basePath": "multi-plugin",
       "currentVersion": "0.1.0"
     },
-    "kubectl-claude": {
-      "name": "kubectl-claude",
-      "basePath": "kubectl-claude",
-      "currentVersion": "0.5.0"
+    "klaude": {
+      "name": "klaude",
+      "basePath": "klaude",
+      "currentVersion": "0.6.0"
     }
   },
   "relatedProjects": [
@@ -211,8 +191,8 @@
       "description": "Multi-cluster configuration management"
     },
     {
-      "title": "kubectl-claude",
-      "href": "/docs/kubectl-claude/overview/introduction",
+      "title": "klaude",
+      "href": "/docs/klaude/overview/introduction",
       "description": "AI-powered kubectl plugin"
     },
     {
@@ -236,7 +216,7 @@
     "a2a": "https://github.com/kubestellar/a2a/edit/main/docs",
     "kubeflex": "https://github.com/kubestellar/kubeflex/edit/main/docs",
     "multi-plugin": "https://github.com/kubestellar/kubectl-multi-plugin/edit/main/docs",
-    "kubectl-claude": "https://github.com/kubestellar/kubectl-claude/edit/main/docs"
+    "klaude": "https://github.com/kubestellar/klaude/edit/main/docs"
   },
   "updatedAt": "2026-01-15T15:43:14.944Z"
 }

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -47,7 +47,7 @@ const versionConstants = {
   'a2a': 'A2A_VERSIONS',
   'kubeflex': 'KUBEFLEX_VERSIONS',
   'multi-plugin': 'MULTI_PLUGIN_VERSIONS',
-  'kubectl-claude': 'KUBECTL_CLAUDE_VERSIONS'
+  'klaude': 'KLAUDE_VERSIONS'
 };
 
 const constName = versionConstants[project];

--- a/src/app/[locale]/marketplace/plugins.tsx
+++ b/src/app/[locale]/marketplace/plugins.tsx
@@ -1043,21 +1043,21 @@ Free and open source, inspired by Chaos Mesh and powered by the community.`,
     },
     {
       id: "25",
-      name: "kubectl-claude",
-      slug: "kubectl-claude",
+      name: "klaude",
+      slug: "klaude",
       tagline: "AI-powered multi-cluster Kubernetes management for Claude Code",
       description:
         "Integrate Claude Code with your Kubernetes clusters. Use natural language to query pods, diagnose issues, analyze RBAC, and manage multi-cluster environments.",
-      longDescription: `kubectl-claude brings the power of AI to multi-cluster Kubernetes management. Install as a Claude Code plugin and use natural language to interact with your clusters.
+      longDescription: `klaude brings the power of AI to multi-cluster Kubernetes management. Install as a Claude Code plugin and use natural language to interact with your clusters.
 
-Ask questions like "find pods with issues", "what permissions does the admin service account have?", or "show me warning events in kube-system". kubectl-claude understands your intent and executes the right kubectl commands across all your clusters.
+Ask questions like "find pods with issues", "what permissions does the admin service account have?", or "show me warning events in kube-system". klaude understands your intent and executes the right kubectl commands across all your clusters.
 
 Built-in diagnostic tools help you quickly identify CrashLoopBackOff pods, stuck deployments, security misconfigurations, and RBAC issues. Perfect for DevOps teams managing complex multi-cluster environments.
 
 **Installation:**
 \`\`\`bash
 brew tap kubestellar/tap
-brew install kubectl-claude
+brew install klaude
 \`\`\`
 
 Or install via Claude Code:
@@ -1074,7 +1074,7 @@ Free, open source, and built by the KubeStellar team.`,
       author: "KubeStellar Core Team",
       downloads: 42,
       rating: 4.9,
-      version: "1.0.0",
+      version: "0.6.0",
       features: [
         "Natural language Kubernetes queries",
         "Multi-cluster support via kubeconfig",
@@ -1094,8 +1094,8 @@ Free, open source, and built by the KubeStellar team.`,
       ],
       compatibility: ["Linux", "macOS", "Windows"],
       screenshots: [],
-      documentation: "https://kubestellar.io/docs/direct/claude-code",
-      github: "https://github.com/kubestellar/kubectl-claude",
+      documentation: "https://kubestellar.io/docs/klaude/overview/introduction",
+      github: "https://github.com/kubestellar/klaude",
       tags: ["claude", "ai", "kubectl", "multi-cluster", "diagnostics", "rbac", "free", "mcp"],
     },
   ];

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -16,7 +16,7 @@ function getProjectFromSlug(slug: string[]): ProjectId {
     if (slug[0] === 'a2a') return 'a2a'
     if (slug[0] === 'kubeflex') return 'kubeflex'
     if (slug[0] === 'multi-plugin') return 'multi-plugin'
-    if (slug[0] === 'kubectl-claude') return 'kubectl-claude'
+    if (slug[0] === 'klaude') return 'klaude'
   }
   return 'kubestellar'
 }
@@ -510,11 +510,11 @@ export async function generateStaticParams() {
     }
   }
 
-  // kubectl-claude routes (prefixed with 'kubectl-claude')
-  const kubectlClaudeMap = buildPageMap('kubectl-claude')
-  for (const route of Object.keys(kubectlClaudeMap.routeMap)) {
+  // klaude routes (prefixed with 'klaude')
+  const klaudeMap = buildPageMap('klaude')
+  for (const route of Object.keys(klaudeMap.routeMap)) {
     if (route !== '') {
-      allParams.push({ slug: ['kubectl-claude', ...route.split('/')] })
+      allParams.push({ slug: ['klaude', ...route.split('/')] })
     }
   }
 

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -16,8 +16,8 @@ export function getContentPath(projectId: ProjectId): string {
       return path.join(process.cwd(), 'docs', 'content', 'kubeflex')
     case 'multi-plugin':
       return path.join(process.cwd(), 'docs', 'content', 'multi-plugin')
-    case 'kubectl-claude':
-      return path.join(process.cwd(), 'docs', 'content', 'kubectl-claude')
+    case 'klaude':
+      return path.join(process.cwd(), 'docs', 'content', 'klaude')
     default:
       return docsContentPath
   }
@@ -32,8 +32,8 @@ export function getBasePath(projectId: ProjectId): string {
       return 'docs/kubeflex'
     case 'multi-plugin':
       return 'docs/multi-plugin'
-    case 'kubectl-claude':
-      return 'docs/kubectl-claude'
+    case 'klaude':
+      return 'docs/klaude'
     default:
       return 'docs'
   }
@@ -173,8 +173,8 @@ const NAV_STRUCTURE_KUBEFLEX: Array<{ title: string; items: NavItem[] }> = [
   }
 ]
 
-// kubectl-claude Navigation Structure
-const NAV_STRUCTURE_KUBECTL_CLAUDE: Array<{ title: string; items: NavItem[] }> = [
+// klaude Navigation Structure
+const NAV_STRUCTURE_KLAUDE: Array<{ title: string; items: NavItem[] }> = [
   {
     title: 'Overview',
     items: [
@@ -330,8 +330,8 @@ function getNavStructure(projectId: ProjectId): Array<{ title: string; items: Na
       return NAV_STRUCTURE_KUBEFLEX
     case 'multi-plugin':
       return NAV_STRUCTURE_MULTI_PLUGIN
-    case 'kubectl-claude':
-      return NAV_STRUCTURE_KUBECTL_CLAUDE
+    case 'klaude':
+      return NAV_STRUCTURE_KLAUDE
     default:
       return NAV_STRUCTURE
   }

--- a/src/components/docs/EditPageLink.tsx
+++ b/src/components/docs/EditPageLink.tsx
@@ -62,7 +62,7 @@ const SOURCE_REPOS: Record<string, { repo: string; docsPath: string }> = {
   a2a: { repo: 'kubestellar/a2a', docsPath: 'docs' },
   kubeflex: { repo: 'kubestellar/kubeflex', docsPath: 'docs' },
   'multi-plugin': { repo: 'kubestellar/kubectl-multi-plugin', docsPath: 'docs' },
-  'kubectl-claude': { repo: 'kubestellar/kubectl-claude', docsPath: 'docs' },
+  'klaude': { repo: 'kubestellar/klaude', docsPath: 'docs' },
 };
 
 // Build edit URL for a project, using correct branch
@@ -74,7 +74,7 @@ function buildEditBaseUrl(projectId: ProjectId, branch: string): string {
 
   // For other projects: version branches are in docs repo, main goes to source repo
   if (branch !== 'main' && branch.startsWith('docs/')) {
-    // Version branch in docs repo (e.g., docs/kubectl-claude/0.4.6)
+    // Version branch in docs repo (e.g., docs/klaude/0.6.0)
     return `https://github.com/kubestellar/docs/edit/${branch}/docs/content/${projectId}`;
   }
 

--- a/src/components/docs/RelatedProjects.tsx
+++ b/src/components/docs/RelatedProjects.tsx
@@ -12,7 +12,7 @@ const PRODUCTION_URL = 'https://kubestellar.io';
 // Static fallback for related projects
 const STATIC_RELATED_PROJECTS = [
   { title: 'KubeStellar', href: '/docs/what-is-kubestellar/overview', description: 'Multi-cluster configuration management' },
-  { title: 'kubectl-claude', href: '/docs/kubectl-claude/overview/introduction', description: 'AI-powered kubectl plugin' },
+  { title: 'klaude', href: '/docs/klaude/overview/introduction', description: 'AI-powered kubectl plugin' },
   { title: 'KubeFlex', href: '/docs/kubeflex/overview/introduction', description: 'Lightweight Kubernetes control planes' },
   { title: 'A2A', href: '/docs/a2a/overview/introduction', description: 'Agent-to-Agent protocol' },
   { title: 'Multi Plugin', href: '/docs/multi-plugin/overview/introduction', description: 'Multi-cluster kubectl plugin' },
@@ -103,7 +103,7 @@ export function RelatedProjects({ variant = 'full', onCollapse, isMobile = false
     if (pathname.startsWith('/docs/a2a')) return 'A2A';
     if (pathname.startsWith('/docs/kubeflex')) return 'KubeFlex';
     if (pathname.startsWith('/docs/multi-plugin')) return 'Multi Plugin';
-    if (pathname.startsWith('/docs/kubectl-claude')) return 'kubectl-claude';
+    if (pathname.startsWith('/docs/klaude')) return 'klaude';
     return 'KubeStellar';
   };
 

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -16,7 +16,7 @@ export const NETLIFY_SITE_NAME = "kubestellar-docs"
 export const PRODUCTION_URL = "https://kubestellar.io"
 
 // Project identifiers
-export type ProjectId = "kubestellar" | "a2a" | "kubeflex" | "multi-plugin" | "kubectl-claude"
+export type ProjectId = "kubestellar" | "a2a" | "kubeflex" | "multi-plugin" | "klaude"
 
 // Version info structure
 export interface VersionInfo {
@@ -183,12 +183,11 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
   },
 }
 
-// kubectl-claude versions
-// Note: Only latest/main for now - older versions don't have docs structure
-const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
+// klaude versions (formerly kubectl-claude)
+const KLAUDE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.5.0 (Latest)",
-    branch: "docs/kubectl-claude/0.5.0",
+    label: "v0.6.0 (Latest)",
+    branch: "docs/klaude/0.6.0",
     isDefault: true,
   },
   main: {
@@ -197,19 +196,9 @@ const KUBECTL_CLAUDE_VERSIONS: Record<string, VersionInfo> = {
     isDefault: false,
     isDev: true,
   },
-  "0.4.6": {
-    label: "v0.4.6",
-    branch: "docs/kubectl-claude/0.4.6",
-    isDefault: false,
-  },
-  "0.4.5": {
-    label: "v0.4.5",
-    branch: "docs/kubectl-claude/0.4.5",
-    isDefault: false,
-  },
-  "0.4.4": {
-    label: "v0.4.4",
-    branch: "docs/kubectl-claude/0.4.4",
+  "0.5.0": {
+    label: "v0.5.0",
+    branch: "docs/klaude/0.5.0",
     isDefault: false,
   },
 }
@@ -248,13 +237,13 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     contentPath: "docs/content/multi-plugin",
     versions: MULTI_PLUGIN_VERSIONS,
   },
-  "kubectl-claude": {
-    id: "kubectl-claude",
-    name: "kubectl-claude",
-    basePath: "kubectl-claude",
-    currentVersion: "0.4.3",
-    contentPath: "docs/content/kubectl-claude",
-    versions: KUBECTL_CLAUDE_VERSIONS,
+  "klaude": {
+    id: "klaude",
+    name: "klaude",
+    basePath: "klaude",
+    currentVersion: "0.6.0",
+    contentPath: "docs/content/klaude",
+    versions: KLAUDE_VERSIONS,
   },
 }
 
@@ -269,8 +258,8 @@ export function getProjectFromPath(pathname: string): ProjectConfig {
   if (pathname.startsWith("/docs/multi-plugin")) {
     return PROJECTS["multi-plugin"]
   }
-  if (pathname.startsWith("/docs/kubectl-claude") || pathname.startsWith("/docs/related-projects/kubectl-claude")) {
-    return PROJECTS["kubectl-claude"]
+  if (pathname.startsWith("/docs/klaude") || pathname.startsWith("/docs/related-projects/klaude")) {
+    return PROJECTS["klaude"]
   }
   return PROJECTS.kubestellar
 }


### PR DESCRIPTION
## Summary
- Rename docs folder from `kubectl-claude` to `klaude`
- Update all configuration references in versions.ts, page-map.ts, and routing
- Update Netlify redirects for claude.kubestellar.io to point to /docs/klaude
- Update marketplace plugin entry with new name and v0.6.0
- Update documentation content to use klaude branding

Part of the kubectl-claude → klaude rename initiative.

## Related
- kubestellar/klaude - Repository renamed and v0.6.0 released
- kubestellar/claude-plugins#1 - Plugin folder rename PR

## Test plan
- [ ] Verify docs site builds successfully
- [ ] Verify /docs/klaude routes work
- [ ] Verify version dropdown shows klaude with correct version
- [ ] Verify claude.kubestellar.io redirects to /docs/klaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)