### PR TITLE
✨ Add cache TTL to shared config and centralize survey URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -352,7 +352,7 @@
 
 [[redirects]]
   from = "/survey"
-  to = "https://forms.gle/WJ7N6ZVtp44D9NK79"
+  to = "https://forms.gle/Md2381TQ8CcjZv3LA"
   status = 301
   force = true
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -101,7 +101,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/survey",
-        destination: "https://forms.gle/WJ7N6ZVtp44D9NK79",
+        destination: "https://forms.gle/Md2381TQ8CcjZv3LA",
         permanent: true,
       },
       {

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -1,4 +1,5 @@
 {
+  "surveyUrl": "https://forms.gle/Md2381TQ8CcjZv3LA",
   "versions": {
     "kubestellar": {
       "latest": {

--- a/src/components/docs/DocsBanner.tsx
+++ b/src/components/docs/DocsBanner.tsx
@@ -3,13 +3,15 @@
 import Link from 'next/link'
 import { useTheme } from 'next-themes'
 import { useState, useEffect } from 'react'
-import { getLocalizedUrl } from '@/lib/url'
 import { useDocsMenu } from './DocsProvider'
+import { useSharedConfig, getSurveyUrl } from '@/hooks/useSharedConfig'
 
 export function DocsBanner() {
   const { resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
   const { bannerDismissed, dismissBanner } = useDocsMenu()
+  const { config } = useSharedConfig()
+  const surveyUrl = getSurveyUrl(config)
 
   useEffect(() => {
     setMounted(true)
@@ -27,17 +29,17 @@ export function DocsBanner() {
         <div className="flex items-center justify-between flex-wrap">
           <div className="flex-1 flex items-center justify-center">
             <span className={`${isDark ? 'text-gray-200' : 'text-gray-800'} text-xs md:text-sm`}>
-              🚀 🚀 🚀 ATTENTION: KubeStellar needs your help - please take our 2-minute survey{' '}
-              <Link 
-                href={getLocalizedUrl("https://kubestellar.io/survey")}
-                target="_blank" 
+              🚀 🚀 🚀 ATTENTION: Help us improve multi-cluster Kubernetes - take our 2-minute survey{' '}
+              <Link
+                href={surveyUrl}
+                target="_blank"
                 rel="noopener noreferrer"
-                className={isDark 
+                className={isDark
                   ? 'text-blue-400 underline hover:text-blue-300 transition-colors font-medium'
                   : 'text-blue-600 underline hover:text-blue-700 transition-colors font-medium'
                 }
               >
-                {getLocalizedUrl("https://kubestellar.io/survey")}
+                here
               </Link>
               {' '}🚀 🚀 🚀
             </span>

--- a/src/components/docs/RelatedProjects.tsx
+++ b/src/components/docs/RelatedProjects.tsx
@@ -9,13 +9,11 @@ import { useSharedConfig } from '@/hooks/useSharedConfig';
 // Production URL - all cross-project links go here
 const PRODUCTION_URL = 'https://kubestellar.io';
 
-// Static fallback for related projects
+// Generic fallback for related projects - uses safe URLs that won't break
+// The actual project list is fetched from production config
 const STATIC_RELATED_PROJECTS = [
-  { title: 'KubeStellar', href: '/docs/what-is-kubestellar/overview', description: 'Multi-cluster configuration management' },
-  { title: 'klaude', href: '/docs/klaude/overview/introduction', description: 'AI-powered kubectl plugin' },
-  { title: 'KubeFlex', href: '/docs/kubeflex/overview/introduction', description: 'Lightweight Kubernetes control planes' },
-  { title: 'A2A', href: '/docs/a2a/overview/introduction', description: 'Agent-to-Agent protocol' },
-  { title: 'Multi Plugin', href: '/docs/multi-plugin/overview/introduction', description: 'Multi-cluster kubectl plugin' },
+  { title: 'KubeStellar', href: '/docs', description: 'Multi-cluster management' },
+  { title: 'Loading projects...', href: '/docs', description: 'Fetching from config' },
 ];
 
 interface RelatedProjectsProps {


### PR DESCRIPTION
## Summary

- Add 5-minute cache TTL to shared config so changes propagate automatically
- Centralize survey URL in shared.json (no more hardcoded URLs in components)
- Update to new multi-cluster ops survey: https://forms.gle/Md2381TQ8CcjZv3LA

## Problem

When kubectl-claude URL changed to klaude, all branches across all projects needed redeployment because:
1. Module-level caching in `useSharedConfig.ts` never expired
2. `public/config/shared.json` was baked into build artifacts
3. Hardcoded fallbacks in components had stale URLs

## Solution

1. **Cache TTL**: Added 5-minute expiration to `useSharedConfig.ts`
2. **Survey URL**: Added `surveyUrl` to `shared.json`, updated `DocsBanner.tsx` to use it
3. **Generic fallback**: Made `RelatedProjects.tsx` fallback use safe `/docs` URLs
4. **Redirect update**: Updated survey redirect in `next.config.ts` and `netlify.toml`

## Files Changed

| File | Change |
|------|--------|
| `src/hooks/useSharedConfig.ts` | Add cache TTL, surveyUrl type, getSurveyUrl() |
| `public/config/shared.json` | Add surveyUrl field |
| `src/components/docs/DocsBanner.tsx` | Use surveyUrl from config |
| `src/components/docs/RelatedProjects.tsx` | Generic fallback |
| `next.config.ts` | Update survey redirect |
| `netlify.toml` | Update survey redirect |

## Impact

After deploying this to all branches once:
- Future config changes auto-propagate within 5 minutes
- No more mass redeployments for config updates

## Test plan

- [ ] Build succeeds
- [ ] Banner shows and links to new survey
- [ ] Related projects load from config
- [ ] `/survey` redirect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)