### PR TITLE
🐛 Include repo name in scan-merged-prs issue titles

### DIFF
--- a/.github/workflows/scan-merged-prs.lock.yml
+++ b/.github/workflows/scan-merged-prs.lock.yml
@@ -2066,10 +2066,12 @@ jobs:
           For each merged PR, create an issue in `kubestellar/docs` with:
           
           **Title Format:**
-          
+
           ```
-          [Doc Update] <Original PR Title>
+          [Doc Update] [<repo-short-name>] <Original PR Title>
           ```
+
+          Where `<repo-short-name>` is the repository name without the org prefix (e.g., `kubectl-multi-plugin` not `kubestellar/kubectl-multi-plugin`).
           
           **Issue Body:**
           


### PR DESCRIPTION
## Summary

- Update issue title format to include the source repository name
- Makes issue titles distinguishable when multiple repos have PRs with the same title

## Changes

Title format changed from:
```
[Doc Update] <Original PR Title>
```

To:
```
[Doc Update] [<repo-short-name>] <Original PR Title>
```

Example: `[Doc Update] [kubectl-multi-plugin] 🌱 Add docs release automation trigger`

## Test plan

- [ ] Wait for next scan-merged-prs run
- [ ] Verify new issues include repo name in title

Fixes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)