### PR TITLE
🐛 Fix Console navigation highlighting in Related Projects

### DIFF
--- a/src/components/docs/RelatedProjects.tsx
+++ b/src/components/docs/RelatedProjects.tsx
@@ -102,6 +102,7 @@ export function RelatedProjects({ variant = 'full', onCollapse, isMobile = false
     if (pathname.startsWith('/docs/kubeflex')) return 'KubeFlex';
     if (pathname.startsWith('/docs/multi-plugin')) return 'Multi Plugin';
     if (pathname.startsWith('/docs/klaude')) return 'klaude';
+    if (pathname.startsWith('/docs/console')) return 'Console';
     return 'KubeStellar';
   };
 


### PR DESCRIPTION
## Summary
Fix Console not being highlighted in the Related Projects sidebar when viewing console docs.

The `getCurrentProject()` function was missing a check for `/docs/console`, causing it to fall through to the default `KubeStellar`.

## Changes
- Add `if (pathname.startsWith('/docs/console')) return 'Console';` to `getCurrentProject()`

## Test plan
- [x] Navigate to /docs/console/readme
- [x] Verify Console is highlighted in Related Projects (not KubeStellar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)