### PR TITLE
📖 : fix Homebrew install command for kubectl-claude

### DIFF
--- a/docs/content/direct/claude-code.md
+++ b/docs/content/direct/claude-code.md
@@ -18,8 +18,11 @@ klaude is an AI-powered kubectl plugin designed for **managing multiple clusters
 
 ```bash
 brew tap kubestellar/tap
-brew install klaude
+brew install kubectl-claude
 ```
+```md
+> The Homebrew formula is published automatically during releases using GoReleaser.
+> This installs the `kubectl-claude` kubectl plugin.
 
 ### Option 2: Claude Code Plugin Marketplace
 


### PR DESCRIPTION
What changed

Updated the Homebrew installation instructions for klaude to use the correct
formula name: kubectl-claude.

This aligns the documentation with the Homebrew publishing setup introduced via
GoReleaser in kubestellar/kubectl-claude#3.

Why this change is needed

The previous command (brew install klaude) does not match the actual Homebrew
formula name.

Users installing via Homebrew would fail without this correction.

Scope

Documentation-only change.

Affects the Claude Code / klaude installation page.

fixes #688 
