### PR TITLE
🐛 Replace hardcoded footer year with dynamic current year

### DIFF
--- a/src/components/docs/DocsFooter.tsx
+++ b/src/components/docs/DocsFooter.tsx
@@ -474,7 +474,7 @@ export default function Footer() {
             <p className={`text-xs sm:text-sm text-center md:text-left order-2 md:order-1 ${
               isDark ? 'text-gray-400' : 'text-gray-600'
             }`}>
-              © 2025 KubeStellar. All rights reserved. Apache 2.0 Licence
+              © {new Date().getFullYear()} KubeStellar. All rights reserved. Apache 2.0 Licence
             </p>
 
             {/* Right side - policy links */}


### PR DESCRIPTION
### 📌 Fixes

Fixes #816  

---

### 📝 Summary of Changes

- Replaced hardcoded footer year (`© 2025`) with a dynamic current year using `new Date().getFullYear()`.
- Ensures the footer stays up-to-date automatically every year.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Fixed footer copyright year to use dynamic current year
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)



---

### 👀 Reviewer Notes

This is a small UI maintenance fix to prevent the footer year from becoming outdated each year.