### PR TITLE
🐛 Fix edit pencil not showing for Console docs on main branch

### DIFF
--- a/src/components/docs/EditPageLink.tsx
+++ b/src/components/docs/EditPageLink.tsx
@@ -58,6 +58,7 @@ function detectCurrentBranch(versions: VersionEntry[]): string {
 }
 
 // Source repos for each project (used when on main branch)
+// Projects not listed here have their docs in the docs repo itself
 const SOURCE_REPOS: Record<string, { repo: string; docsPath: string }> = {
   a2a: { repo: 'kubestellar/a2a', docsPath: 'docs' },
   kubeflex: { repo: 'kubestellar/kubeflex', docsPath: 'docs' },
@@ -65,11 +66,19 @@ const SOURCE_REPOS: Record<string, { repo: string; docsPath: string }> = {
   'klaude': { repo: 'kubestellar/klaude', docsPath: 'docs' },
 };
 
+// Projects whose docs live in the docs repo itself (not a separate source repo)
+const DOCS_REPO_PROJECTS = ['console'];
+
 // Build edit URL for a project, using correct branch
 function buildEditBaseUrl(projectId: ProjectId, branch: string): string {
   // KubeStellar docs always live in docs repo
   if (projectId === 'kubestellar') {
     return `https://github.com/kubestellar/docs/edit/${branch}/docs/content`;
+  }
+
+  // Projects whose docs live in the docs repo itself (e.g., console)
+  if (DOCS_REPO_PROJECTS.includes(projectId)) {
+    return `https://github.com/kubestellar/docs/edit/${branch}/docs/content/${projectId}`;
   }
 
   // For other projects: version branches are in docs repo, main goes to source repo


### PR DESCRIPTION
## Summary
- Fix edit pencil icon not appearing for Console documentation pages when viewing the main branch
- Add `DOCS_REPO_PROJECTS` array to handle projects whose docs live in the docs repo itself (not a separate source repo)
- Console was the only affected project - other projects (a2a, kubeflex, multi-plugin, klaude) work correctly because they have entries in `SOURCE_REPOS`

## Root Cause
Console documentation lives in the docs repo itself (unlike other projects like klaude that have separate source repos). The `buildEditBaseUrl` function was returning an empty string for console on main branch because it wasn't in `SOURCE_REPOS` and had no special handling.

## Test plan
- [ ] Verify edit pencil appears on Console docs when viewing main branch
- [ ] Verify edit pencil still works on version branches (e.g., docs/console/0.1.0)
- [ ] Verify other projects (klaude, a2a, kubeflex, multi-plugin) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)