### PR TITLE
📖 Docs: fix Markdown rendering in Claude Code Integration page

### DIFF
--- a/docs/content/direct/claude-code.md
+++ b/docs/content/direct/claude-code.md
@@ -20,7 +20,7 @@ klaude is an AI-powered kubectl plugin designed for **managing multiple clusters
 brew tap kubestellar/tap
 brew install kubectl-claude
 ```
-```md
+
 > The Homebrew formula is published automatically during releases using GoReleaser.
 > This installs the `kubectl-claude` kubectl plugin.
 


### PR DESCRIPTION
Fixes #835

Summary of Changes

This PR fixes a Markdown formatting issue in the Claude Code Integration documentation where an unclosed fenced code block caused incorrect rendering of subsequent content.

Reference:
•https://github.com/kubestellar/docs/blob/main/docs/content/direct/claude-code.md

Changes Made
	•	Fixed an unclosed fenced code block in the Homebrew installation section
	•	Ensured explanatory text renders as normal Markdown instead of being treated as code

