### PR TITLE
🐛 Make homepage footer year dynamic across all locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -58,7 +58,7 @@
     "subscribe": "Abonnieren",
     "subscribed": "Abonniert!",
     "privacyNotice": "Wir respektieren Ihre Privatsphäre. Kein Spam.",
-    "copyright": "© 2025 KubeStellar. Alle Rechte vorbehalten. Apache-2.0-Lizenz",
+    "copyright": "© {year} KubeStellar. Alle Rechte vorbehalten. Apache-2.0-Lizenz",
     "privacyPolicy": "Datenschutzrichtlinie",
     "termsOfService": "Nutzungsbedingungen",
     "cookiePolicy": "Cookie-Richtlinie",

--- a/messages/en.json
+++ b/messages/en.json
@@ -64,7 +64,7 @@
     "subscribe": "Subscribe",
     "subscribed": "Subscribed!",
     "privacyNotice": "We respect your privacy. No spam.",
-    "copyright": "© 2025 KubeStellar. All rights reserved. Apache 2.0 Licence",
+    "copyright": "© {year} KubeStellar. All rights reserved. Apache 2.0 Licence",
     "privacyPolicy": "Privacy Policy",
     "termsOfService": "Terms of Service",
     "cookiePolicy": "Cookie Policy",

--- a/messages/es.json
+++ b/messages/es.json
@@ -97,7 +97,7 @@
     "subscribe": "Suscribirse",
     "subscribed": "¡Suscrito!",
     "privacyNotice": "Respetamos tu privacidad. Sin spam.",
-    "copyright": "© 2025 KubeStellar. Todos los derechos reservados. Licencia Apache 2.0",
+    "copyright": "© {year} KubeStellar. Todos los derechos reservados. Licencia Apache 2.0",
     "privacyPolicy": "Política de privacidad",
     "termsOfService": "Términos del servicio",
     "cookiePolicy": "Política de cookies",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -58,7 +58,7 @@
     "subscribe": "S'abonner",
     "subscribed": "Abonné !",
     "privacyNotice": "Nous respectons votre vie privée. Pas de spam.",
-    "copyright": "© 2025 KubeStellar. Tous droits réservés. Licence Apache 2.0",
+    "copyright": "© {year} KubeStellar. Tous droits réservés. Licence Apache 2.0",
     "privacyPolicy": "Politique de Confidentialité",
     "termsOfService": "Conditions de Service",
     "cookiePolicy": "Politique des Cookies",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -58,7 +58,7 @@
     "subscribe": "सब्सक्राइब करें",
     "subscribed": "सब्सक्राइब हो गया!",
     "privacyNotice": "हम आपकी गोपनीयता का सम्मान करते हैं। कोई स्पैम नहीं।",
-    "copyright": "© 2025 KubeStellar। सर्वाधिकार सुरक्षित। Apache 2.0 लाइसेंस",
+    "copyright": "© {year} KubeStellar। सर्वाधिकार सुरक्षित। Apache 2.0 लाइसेंस",
     "privacyPolicy": "गोपनीयता नीति",
     "termsOfService": "सेवा की शर्तें",
     "cookiePolicy": "कुकी नीति",

--- a/messages/it.json
+++ b/messages/it.json
@@ -64,7 +64,7 @@
     "subscribe": "Iscriviti",
     "subscribed": "Iscritto!",
     "privacyNotice": "Rispettiamo la tua privacy. Niente spam.",
-    "copyright": "© 2025 KubeStellar. Tutti i diritti riservati. Licenza Apache 2.0",
+    "copyright": "© {year} KubeStellar. Tutti i diritti riservati. Licenza Apache 2.0",
     "privacyPolicy": "Informativa sulla privacy",
     "termsOfService": "Termini di servizio",
     "cookiePolicy": "Cookie policy",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -64,7 +64,7 @@
     "subscribe": "購読する",
     "subscribed": "購読しました！",
     "privacyNotice": "お客様のプライバシーを尊重します。スパムは送信しません。",
-    "copyright": "© 2025 KubeStellar. All rights reserved. Apache 2.0 ライセンス",
+    "copyright": "© {year} KubeStellar. All rights reserved. Apache 2.0 ライセンス",
     "privacyPolicy": "プライバシーポリシー",
     "termsOfService": "利用規約",
     "cookiePolicy": "Cookie ポリシー",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -58,7 +58,7 @@
     "subscribe": "Inscrever-se",
     "subscribed": "Inscrito!",
     "privacyNotice": "Respeitamos sua privacidade. Sem spam.",
-    "copyright": "© 2025 KubeStellar. Todos os direitos reservados. Licença Apache 2.0",
+    "copyright": "© {year} KubeStellar. Todos os direitos reservados. Licença Apache 2.0",
     "privacyPolicy": "Política de Privacidade",
     "termsOfService": "Termos de Serviço",
     "cookiePolicy": "Política de Cookies",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -58,7 +58,7 @@
     "subscribe": "订阅",
     "subscribed": "订阅成功！",
     "privacyNotice": "我们尊重您的隐私，不会发送垃圾邮件。",
-    "copyright": "© 2025 KubeStellar。保留所有权利。Apache 2.0 许可证",
+    "copyright": "© {year} KubeStellar。保留所有权利。Apache 2.0 许可证",
     "privacyPolicy": "隐私政策",
     "termsOfService": "服务条款",
     "cookiePolicy": "Cookie 政策",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -58,7 +58,7 @@
     "subscribe": "訂閱",
     "subscribed": "已訂閱！",
     "privacyNotice": "我們尊重您的隱私。不會發送垃圾郵件。",
-    "copyright": "© 2025 KubeStellar。保留所有權利。Apache 2.0 授權",
+    "copyright": "© {year} KubeStellar。保留所有權利。Apache 2.0 授權",
     "privacyPolicy": "隱私權政策",
     "termsOfService": "服務條款",
     "cookiePolicy": "Cookie 政策",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -338,7 +338,7 @@ export default function Footer() {
           <div className="flex flex-col md:flex-row justify-between items-center gap-3 sm:gap-4">
             {/* Left side - copyright */}
             <p className="text-gray-400 text-xs sm:text-sm text-center md:text-left order-2 md:order-1">
-              {t("copyright")}
+              {t("copyright", { year: new Date().getFullYear() })}
             </p>
 
             {/* Right side - policy links */}


### PR DESCRIPTION
### 📌 Fixes

Fixes #837 

---

### 📝 Summary of Changes

- Made footer year dynamic using `new Date().getFullYear()` instead of hardcoding `2025`.
- Updated locale JSON files to remove the hardcoded year so all languages stay correct automatically.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
