### PR TITLE
📖 Update repo URLs: kubestellar/klaude → kubestellar/kubestellar-mcp

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -280,7 +280,7 @@
     "a2a": "https://github.com/kubestellar/a2a/edit/main/docs",
     "kubeflex": "https://github.com/kubestellar/kubeflex/edit/main/docs",
     "multi-plugin": "https://github.com/kubestellar/kubectl-multi-plugin/edit/main/docs",
-    "kubestellar-mcp": "https://github.com/kubestellar/klaude/edit/main/docs",
+    "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs",
     "console": "https://github.com/kubestellar/docs/edit/main/docs/content/console"
   },
   "updatedAt": "2026-01-16T18:24:27.434Z"

--- a/src/app/[locale]/marketplace/plugins.tsx
+++ b/src/app/[locale]/marketplace/plugins.tsx
@@ -1095,7 +1095,7 @@ Free, open source, and built by the KubeStellar team.`,
       compatibility: ["Linux", "macOS", "Windows"],
       screenshots: [],
       documentation: "https://kubestellar.io/docs/kubestellar-mcp/overview/introduction",
-      github: "https://github.com/kubestellar/klaude",
+      github: "https://github.com/kubestellar/kubestellar-mcp",
       tags: ["claude", "ai", "kubectl", "multi-cluster", "diagnostics", "rbac", "free", "mcp"],
     },
   ];

--- a/src/components/docs/EditPageLink.tsx
+++ b/src/components/docs/EditPageLink.tsx
@@ -63,7 +63,7 @@ const SOURCE_REPOS: Record<string, { repo: string; docsPath: string }> = {
   a2a: { repo: 'kubestellar/a2a', docsPath: 'docs' },
   kubeflex: { repo: 'kubestellar/kubeflex', docsPath: 'docs' },
   'multi-plugin': { repo: 'kubestellar/kubectl-multi-plugin', docsPath: 'docs' },
-  'kubestellar-mcp': { repo: 'kubestellar/klaude', docsPath: 'docs' },
+  'kubestellar-mcp': { repo: 'kubestellar/kubestellar-mcp', docsPath: 'docs' },
 };
 
 // Projects whose docs live in the docs repo itself (not a separate source repo)


### PR DESCRIPTION
## Summary

The GitHub repository `kubestellar/klaude` has been renamed to `kubestellar/kubestellar-mcp`. This PR updates the three remaining references to the old repo name:

- **`public/config/shared.json`** — Edit base URL for kubestellar-mcp docs
- **`src/components/docs/EditPageLink.tsx`** — Source repo mapping used for "Edit this page" links
- **`src/app/[locale]/marketplace/plugins.tsx`** — GitHub link in the marketplace plugin listing

### Not changed (intentionally)

- Git branch names like `docs/klaude/0.8.1` are immutable historical references and must not be changed
- The backward-compat redirect in `netlify.toml` (`/docs/klaude/*` → `/docs/kubestellar-mcp/*`) is correct as-is

## Test plan

- [ ] Verify "Edit this page" links on kubestellar-mcp docs point to `github.com/kubestellar/kubestellar-mcp`
- [ ] Verify the marketplace plugin page GitHub link resolves correctly
- [ ] Confirm no broken links from the shared config edit base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)