### PR TITLE
⚠️ Rename: Fix missed klaude-console doc files

### DIFF
--- a/docs/content/console/console-cards.md
+++ b/docs/content/console/console-cards.md
@@ -3,12 +3,12 @@ title: "Card Reference"
 linkTitle: "Cards"
 weight: 3
 description: >
-  Complete reference of all dashboard cards available in the Klaude Console
+  Complete reference of all dashboard cards available in the KubeStellar Console
 ---
 
 # Card Reference
 
-The Klaude Console includes over 100 dashboard cards organized into categories. Cards can display live data from your clusters or demo data for evaluation.
+The KubeStellar Console includes over 100 dashboard cards organized into categories. Cards can display live data from your clusters or demo data for evaluation.
 
 ![Card Catalog](images/card-catalog.png)
 
@@ -127,13 +127,13 @@ The Klaude Console includes over 100 dashboard cards organized into categories. 
 | Resource Trend | CPU, memory, pods, nodes over time | Live |
 | GPU Utilization | GPU allocation trend | Live |
 
-### Klaude AI (3 cards)
+### AI (3 cards)
 
 | Card | Description | Data Source |
 |------|-------------|-------------|
-| Klaude Issues | AI-powered issue detection | Live |
-| Klaude Kubeconfig Audit | Audit kubeconfig for stale contexts | Live |
-| Klaude Health Check | Comprehensive AI health analysis | Live |
+| AI Issues | AI-powered issue detection | Live |
+| AI Kubeconfig Audit | Audit kubeconfig for stale contexts | Live |
+| AI Health Check | Comprehensive AI health analysis | Live |
 
 ### Alerting (2 cards)
 

--- a/docs/content/console/console-features.md
+++ b/docs/content/console/console-features.md
@@ -3,12 +3,12 @@ title: "Console Features"
 linkTitle: "Features"
 weight: 2
 description: >
-  Detailed guide to KubeStellar Klaude Console features
+  Detailed guide to KubeStellar Console features
 ---
 
-# Klaude Console Features
+# KubeStellar Console Features
 
-This guide covers the main features of the KubeStellar Klaude Console.
+This guide covers the main features of the KubeStellar Console.
 
 ## Dashboard
 

--- a/docs/content/console/console-overview.md
+++ b/docs/content/console/console-overview.md
@@ -3,12 +3,12 @@ title: "Console Overview"
 linkTitle: "Overview"
 weight: 1
 description: >
-  Overview of the KubeStellar Klaude Console features and capabilities
+  Overview of the KubeStellar Console features and capabilities
 ---
 
-# KubeStellar Klaude Console
+# KubeStellar Console
 
-The KubeStellar Klaude Console is a modern, AI-powered multi-cluster management interface that provides real-time monitoring, intelligent insights, and a customizable dashboard experience for managing Kubernetes clusters at scale.
+The KubeStellar Console is a modern, AI-powered multi-cluster management interface that provides real-time monitoring, intelligent insights, and a customizable dashboard experience for managing Kubernetes clusters at scale.
 
 ![Dashboard Overview](images/dashboard-overview.png)
 
@@ -46,7 +46,7 @@ The KubeStellar Klaude Console is a modern, AI-powered multi-cluster management 
 
 ### Demo Mode
 
-The Klaude Console includes a demo mode that showcases all features with simulated data. To run in demo mode:
+The KubeStellar Console includes a demo mode that showcases all features with simulated data. To run in demo mode:
 
 ```bash
 cd web
@@ -59,25 +59,25 @@ Navigate to `http://localhost:5174` to explore the console with demo data.
 
 For production use, the console requires:
 
-1. **KKC Agent**: A local agent that connects to your kubeconfig
-2. **Backend API**: The KKC API server running on port 8080
+1. **KSC Agent**: A local agent that connects to your kubeconfig
+2. **Backend API**: The KSC API server running on port 8080
 
 See the [installation guide](installation.md) for detailed setup instructions.
 
 ## Architecture
 
-The Klaude Console consists of:
+The KubeStellar Console consists of:
 
 - **Frontend**: React + TypeScript + Vite application
-- **KKC Agent**: Go-based agent that interfaces with Kubernetes clusters
+- **KSC Agent**: Go-based agent that interfaces with Kubernetes clusters
 - **Backend API**: REST API for data aggregation and AI features
 
 ## Documentation
 
-- [Features Guide](klaude-console-features.md) - Detailed feature documentation
-- [Card Reference](klaude-console-cards.md) - Complete list of available cards
-- [Rewards System](klaude-console-rewards.md) - Community engagement and rewards
-- [Updates](klaude-console-updates.md) - Release channels and version management
+- [Features Guide](console-features.md) - Detailed feature documentation
+- [Card Reference](console-cards.md) - Complete list of available cards
+- [Rewards System](console-rewards.md) - Community engagement and rewards
+- [Updates](console-updates.md) - Release channels and version management
 
 ## Community
 

--- a/docs/content/console/console-rewards.md
+++ b/docs/content/console/console-rewards.md
@@ -3,12 +3,12 @@ title: "Rewards System"
 linkTitle: "Rewards"
 weight: 4
 description: >
-  Community engagement and rewards system in the Klaude Console
+  Community engagement and rewards system in the KubeStellar Console
 ---
 
 # Rewards System
 
-The KubeStellar Klaude Console includes a community rewards system to encourage engagement and contributions.
+The KubeStellar Console includes a community rewards system to encourage engagement and contributions.
 
 ![Rewards Panel](images/rewards-panel.png)
 

--- a/docs/content/console/console-updates.md
+++ b/docs/content/console/console-updates.md
@@ -3,12 +3,12 @@ title: "Updates and Releases"
 linkTitle: "Updates"
 weight: 5
 description: >
-  Release channels and version management for the Klaude Console
+  Release channels and version management for the KubeStellar Console
 ---
 
 # Updates and Releases
 
-The KubeStellar Klaude Console follows a regular release schedule with two update channels.
+The KubeStellar Console follows a regular release schedule with two update channels.
 
 ## Release Channels
 


### PR DESCRIPTION
## Summary

- Rename five `klaude-console-*.md` files that were missed in the earlier rename pass:
  - `klaude-console-overview.md` → `console-overview.md`
  - `klaude-console-features.md` → `console-features.md`
  - `klaude-console-cards.md` → `console-cards.md`
  - `klaude-console-rewards.md` → `console-rewards.md`
  - `klaude-console-updates.md` → `console-updates.md`
- Update all internal references: "KubeStellar Klaude Console" → "KubeStellar Console", "Klaude Console" → "KubeStellar Console", "Klaude AI/Issues/Health Check/Kubeconfig Audit" → "AI ...", "KKC Agent/API" → "KSC Agent/API"
- Fix all internal doc links pointing to old filenames

## Test plan

- [ ] Verify renamed files render correctly in the docs site
- [ ] Confirm all internal links resolve (no broken `klaude-console-*.md` references)
- [ ] Grep for any remaining `klaude` references in `docs/content/console/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)