### PR TITLE
🌱 Update domain redirect to mcp.kubestellar.io

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -213,28 +213,28 @@
   status = 301
   force = true
 
-# Redirect klaude.kubestellar.io to kubestellar.io/docs/kubestellar-mcp
+# Redirect mcp.kubestellar.io to kubestellar.io/docs/kubestellar-mcp
 # Handle old URL structure with /en/ prefix
 [[redirects]]
-  from = "https://klaude.kubestellar.io/en/*"
+  from = "https://mcp.kubestellar.io/en/*"
   to = "https://kubestellar.io/docs/kubestellar-mcp/:splat"
   status = 301
   force = true
 
 [[redirects]]
-  from = "https://klaude.kubestellar.io/en"
+  from = "https://mcp.kubestellar.io/en"
   to = "https://kubestellar.io/docs/kubestellar-mcp/overview/introduction"
   status = 301
   force = true
 
 [[redirects]]
-  from = "https://klaude.kubestellar.io/*"
+  from = "https://mcp.kubestellar.io/*"
   to = "https://kubestellar.io/docs/kubestellar-mcp/:splat"
   status = 301
   force = true
 
 [[redirects]]
-  from = "https://klaude.kubestellar.io"
+  from = "https://mcp.kubestellar.io"
   to = "https://kubestellar.io/docs/kubestellar-mcp/overview/introduction"
   status = 301
   force = true

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -183,7 +183,7 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
   },
 }
 
-// kubestellar-mcp versions (formerly klaude/kubectl-claude)
+// kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
     label: "v0.8.1 (Latest)",


### PR DESCRIPTION
## Summary
- Replace `klaude.kubestellar.io` → `mcp.kubestellar.io` in all netlify redirect rules
- Remove historical "formerly klaude" comment from `versions.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)