### PR TITLE
⚠️ Remove old klaude version branches and redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -280,16 +280,6 @@
   to = "/docs/kubestellar-mcp/overview/introduction"
   status = 302
 
-# Backwards-compat redirects: /docs/klaude/* -> /docs/kubestellar-mcp/*
-[[redirects]]
-  from = "/docs/klaude/*"
-  to = "/docs/kubestellar-mcp/:splat"
-  status = 301
-
-[[redirects]]
-  from = "/docs/klaude"
-  to = "/docs/kubestellar-mcp/overview/introduction"
-  status = 301
 
 [[redirects]]
   from = "/agenda"

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -155,7 +155,7 @@
     "kubestellar-mcp": {
       "latest": {
         "label": "v0.8.1 (Latest)",
-        "branch": "docs/klaude/0.8.1",
+        "branch": "docs/kubestellar-mcp/0.8.1",
         "isDefault": true
       },
       "main": {
@@ -163,51 +163,6 @@
         "branch": "main",
         "isDefault": false,
         "isDev": true
-      },
-      "0.7.1": {
-        "label": "v0.7.1",
-        "branch": "docs/klaude/0.7.1",
-        "isDefault": false
-      },
-      "0.6.0": {
-        "label": "v0.6.0",
-        "branch": "docs/klaude/0.6.0",
-        "isDefault": false
-      },
-      "0.5.0": {
-        "label": "v0.5.0",
-        "branch": "docs/klaude/0.5.0",
-        "isDefault": false
-      },
-      "0.4.6": {
-        "label": "v0.4.6",
-        "branch": "docs/klaude/0.4.6",
-        "isDefault": false
-      },
-      "0.4.5": {
-        "label": "v0.4.5",
-        "branch": "docs/klaude/0.4.5",
-        "isDefault": false
-      },
-      "0.4.4": {
-        "label": "v0.4.4",
-        "branch": "docs/klaude/0.4.4",
-        "isDefault": false
-      },
-      "0.4.3": {
-        "label": "v0.4.3",
-        "branch": "docs/klaude/0.4.3",
-        "isDefault": false
-      },
-      "0.4.0": {
-        "label": "v0.4.0",
-        "branch": "docs/klaude/0.4.0",
-        "isDefault": false
-      },
-      "0.8.0": {
-        "label": "v0.8.0",
-        "branch": "docs/klaude/0.8.0",
-        "isDefault": false
       }
     }
   },

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -187,7 +187,7 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
     label: "v0.8.1 (Latest)",
-    branch: "docs/klaude/0.8.1",
+    branch: "docs/kubestellar-mcp/0.8.1",
     isDefault: true,
   },
   main: {
@@ -195,46 +195,6 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
-  },
-  "0.7.1": {
-    label: "v0.7.1",
-    branch: "docs/klaude/0.7.1",
-    isDefault: false,
-  },
-  "0.6.0": {
-    label: "v0.6.0",
-    branch: "docs/klaude/0.6.0",
-    isDefault: false,
-  },
-  "0.5.0": {
-    label: "v0.5.0",
-    branch: "docs/klaude/0.5.0",
-    isDefault: false,
-  },
-  "0.4.6": {
-    label: "v0.4.6",
-    branch: "docs/klaude/0.4.6",
-    isDefault: false,
-  },
-  "0.4.5": {
-    label: "v0.4.5",
-    branch: "docs/klaude/0.4.5",
-    isDefault: false,
-  },
-  "0.4.4": {
-    label: "v0.4.4",
-    branch: "docs/klaude/0.4.4",
-    isDefault: false,
-  },
-  "0.4.3": {
-    label: "v0.4.3",
-    branch: "docs/klaude/0.4.3",
-    isDefault: false,
-  },
-  "0.4.0": {
-    label: "v0.4.0",
-    branch: "docs/klaude/0.4.0",
-    isDefault: false,
   },
 }
 


### PR DESCRIPTION
## Summary
- Latest branch renamed: `docs/klaude/0.8.1` → `docs/kubestellar-mcp/0.8.1`
- Removed all old version entries (0.4.0 through 0.8.0) — only latest + main remain
- Removed backwards-compat `/docs/klaude/*` redirects from netlify.toml
- All 11 `docs/klaude/*` branches deleted from remote

## Result
Zero remaining "klaude" references in the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)