### PR TITLE
🐛fix: improve dark mode hover visibility in Related Projects sidebar

### DIFF
--- a/src/components/docs/RelatedProjects.tsx
+++ b/src/components/docs/RelatedProjects.tsx
@@ -153,6 +153,25 @@ export function RelatedProjects({ variant = 'full', onCollapse, isMobile = false
           const isCurrentProject = project.title === currentProject;
           const projectUrl = getProjectUrl(project.href);
 
+          if (isCurrentProject) {
+            return (
+              <a
+                key={project.title}
+                href={projectUrl}
+                className={`
+                  block px-3 text-sm rounded-md transition-colors font-medium
+                  ${bannerActive ? 'py-0.5' : 'py-1.5'}
+                `}
+                style={{
+                  color: isDark ? '#60a5fa' : '#2563eb',
+                  backgroundColor: isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(239, 246, 255, 1)'
+                }}
+              >
+                {project.title}
+              </a>
+            );
+          }
+
           return (
             <a
               key={project.title}
@@ -160,19 +179,11 @@ export function RelatedProjects({ variant = 'full', onCollapse, isMobile = false
               className={`
                 block px-3 text-sm rounded-md transition-colors
                 ${bannerActive ? 'py-0.5' : 'py-1.5'}
-                ${isCurrentProject
-                  ? 'font-medium'
-                  : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                ${isDark 
+                  ? 'text-gray-200 hover:bg-blue-500/20 hover:text-blue-400' 
+                  : 'text-gray-700 hover:bg-blue-50 hover:text-blue-600'
                 }
               `}
-              style={{
-                color: isCurrentProject
-                  ? (isDark ? '#60a5fa' : '#2563eb')  // blue-400 : blue-600
-                  : textColor,
-                backgroundColor: isCurrentProject
-                  ? (isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(239, 246, 255, 1)')  // blue-500/20 : blue-50
-                  : undefined
-              }}
             >
               {project.title}
             </a>


### PR DESCRIPTION
### 📌 Fixes

Fixes #918 

---

### 📝 Summary of Changes
In dark mode, hovering over project links in the Related Projects sidebar was barely visible. The `hover:bg-gray-800` background didn't provide enough contrast, making it hard to see which item was being hovered.

- Separated current/active project into its own rendering block with dedicated styling
- Replaced inline styles with Tailwind classes for proper hover states
- Added blue-tinted hover effects that are visible in both themes:
  - **Dark mode:** `hover:bg-blue-500/20 hover:text-blue-400`
  - **Light mode:** `hover:bg-blue-50 hover:text-blue-600`

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- Separated active project styling into dedicated render block
- Replaced `hover:bg-gray-800` with `hover:bg-blue-500/20 hover:text-blue-400` (dark mode)
- Replaced `hover:bg-gray-100` with `hover:bg-blue-50 hover:text-blue-600` (light mode)
- Removed inline style logic for non-current projects, using Tailwind classes instead

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<img width="1033" height="442" alt="Screenshot 2026-01-29 222801" src="https://github.com/user-attachments/assets/19ac439f-5099-40eb-bc3c-9525aed67334" />


---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
