### PR TITLE
📖 Relocating The Inline Comments From Script Inside Getting Started Document

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -127,18 +127,22 @@ helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart 
     --version "$kubestellar_version" \
     --set-json ITSes='[{"name":"its1"}]' \
     --set-json WDSes='[{"name":"wds1"},{"name":"wds2","type":"host"}]' \
-    --set verbosity.default=5  # so we can debug your problem reports
+    --set verbosity.default=5
 ```
+The `verbosity.default=5` flag enables more detailed logs for easier debugging.
 
 That command will print some notes about how to get kubeconfig "contexts" named "its1", "wds1", and "wds2" defined. Do that, because those contexts are used in the steps that follow.
 
 ```shell
-kubectl config use-context kind-kubeflex # this is here only to remind you, it will already be the current context if you are following this recipe exactly
-kflex ctx --set-current-for-hosting # make sure the KubeFlex CLI's hidden state is right for what the Helm chart just did
+kubectl config use-context kind-kubeflex
+kflex ctx --set-current-for-hosting
 kflex ctx --overwrite-existing-context wds1
 kflex ctx --overwrite-existing-context wds2
 kflex ctx --overwrite-existing-context its1
 ```
+
+The first command, `kubectl config use-context kind-kubeflex`, is only to remind you, it will already be the current context if you are following this recipe exactly.
+The second command, `kflex ctx --set-current-for-hosting`, is for making sure the KubeFlex CLI's hidden state is right for what the Helm chart just did.
 
 #### Wait for ITS to be fully initialized
 


### PR DESCRIPTION
In this PR, I removed the inline comments from the script commands under the Use Core Helm chart to initialize KubeFlex and create ITS and WDS section, and relocated them to the lines outside the script.
This change helps the users to easily copy, paste, and run the script without modifying it manually.

### 📌 Fixes

Fixes #920 (Use "Fixes", "Closes", or "Resolves" for automatic closing)

---

### 📝 Summary of Changes

- I removed the inline comments in some installation scripts and made the explanation for them outside the scripts instead. This will avoid any errors when new users try to copy and paste to run all the scripts.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated Getting Started document for KubeStellar.io

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->
<img width="1217" height="894" alt="image" src="https://github.com/user-attachments/assets/1a2034bb-b2e5-4621-8cee-13138babe3bd" />
<img width="1217" height="894" alt="image" src="https://github.com/user-attachments/assets/e1ec1910-5423-4ae9-aecb-6ca6598f2e28" />


---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
