### PR TITLE
✨ Add console-docs.kubestellar.io subdomain redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -83,6 +83,30 @@
 
 # Redirects for short URLs
 
+# Redirect console-docs.kubestellar.io to kubestellar.io/docs/console
+[[redirects]]
+  from = "https://console-docs.kubestellar.io/*"
+  to = "https://kubestellar.io/docs/console/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://console-docs.kubestellar.io"
+  to = "https://kubestellar.io/docs/console/readme"
+  status = 301
+  force = true
+
+# Redirect project root pages to first content page
+[[redirects]]
+  from = "/docs/console"
+  to = "/docs/console/readme"
+  status = 302
+
+[[redirects]]
+  from = "/docs/console/"
+  to = "/docs/console/readme"
+  status = 302
+
 # Redirect docs.kubestellar.io to kubestellar.io/docs
 # [[redirects]]
 #   from = "https://docs.kubestellar.io/*"


### PR DESCRIPTION
## Summary
- Adds `console-docs.kubestellar.io` → `kubestellar.io/docs/console/readme` redirect
- Adds `console-docs.kubestellar.io/*` → `kubestellar.io/docs/console/:splat` for deep links
- Adds `/docs/console` and `/docs/console/` root path redirects to `/docs/console/readme`
- Follows the same pattern as a2a, kubeflex, multi, and mcp subdomain redirects

## Prerequisites (Netlify dashboard)
- [ ] Add `console-docs.kubestellar.io` as domain alias on kubestellar-docs site
- [ ] Ensure CNAME record exists in Netlify DNS: `console-docs` → `kubestellar-docs.netlify.app`

## Test plan
- [ ] Visit `https://console-docs.kubestellar.io` → should redirect to `https://kubestellar.io/docs/console/readme`
- [ ] Visit `https://console-docs.kubestellar.io/installation` → should redirect to `https://kubestellar.io/docs/console/installation`
- [ ] Visit `https://kubestellar.io/docs/console` → should redirect to `https://kubestellar.io/docs/console/readme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)