### PR TITLE
🐛 Fix console-docs.kubestellar.io i18n redirect loop

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,6 +15,13 @@ export default function middleware(request: NextRequest) {
     return NextResponse.redirect("https://kubestellar.io/docs", 301);
   }
 
+  // Redirect console-docs.kubestellar.io to console docs section
+  if (request.nextUrl.hostname === "console-docs.kubestellar.io") {
+    const path = request.nextUrl.pathname;
+    const target = path === "/" ? "/docs/console/readme" : `/docs/console${path}`;
+    return NextResponse.redirect(`https://kubestellar.io${target}`, 301);
+  }
+
   // Redirect localized docs URLs to non-localized version
   // e.g., /es/docs/... -> /docs/...
   const docsPathMatch = request.nextUrl.pathname.match(/^\/([a-z]{2}(?:-[A-Z]{2})?|SC)\/docs\//);


### PR DESCRIPTION
## Summary
- Fix `console-docs.kubestellar.io` landing on `/docs/console/en` (404) instead of `/docs/console/readme`
- Root cause: Next.js i18n middleware intercepts `/` → `/en` before Netlify redirect rules fire
- Add hostname check in `middleware.ts` (same pattern as `docs.kubestellar.io`) to redirect before i18n

## Test plan
- [ ] `console-docs.kubestellar.io` → `kubestellar.io/docs/console/readme`
- [ ] `console-docs.kubestellar.io/installation` → `kubestellar.io/docs/console/installation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)