### PR TITLE
📖 docs: update console to v0.3.6 and add console to version workflow

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       project:
-        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin, kubestellar-mcp)'
+        description: 'Project (kubestellar, a2a, kubeflex, multi-plugin, kubestellar-mcp, console)'
         required: true
         type: choice
         options:
@@ -15,6 +15,7 @@ on:
           - kubeflex
           - multi-plugin
           - kubestellar-mcp
+          - console
       version:
         description: 'Version number (e.g., 0.30.0)'
         required: true
@@ -73,6 +74,7 @@ jobs:
             kubeflex) BRANCH="docs/kubeflex/${VERSION}" ;;
             multi-plugin) BRANCH="docs/multi-plugin/${VERSION}" ;;
             kubestellar-mcp) BRANCH="docs/kubestellar-mcp/${VERSION}" ;;
+            console) BRANCH="docs/console/${VERSION}" ;;
             *) echo "Unknown project: $PROJECT"; exit 1 ;;
           esac
           echo "name=$BRANCH" >> $GITHUB_OUTPUT

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -141,8 +141,8 @@
     },
     "console": {
       "latest": {
-        "label": "v0.1.0 (Latest)",
-        "branch": "docs/console/0.1.0",
+        "label": "v0.3.6 (Latest)",
+        "branch": "docs/console/0.3.6",
         "isDefault": true
       },
       "main": {
@@ -150,6 +150,11 @@
         "branch": "main",
         "isDefault": false,
         "isDev": true
+      },
+      "0.1.0": {
+        "label": "v0.1.0",
+        "branch": "docs/console/0.1.0",
+        "isDefault": false
       }
     },
     "kubestellar-mcp": {
@@ -195,7 +200,7 @@
     "console": {
       "name": "Console",
       "basePath": "console",
-      "currentVersion": "0.1.0"
+      "currentVersion": "0.3.6"
     }
   },
   "relatedProjects": [

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -201,8 +201,8 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // console versions
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.1.0 (Latest)",
-    branch: "docs/console/0.1.0",
+    label: "v0.3.6 (Latest)",
+    branch: "docs/console/0.3.6",
     isDefault: true,
   },
   main: {
@@ -210,6 +210,11 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.1.0": {
+    label: "v0.1.0",
+    branch: "docs/console/0.1.0",
+    isDefault: false,
   },
 }
 
@@ -259,7 +264,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "0.1.0",
+    currentVersion: "0.3.6",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
## Summary

- Update console docs version from v0.1.0 to v0.3.6 (Latest) in versions.ts and shared.json
- Add `console` as a project option in `create-version-branch.yml` workflow for future automated version cuts
- Created version branch `docs/console/0.3.6` from current main (already pushed)
- Demote v0.1.0 to historical version entry

This accompanies the console v0.3.6 weekly release.

## Test plan

- [ ] Verify `docs/console/0.3.6` branch deploys on Netlify
- [ ] Verify console version dropdown shows v0.3.6 as Latest
- [ ] Verify `create-version-branch` workflow now includes `console` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)