### PR TITLE
📖 Fix casing: PROW (all caps) and llm-d (lowercase)

### DIFF
--- a/docs/content/console/all-cards.md
+++ b/docs/content/console/all-cards.md
@@ -217,37 +217,37 @@ The console ships with 110+ built-in cards, and you can create more using the Ca
 
 ---
 
-### LLM-d Inference Cards (7)
+### llm-d Inference Cards (7)
 
-![LLM-d Cards](images/llmd-cards.jpg)
+![llm-d Cards](images/llmd-cards.jpg)
 
 | # | Card | What it shows |
 |---|------|---------------|
-| 67 | **LLM-d Request Flow** | Animated request flow through the inference stack with throughput/latency metrics |
+| 67 | **llm-d Request Flow** | Animated request flow through the inference stack with throughput/latency metrics |
 | 68 | **KV Cache Monitor** | KV cache utilization, per-pod cache stats, aggregated/per-pod toggle |
 | 69 | **EPP Routing** | Endpoint Picker routing decisions with RPS and routing distribution |
 | 70 | **P/D Disaggregation** | Prefill and Decode server load, queue depth, throughput, TPOT, GPU memory |
-| 71 | **LLM-d Benchmarks** | Stacks vs Comparison vs Latency views with TTFT, throughput, bar charts |
-| 72 | **LLM-d AI Insights** | AI-generated insights about balanced P/D configuration and optimization |
-| 73 | **LLM-d Configurator** | Configure inference strategies: Intelligent Scheduling, P/D Disaggregation, Wide Expert Parallelism, Variant Autoscaling |
+| 71 | **llm-d Benchmarks** | Stacks vs Comparison vs Latency views with TTFT, throughput, bar charts |
+| 72 | **llm-d AI Insights** | AI-generated insights about balanced P/D configuration and optimization |
+| 73 | **llm-d Configurator** | Configure inference strategies: Intelligent Scheduling, P/D Disaggregation, Wide Expert Parallelism, Variant Autoscaling |
 
-![LLM-d Stack](images/llmd-stack.jpg)
+![llm-d Stack](images/llmd-stack.jpg)
 
 | # | Card | What it shows |
 |---|------|---------------|
-| 74 | **LLM-d Stack** | Stack health, component status, model serving details with cluster discovery |
-| 75 | **LLM-d Models** | Loaded models with namespace, cluster, and GPU allocation |
-| 76 | **LLM-d Inference Servers** | Running inference servers with status and throughput |
+| 74 | **llm-d Stack** | Stack health, component status, model serving details with cluster discovery |
+| 75 | **llm-d Models** | Loaded models with namespace, cluster, and GPU allocation |
+| 76 | **llm-d Inference Servers** | Running inference servers with status and throughput |
 
 ---
 
-### Prow CI Cards (3)
+### PROW CI Cards (3)
 
 | # | Card | What it shows |
 |---|------|---------------|
-| 77 | **Prow CI Monitor** | Overall Prow health: success rate, job counts (running, pending, failed) |
-| 78 | **Prow Jobs** | Filterable job list with type, state, PR number, duration, and age |
-| 79 | **Prow History** | Revision history with pass/fail trends |
+| 77 | **PROW CI Monitor** | Overall PROW health: success rate, job counts (running, pending, failed) |
+| 78 | **PROW Jobs** | Filterable job list with type, state, PR number, duration, and age |
+| 79 | **PROW History** | Revision history with pass/fail trends |
 
 ---
 

--- a/docs/content/console/console-cards.md
+++ b/docs/content/console/console-cards.md
@@ -175,9 +175,9 @@ The KubeStellar Console includes over 100 dashboard cards organized into categor
 
 | Card | Description | Data Source |
 |------|-------------|-------------|
-| Prow Jobs | Prow CI/CD job status | Live |
-| Prow Status | Prow controller health | Live |
-| Prow History | Recent Prow job runs | Live |
+| PROW Jobs | PROW CI/CD job status | Live |
+| PROW Status | PROW controller health | Live |
+| PROW History | Recent PROW job runs | Live |
 | llm-d inference | vLLM, llm-d, TGI server status | Live |
 | llm-d models | Deployed language models | Live |
 | ML Training Jobs | Kubeflow, Ray training status | Demo |

--- a/docs/content/console/console-features.md
+++ b/docs/content/console/console-features.md
@@ -314,17 +314,17 @@ The Local Clusters page shows all local clusters with:
 
 ---
 
-## LLM-d Inference Monitoring
+## llm-d Inference Monitoring
 
-![LLM-d Cards](images/llmd-cards.jpg)
+![llm-d Cards](images/llmd-cards.jpg)
 
-The AI/ML dashboard includes specialized cards for monitoring LLM-d inference serving stacks.
+The AI/ML dashboard includes specialized cards for monitoring llm-d inference serving stacks.
 
 ### Stack Discovery
 
-The console automatically discovers LLM-d stacks across your clusters:
-- Scans all namespaces for LLM-d deployments
-- Detects vLLM, TGI, LLM-d, and Triton inference servers
+The console automatically discovers llm-d stacks across your clusters:
+- Scans all namespaces for llm-d deployments
+- Detects vLLM, TGI, llm-d, and Triton inference servers
 - Shows stack health with component status
 
 ### Key Cards
@@ -336,7 +336,7 @@ The console automatically discovers LLM-d stacks across your clusters:
 - **Benchmarks** - Compare stacks with TTFT, throughput, and latency charts
 - **Configurator** - Configure inference strategies (Intelligent Scheduling, P/D Disaggregation, Wide Expert Parallelism, Variant Autoscaling)
 
-### LLM-d AI Insights
+### llm-d AI Insights
 
 The AI Insights card provides automated analysis of your inference stack configuration, identifying:
 - Balanced vs imbalanced prefill-to-decode ratios
@@ -345,29 +345,29 @@ The AI Insights card provides automated analysis of your inference stack configu
 
 ---
 
-## Prow CI Monitoring
+## PROW CI Monitoring
 
-![Prow CI](images/prow-ci.jpg)
+![PROW CI](images/prow-ci.jpg)
 
-The CI/CD dashboard includes Prow CI integration for monitoring Kubernetes-style CI/CD.
+The CI/CD dashboard includes PROW CI integration for monitoring Kubernetes-style CI/CD.
 
-### Prow Status Card
+### PROW Status Card
 
-Shows overall Prow health:
+Shows overall PROW health:
 - Success rate percentage
 - Job counts in the last hour
 - Running, pending, and failed job breakdown
-- Link to your Prow dashboard
+- Link to your PROW dashboard
 
-### Prow Jobs Card
+### PROW Jobs Card
 
-Filterable list of Prow jobs:
+Filterable list of PROW jobs:
 - Filter by **job type** (presubmit, postsubmit, periodic, batch)
 - Filter by **state** (all states, triggered, pending, running, succeeded, failed)
 - Each job shows PR number, duration, and age
-- Click to open the job in your Prow instance
+- Click to open the job in your PROW instance
 
-### Prow History Card
+### PROW History Card
 
 Revision history showing pass/fail trends over time.
 

--- a/docs/content/console/dashboards.md
+++ b/docs/content/console/dashboards.md
@@ -308,9 +308,9 @@ Focus on pods:
 ![AI/ML Dashboard](images/aiml-dashboard.jpg)
 
 Monitor AI and Machine Learning workloads:
-- LLM-d inference stack monitoring (Request Flow, KV Cache, EPP Routing)
+- llm-d inference stack monitoring (Request Flow, KV Cache, EPP Routing)
 - Prefill/Decode disaggregation metrics
-- LLM-d benchmarks and comparisons
+- llm-d benchmarks and comparisons
 - ML Jobs and Notebooks
 - GPU Overview with type breakdown
 - Hardware Health monitoring
@@ -344,14 +344,14 @@ Manage Kagenti AI agents:
 ![CI/CD Dashboard](images/prow-ci.jpg)
 
 Monitor continuous integration and deployment:
-- Prow CI status and success rates
-- Prow Jobs with type/state filtering
-- Prow revision history
+- PROW CI status and success rates
+- PROW Jobs with type/state filtering
+- PROW revision history
 - Helm release tracking
 - Kustomize and ArgoCD sync status
 - Operator deployments and synced counts
 
-**Best for:** Monitoring CI/CD pipelines and Prow test infrastructure
+**Best for:** Monitoring CI/CD pipelines and PROW test infrastructure
 
 ---
 


### PR DESCRIPTION
## Summary

Fix product name casing in console docs:
- **PROW** → all caps (was mixed-case "Prow")
- **llm-d** → all lowercase (was mixed-case "LLM-d")

## Test plan
- [x] Verify all occurrences replaced across 4 files