### PR TITLE
🌱 Add News link to Community dropdown in navbar

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Sign-off and Signing Contributions: kubestellar/pr-signoff.md
   - Community:
     - Get Involved: Community/_index.md
+    - News: news/index.md
     - Contact Us:
         - Mailing List: https://kubestellar.io/join_us
         - Community Meeting Agenda (join mailing list first): https://kubestellar.io/agenda


### PR DESCRIPTION
## Summary
- Adds a "News" link to the Community dropdown in the top navbar
- Points to the existing `news/index.md` page (already exists from PR #1168)
- Placed after "Get Involved" and before "Contact Us" in the nav hierarchy

## Test plan
- [ ] Verify News link appears in Community dropdown
- [ ] Verify it navigates to the News page correctly
- [ ] `mkdocs serve` builds without errors