### PR TITLE
📖 Fix console install docs: ASCII art, OAuth optional, correct scripts

### DIFF
--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -14,51 +14,60 @@ This guide covers all deployment options for KubeStellar Console.
 
 ---
 
+## Fastest Path
+
+One command downloads pre-built binaries, starts the backend + agent, and opens your browser:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash
+```
+
+This typically takes under 45 seconds. No OAuth or GitHub credentials required — you get a local `dev-user` session automatically.
+
+---
+
 ## System Components
 
 KubeStellar Console has **6 components** that work together:
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           YOUR SETUP                                             │
-│                                                                                  │
-│  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐   │
-│  │  1. GitHub  │     │ 2. Frontend │     │ 3. Backend  │     │  4. Agent   │   │
-│  │   OAuth App │     │  (React UI) │     │    (Go)     │     │ (MCP Bridge)│   │
-│  │             │────▶│             │◀───▶│             │────▶│             │   │
-│  │  Login with │     │ Dashboard,  │     │ API server, │     │ Talks to    │   │
-│  │   GitHub    │     │ cards, AI   │     │ auth, data  │     │ clusters    │   │
-│  └─────────────┘     └─────────────┘     └─────────────┘     └──────┬──────┘   │
-│                                                                      │          │
-│  ┌─────────────────────────────────────────────────────────────────┐│          │
-│  │                    5. Claude Code Plugins                        ││          │
-│  │  ┌──────────────────────┐     ┌──────────────────────┐         ││          │
-│  │  │    kubestellar-ops        │     │    kubestellar-deploy     │         ││          │
-│  │  │  - List clusters     │     │  - Deploy apps       │         ││          │
-│  │  │  - Find pod issues   │     │  - GitOps sync       │         ││          │
-│  │  │  - Check security    │     │  - Scale apps        │         ││          │
-│  │  │  - Analyze RBAC      │     │  - Check drift       │         ││          │
-│  │  └──────────────────────┘     └──────────────────────┘         ││          │
-│  └─────────────────────────────────────────────────────────────────┘│          │
-│                                                                      │          │
-│  ┌───────────────────────────────────────────────────────────────────▼────────┐│
-│  │                           6. Kubeconfig                                    ││
-│  │     ~/.kube/config with access to your clusters                            ││
-│  │     [cluster-1]    [cluster-2]    [cluster-3]    [cluster-n]              ││
-│  └────────────────────────────────────────────────────────────────────────────┘│
-└─────────────────────────────────────────────────────────────────────────────────┘
+  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐   ┌──────────────┐
+  │  1. GitHub  │   │ 2. Frontend │   │ 3. Backend  │   │   4. Agent   │
+  │  OAuth App  │──▶│  (React UI) │◀─▶│    (Go)     │──▶│ (MCP Bridge) │
+  │ (optional)  │   │             │   │             │   │              │
+  │  Login via  │   │  Dashboard, │   │  API server,│   │  Talks to    │
+  │  GitHub     │   │  cards, AI  │   │  auth, data │   │  clusters    │
+  └─────────────┘   └─────────────┘   └─────────────┘   └──────┬───────┘
+                                                                │
+  ┌──────────────────────────────────────────────────┐          │
+  │           5. Claude Code Plugins                 │          │
+  │                                                  │          │
+  │  ┌──────────────────┐  ┌──────────────────────┐  │          │
+  │  │  kubestellar-ops │  │  kubestellar-deploy  │  │          │
+  │  │ - List clusters  │  │  - Deploy apps       │  │          │
+  │  │ - Find pod issues│  │  - GitOps sync       │  │          │
+  │  │ - Check security │  │  - Scale apps        │  │          │
+  │  │ - Analyze RBAC   │  │  - Check drift       │  │          │
+  │  └──────────────────┘  └──────────────────────┘  │          │
+  └──────────────────────────────────────────────────┘          │
+                                                                │
+  ┌─────────────────────────────────────────────────────────────▼──┐
+  │                        6. Kubeconfig                           │
+  │    ~/.kube/config with access to your clusters                 │
+  │    [cluster-1]   [cluster-2]   [cluster-3]   [cluster-n]      │
+  └────────────────────────────────────────────────────────────────┘
 ```
 
 ### Component Summary
 
-| # | Component | What it does | Where to get it |
-|---|-----------|--------------|-----------------|
-| 1 | **GitHub OAuth App** | Lets users sign in with GitHub | [GitHub Developer Settings](https://github.com/settings/developers) |
-| 2 | **Frontend** | React web app you see in browser | Bundled in console image |
-| 3 | **Backend** | Go server that handles API calls | Bundled in console image |
-| 4 | **Agent (MCP Bridge)** | Connects backend to your clusters | Bundled in console image |
-| 5 | **Claude Code Plugins** | kubestellar-ops + kubestellar-deploy tools | [Claude Marketplace](#step-1-install-claude-code-plugins) or Homebrew |
-| 6 | **Kubeconfig** | Your cluster credentials | Your existing `~/.kube/config` |
+| # | Component | What it does | Required? |
+|---|-----------|--------------|-----------|
+| 1 | **GitHub OAuth App** | Lets users sign in with GitHub | Optional — without it, a local `dev-user` session is created |
+| 2 | **Frontend** | React web app you see in browser | Yes — bundled in console image |
+| 3 | **Backend** | Go server that handles API calls | Yes — bundled in console image |
+| 4 | **Agent (MCP Bridge)** | Connects backend to your clusters | Yes — bundled in console image |
+| 5 | **Claude Code Plugins** | kubestellar-ops + kubestellar-deploy tools | Yes — [Claude Marketplace](#step-1-install-claude-code-plugins) or Homebrew |
+| 6 | **Kubeconfig** | Your cluster credentials | Yes — your existing `~/.kube/config` |
 
 ---
 
@@ -111,33 +120,98 @@ KUBECONFIG=~/.kube/config:~/.kube/cluster2.yaml kubectl config view --flatten > 
 mv ~/.kube/merged ~/.kube/config
 ```
 
-### Step 3: Create GitHub OAuth App
+### Step 3: Deploy the Console
+
+Choose your deployment method:
+
+- [Curl one-liner](#curl-quickstart) - Fastest, downloads pre-built binaries
+- [Run from source (no OAuth)](#run-from-source) - For development, no GitHub credentials needed
+- [Run from source (with OAuth)](#run-from-source-with-oauth) - Full GitHub login experience
+- [Helm (Kubernetes)](#helm-installation) - Production deployment
+- [OpenShift](#openshift-installation) - OpenShift with Routes
+- [Docker](#docker-installation) - Single-node or development
+
+---
+
+## Curl Quickstart
+
+Downloads pre-built binaries and starts the console:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash
+```
+
+This starts the backend (port 8080) and opens the frontend in your browser. No OAuth credentials needed — a local `dev-user` session is created automatically.
+
+---
+
+## Run from Source
+
+For contributors or if you want to build from source. No GitHub OAuth required.
+
+### Prerequisites
+
+- Go 1.24+
+- Node.js 20+
+- kubestellar-ops and kubestellar-deploy installed (see [Step 1](#step-1-install-claude-code-plugins))
+
+### Setup
+
+```bash
+git clone https://github.com/kubestellar/console.git
+cd console
+./start-dev.sh
+```
+
+This compiles the Go backend, installs npm dependencies, starts a Vite dev server on port 5174, and creates a local `dev-user` session (no GitHub login needed).
+
+Open http://localhost:5174
+
+---
+
+## Run from Source with OAuth
+
+To enable GitHub login (for multi-user deployments or to test the full auth flow):
+
+### 1. Create a GitHub OAuth App
 
 1. Go to **[GitHub Developer Settings](https://github.com/settings/developers)** → **OAuth Apps** → **New OAuth App**
 
 2. Fill in:
    - **Application name**: `KubeStellar Console`
-   - **Homepage URL**: Your console URL (e.g., `https://console.your-domain.com`)
-   - **Authorization callback URL**: `https://console.your-domain.com/auth/github/callback`
+   - **Homepage URL**: `http://localhost:8080`
+   - **Authorization callback URL**: `http://localhost:8080/auth/github/callback`
 
 3. Click **Register application**
 
 4. Copy the **Client ID** and generate a **Client Secret**
+
+### 2. Configure Environment
+
+Create a `.env` file in the project root with only these two variables:
+
+```bash
+GITHUB_CLIENT_ID=your_client_id
+GITHUB_CLIENT_SECRET=your_client_secret
+```
+
+### 3. Start the Console
+
+```bash
+git clone https://github.com/kubestellar/console.git
+cd console
+./startup-oauth.sh
+```
+
+Open http://localhost:5174 and sign in with GitHub.
+
+> **Tip**: Once running, click your profile avatar → the **Developer** panel shows your OAuth status, console version, and quick links.
 
 | Environment | Callback URL |
 |-------------|--------------|
 | Local dev | `http://localhost:8080/auth/github/callback` |
 | Kubernetes | `https://console.your-domain.com/auth/github/callback` |
 | OpenShift | `https://ksc.apps.your-cluster.com/auth/github/callback` |
-
-### Step 4: Deploy the Console
-
-Choose your deployment method:
-
-- [Helm (Kubernetes)](#helm-installation) - Production deployment
-- [OpenShift](#openshift-installation) - OpenShift with Routes
-- [Docker](#docker-installation) - Single-node or development
-- [Local Development](#local-development) - For contributors
 
 ---
 
@@ -236,6 +310,16 @@ docker run -d \
   ghcr.io/kubestellar/console:latest
 ```
 
+## Kubernetes Deployment via Script
+
+One command that handles helm, secrets, and ingress:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/deploy.sh | bash
+```
+
+Supports `--context`, `--openshift`, `--ingress <host>`, and `--github-oauth` flags.
+
 ## Multi-Cluster Access
 
 The console reads clusters from your kubeconfig. To access multiple clusters:
@@ -268,39 +352,6 @@ helm uninstall ksc --namespace ksc
 kubectl delete namespace ksc
 ```
 
-## Local Development
-
-For contributing to the console or running from source:
-
-### Prerequisites
-
-- Go 1.23+
-- Node.js 20+
-- kubestellar-ops and kubestellar-deploy installed (see [Step 1](#step-1-install-claude-code-plugins))
-
-### Setup
-
-```bash
-# Clone the repo
-git clone https://github.com/kubestellar/console.git
-cd console
-
-# Create .env file
-cat > .env << EOF
-GITHUB_CLIENT_ID=your_client_id
-GITHUB_CLIENT_SECRET=your_client_secret
-DEV_MODE=false
-FRONTEND_URL=http://localhost:5174
-JWT_SECRET=your-secret-key-here
-DATABASE_PATH=./data/console.db
-EOF
-
-# Run both frontend and backend
-./dev.sh
-```
-
-Open http://localhost:5174 and sign in with GitHub.
-
 ---
 
 ## Troubleshooting
@@ -323,8 +374,35 @@ brew install kubestellar-ops kubestellar-deploy
 
 **Solutions**:
 1. Verify the secret contains correct credentials
-2. Check callback URL matches exactly (see [Step 3](#step-3-create-github-oauth-app))
+2. Check callback URL matches exactly (see [Run from Source with OAuth](#run-from-source-with-oauth))
 3. View pod logs: `kubectl logs -n ksc deployment/ksc`
+
+### "GITHUB_CLIENT_SECRET is not set"
+
+**Cause**: You're running `startup-oauth.sh` without a `.env` file.
+
+**Solutions**:
+1. Create a `.env` file with `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` (see [Run from Source with OAuth](#run-from-source-with-oauth))
+2. Or use `./start-dev.sh` instead — it doesn't require OAuth credentials
+
+### "exchange_failed" After GitHub Login
+
+**Cause**: The Client Secret is wrong or has been regenerated.
+
+**Solutions**:
+1. Go to [GitHub Developer Settings](https://github.com/settings/developers) → your OAuth App
+2. Generate a new Client Secret
+3. Update `GITHUB_CLIENT_SECRET` in your `.env` file
+4. Restart the console
+
+### "csrf_validation_failed"
+
+**Cause**: The callback URL in GitHub doesn't match the console's URL.
+
+**Solutions**:
+1. Verify the **Authorization callback URL** in your GitHub OAuth App settings matches exactly: `http://localhost:8080/auth/github/callback`
+2. Clear your browser cookies for `localhost`
+3. Restart the console
 
 ### Clusters Not Showing
 


### PR DESCRIPTION
## Summary

- **Fix broken ASCII art diagram** — the right borders were completely misaligned with stray `│` and `││` characters (see screenshot in issue). Replaced with a clean, properly-aligned diagram without the problematic nested outer box.
- **Mark GitHub OAuth as optional** — console creates a local `dev-user` session automatically without OAuth. Updated component table, prerequisites, and instructions throughout.
- **Add curl one-liner** as the fastest path (both quickstart.md and installation.md)
- **Fix Go version** requirement: `1.23+` → `1.24+`
- **Fix startup scripts**: `./dev.sh` → `./start-dev.sh` (no OAuth) and `./startup-oauth.sh` (with OAuth)
- **Simplify `.env`** configuration to only 2 required vars (was listing 6 unnecessary vars)
- **Add three deployment paths**: curl quickstart, run from source (no OAuth), run from source with OAuth
- **Add new troubleshooting** entries: `exchange_failed`, `csrf_validation_failed`, `GITHUB_CLIENT_SECRET is not set`
- **Add `deploy.sh` script** option for Kubernetes deployment

## Test plan

- [ ] Verify ASCII art renders correctly on the docs site (no stray border characters)
- [ ] Verify all internal links resolve (`#step-1-install-claude-code-plugins`, `#run-from-source-with-oauth`, etc.)
- [ ] Verify curl commands match what's in the console repo (`start.sh`, `deploy.sh`)
- [ ] Verify Go version matches console's go.mod (`1.24+`)
- [ ] Verify script names match console repo (`start-dev.sh`, `startup-oauth.sh`)