### PR TITLE
🐛 Fix: remove duplicate non-functional icons from feature cards 

### DIFF
--- a/src/components/master-page/AboutSection.tsx
+++ b/src/components/master-page/AboutSection.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import { GridLines, StarField } from "../index";
 import { useTranslations } from "next-intl";
-import { DocsSourceActions } from "@/components/docs/DocsSourceActions";
 import Link from "next/link";
 
 export default function AboutSection() {
@@ -176,14 +175,7 @@ export default function AboutSection() {
                     </svg>
                   </div>
                 </Link>
-                <div className="mt-4 pt-3 border-t border-gray-700/40">
-                  <DocsSourceActions
-                    filePath="direct/architecture.md"
-                    projectId="kubestellar"
-                    pageTitle={t("card1Title")}
-                    variant="compact"
-                  />
-                </div>
+
               </div>
             </div>
           </div>
@@ -240,14 +232,7 @@ export default function AboutSection() {
                     </svg>
                   </div>
                 </Link>
-                <div className="mt-4 pt-3 border-t border-gray-700/40">
-                  <DocsSourceActions
-                    filePath="direct/wds.md"
-                    projectId="kubestellar"
-                    pageTitle={t("card2Title")}
-                    variant="compact"
-                  />
-                </div>
+
               </div>
             </div>
           </div>
@@ -304,14 +289,7 @@ export default function AboutSection() {
                     </svg>
                   </div>
                 </Link>
-                <div className="mt-4 pt-3 border-t border-gray-700/40">
-                  <DocsSourceActions
-                    filePath="direct/binding.md"
-                    projectId="kubestellar"
-                    pageTitle={t("card3Title")}
-                    variant="compact"
-                  />
-                </div>
+
               </div>
             </div>
           </div>


### PR DESCRIPTION
The DocsSourceActions compact icon group (PR, source, issue buttons) was rendered at the bottom of each feature card in AboutSection. These icons were non-functional in the homepage context and appeared as duplicate/confusing UI elements. Removed all three instances and the now-unused DocsSourceActions import.

### 📌 Fixes

Fixes #1191 (Use "Fixes", "Closes", or "Resolves" for automatic closing)

---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
