### PR TITLE
🐛 Fix DocsNavbar GitHub stats fetch error handling

### DIFF
--- a/src/components/docs/DocsNavbar.tsx
+++ b/src/components/docs/DocsNavbar.tsx
@@ -54,7 +54,8 @@ export default function DocsNavbar() {
           "https://api.github.com/repos/kubestellar/kubestellar"
         );
         if (!response.ok) {
-          throw new Error("Network response was not okay");
+          console.warn(`GitHub API returned ${response.status} — using fallback stats`);
+          return;
         }
         const data = await response.json();
         const formatNumber = (num: number): string => {
@@ -69,11 +70,13 @@ export default function DocsNavbar() {
           watchers: formatNumber(data.subscribers_count),
         });
       } catch (err) {
-        console.error("Failed to fetch Github stats: ", err);
+        console.warn("Failed to fetch GitHub stats — using fallback values:", err);
       }
     };
     fetchGithubStats();
+  }, []);
 
+  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         if (isSearchOpen) {
@@ -90,7 +93,7 @@ export default function DocsNavbar() {
         setIsSearchOpen(!isSearchOpen);
         setTimeout(() => searchInputRef.current?.focus(), 100);
       }
-      
+
       // Navigation in search results
       if (isSearchOpen && searchResults.length > 0) {
         if (e.key === "ArrowDown") {
@@ -105,7 +108,7 @@ export default function DocsNavbar() {
         }
       }
     };
-    
+
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isSearchOpen, searchResults, selectedIndex]);


### PR DESCRIPTION
## Summary
- Fixes uncaught console error when GitHub API returns non-OK response (e.g., rate limiting)
- Separates GitHub stats fetch into its own useEffect with empty dependency array to prevent redundant API calls

## Changes
- `fetchGithubStats`: gracefully handles non-OK responses with `console.warn` and fallback values instead of throwing
- Moved GitHub stats fetch to a dedicated useEffect with `[]` dependencies

Fixes #1197