### PR TITLE
🐛 Update kubestellar-console-announcement.md

### DIFF
--- a/docs/content/news/kubestellar-console-announcement.md
+++ b/docs/content/news/kubestellar-console-announcement.md
@@ -25,7 +25,7 @@ That's it — one command, no dependencies beyond curl. It downloads the console
 
 ## What Is It?
 
-KubeStellar Console is a multi-cluster Kubernetes dashboard that's AI-powered and adapts to how you work. It's multi-cluster from day one — OpenShift, EKS, GKE, kind, k3s, whatever you have in your kubeconfig shows up automatically.
+KubeStellar Console is a multi-cluster Kubernetes dashboard that's AI-powered and adapts to how you work. It's multi-cluster from day&nbsp;one — OpenShift, EKS, GKE, kind, k3s, whatever you have in your kubeconfig shows up automatically.
 
 ---
 


### PR DESCRIPTION
Add a nonbreaking space character in "day one" (to "day&nbsp;one" to solve mystery elision of the word "one"

### 📌 Fixes

For some mysterious reason, the phrase `day one` in this file was rendering as `day` (the word "one" was vanishing despite its presence in the source.) Adding the non-breaking space to join the words in the phrase seems to prevent the elision.