### PR TITLE
✨ Fix marketplace to show all 76 items from registry

### DIFF
--- a/src/app/[locale]/marketplace/page.tsx
+++ b/src/app/[locale]/marketplace/page.tsx
@@ -39,6 +39,7 @@ interface RegistryData {
   version: string;
   updatedAt: string;
   items: MarketplaceItem[];
+  presets?: MarketplaceItem[];
 }
 
 const TYPE_CONFIG = {
@@ -85,7 +86,8 @@ export default function MarketplacePage() {
         return res.json();
       })
       .then((d: RegistryData) => {
-        setData(d);
+        const allItems = [...(d.items || []), ...(d.presets || [])];
+        setData({ ...d, items: allItems });
         setLoading(false);
       })
       .catch((e) => {


### PR DESCRIPTION
## Problem
The marketplace page at kubestellar.io/en/marketplace only shows 3 dashboards. The console-marketplace registry.json has 76 items across two arrays:
- `items`: 3 dashboards
- `presets`: 71 card-presets + 2 themes

The page component was only reading `data.items`, missing all presets.

## Fix
- Added `presets` to the `RegistryData` interface
- Merge `items` + `presets` arrays when data loads

Now all 76 marketplace items are displayed.