### PR TITLE
📖 added book icon to hero documentation link

### DIFF
--- a/src/components/master-page/HeroSection.tsx
+++ b/src/components/master-page/HeroSection.tsx
@@ -185,8 +185,22 @@ export default function HeroSection() {
             <div className="mt-4 animate-btn-float" style={{ animationDelay: "0.8s" }}>
               <IntlLink
                 href="/docs/console/readme"
-                className="inline-flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors font-medium"
+                className="inline-flex items-center text-lg text-blue-400 hover:text-blue-300 transition-colors font-medium"
               >
+                
+                <svg
+                   className="mr-2 h-4 w-4"
+                   fill="none"
+                   viewBox="0 0 24 24"
+                   stroke="currentColor"
+                >
+                   <path
+                     strokeLinecap="round"
+                     strokeLinejoin="round"
+                     strokeWidth="2"
+                     d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                   ></path>
+                </svg>
                 Console Documentation
                 <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />


### PR DESCRIPTION
### 📝 Summary of Changes

This restores an svg "book" item to the Console Documentation link in the Hero section of the landing page.
