### PR TITLE
📖 Fix typos and grammar across docs

### DIFF
--- a/docs/content/kubestellar/core-chart-argocd.md
+++ b/docs/content/kubestellar/core-chart-argocd.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This documents explains how to use the KubeStellar core Helm chart to:
+This document explains how to use the KubeStellar core Helm chart to:
 
 - deploy Argo CD in KubeFlex hosting cluster;
 - register every WDS as a target cluster in Argo CD; and

--- a/docs/content/kubestellar/core-chart.md
+++ b/docs/content/kubestellar/core-chart.md
@@ -9,7 +9,7 @@
 - [Argo CD Integration](#argo-cd-integration)
 - [Uninstalling the KubeStellar Core Chart](#uninstalling-the-kubestellar-core-chart)
 
-This documents explains how to use KubeStellar Core chart to do three
+This document explains how to use KubeStellar Core chart to do three
 of the 11 installation and usage steps; please see [the
 full outline](user-guide-intro.md#the-full-story) for generalities and [Getting Started](get-started.md) for an example of usage.
 

--- a/docs/content/kubestellar/pre-reqs.md
+++ b/docs/content/kubestellar/pre-reqs.md
@@ -53,7 +53,7 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
 
 ## Additional Software for monitoring
 
-The setup in `montoring/` additional uses the following.
+The setup in `monitoring/` additionally uses the following.
 
 - [`yq`](https://github.com/mikefarah/yq) (also available from [Homebrew](https://formulae.brew.sh/formula/yq)) version >= 1.5
 

--- a/docs/content/kubestellar/release-notes.md
+++ b/docs/content/kubestellar/release-notes.md
@@ -62,7 +62,7 @@ Also some doc improvements, and bumps to some build-time dependencies.
 
 ## 0.27.1
 
-Bumps version of ingrex-nginx used to 0.12.1, to avoid recently disclosed vulnerabilities in older versions.
+Bumps version of ingress-nginx used to 0.12.1, to avoid recently disclosed vulnerabilities in older versions.
 
 Avoids use of release 0.11 of clusteradm, **which introduced an incompatible change in the name of a ServiceAccount**.
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -584,7 +584,7 @@
       "console": {
         "name": "KubeStellar Console",
         "fullName": "KubeStellar Console",
-        "description": "An AI-powered, multi-cluster Kubernetes dashboard that adapts to how you work. Try it or install locally it locally in under a minute. It's multi-cluster from day one — OpenShift, EKS, GKE, kind, k3s, whatever you have in your kubeconfig shows up automatically."
+        "description": "An AI-powered, multi-cluster Kubernetes dashboard that adapts to how you work. Try it or install it locally in under a minute. It's multi-cluster from day one — OpenShift, EKS, GKE, kind, k3s, whatever you have in your kubeconfig shows up automatically."
       },
       "kubestellar": {
         "name": "KubeStellar (Legacy)",


### PR DESCRIPTION
## Summary
- Fix "This documents explains" → "This document explains" in core-chart.md and core-chart-argocd.md
- Fix "montoring" → "monitoring" and "additional uses" → "additionally uses" in pre-reqs.md
- Fix "ingrex-nginx" → "ingress-nginx" in release-notes.md
- Fix "install locally it locally" → "install it locally" in en.json

## Test plan
- [ ] Verify docs site builds without errors
- [ ] Spot-check affected pages render correctly