### PR TITLE
📖 Fix install instructions in console announcement

### DIFF
--- a/docs/content/news/kubestellar-console-announcement.md
+++ b/docs/content/news/kubestellar-console-announcement.md
@@ -50,7 +50,7 @@ We have a rewards program! Open issues and feature requests directly through the
 
 - **Live site:** [https://console.kubestellar.io](https://console.kubestellar.io)
 - **GitHub:** [https://github.com/kubestellar/console](https://github.com/kubestellar/console)
-- **Local agent install:** `brew tap kubestellar/tap && brew install --head kc-agent`
+- **Local install:** `curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash`
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace outdated `brew tap kubestellar/tap && brew install --head kc-agent` with `curl -sSL .../start.sh | bash` in the console announcement post

## Test plan
- [ ] Verify announcement page renders correctly