### PR TITLE
✨ Add copilot-setup-steps.yml to enable Copilot coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,29 @@
+name: Copilot Setup Steps
+# Pre-configures the Copilot coding agent's Ubuntu VM with build tools
+# so it can validate changes to the docs site (Next.js + Nextra).
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs site
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
## Problem

The Copilot coding agent requires `copilot-setup-steps.yml` to accept issue assignments. Without it, assigning issues to Copilot fails with `Forbidden`.

This was the root cause of the same failure in console-marketplace (fixed in [#87](https://github.com/kubestellar/console-marketplace/pull/87)).

## Fix

Adds `.github/workflows/copilot-setup-steps.yml` with:
- Node.js 20 setup
- `npm ci` + `npm run build` + `npm run lint`

This enables Copilot to work on docs issues autonomously.