### PR TITLE
✨ Add contributor leaderboard page with CI-generated data

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -1,0 +1,33 @@
+name: Generate Leaderboard Data
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6am UTC
+  workflow_dispatch:       # Manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate leaderboard data
+        env:
+          GITHUB_TOKEN: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}
+        run: node scripts/generate-leaderboard.mjs
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/data/leaderboard.json
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "chore: update leaderboard data"
+          git push

--- a/public/data/leaderboard.json
+++ b/public/data/leaderboard.json
@@ -1,0 +1,4 @@
+{
+  "generated_at": "",
+  "entries": []
+}

--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+/**
+ * Generates leaderboard data by fetching contributor activity from GitHub.
+ *
+ * Replicates the scoring logic from the KubeStellar Console backend
+ * (pkg/api/handlers/rewards.go) so that results are consistent.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=ghp_xxx node scripts/generate-leaderboard.mjs
+ *
+ * Output: public/data/leaderboard.json
+ */
+
+import { writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Point values (mirrors rewards.go lines 23-31) ─────────────────────
+const POINTS_BUG_ISSUE = 300;
+const POINTS_FEATURE_ISSUE = 100;
+const POINTS_OTHER_ISSUE = 50;
+const POINTS_PR_OPENED = 200;
+const POINTS_PR_MERGED = 500;
+
+// ── Repos to scan (mirrors REWARDS_GITHUB_ORGS default in server.go:928) ──
+const REPOS = [
+  "kubestellar/console",
+  "kubestellar/console-marketplace",
+  "kubestellar/console-kb",
+];
+
+// ── Contributor levels (mirrors rewards.go lines 138-147) ─────────────
+const CONTRIBUTOR_LEVELS = [
+  { rank: 1, name: "Observer", minCoins: 0 },
+  { rank: 2, name: "Explorer", minCoins: 500 },
+  { rank: 3, name: "Navigator", minCoins: 2000 },
+  { rank: 4, name: "Pilot", minCoins: 5000 },
+  { rank: 5, name: "Commander", minCoins: 15000 },
+  { rank: 6, name: "Captain", minCoins: 50000 },
+  { rank: 7, name: "Admiral", minCoins: 150000 },
+  { rank: 8, name: "Legend", minCoins: 500000 },
+];
+
+// ── GitHub API constants ──────────────────────────────────────────────
+const MAX_CONTRIBUTORS_PER_REPO = 50;
+const SEARCH_PER_PAGE = 100;
+const SEARCH_MAX_PAGES = 10;
+const API_BASE = "https://api.github.com";
+const SEARCH_RATE_LIMIT_DELAY_MS = 2500; // GitHub Search API: 30 req/min for authenticated
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const TOKEN = process.env.GITHUB_TOKEN;
+if (!TOKEN) {
+  console.error("Error: GITHUB_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+const headers = {
+  Accept: "application/vnd.github.v3+json",
+  Authorization: `Bearer ${TOKEN}`,
+};
+
+async function ghFetch(url) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub API ${res.status}: ${url}\n${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/** Delay to avoid hitting GitHub Search API rate limit (30 req/min). */
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Bug / feature label sets (mirrors classifyIssue in rewards.go:386) ──
+const BUG_LABELS = new Set(["bug", "kind/bug", "type/bug"]);
+const FEATURE_LABELS = new Set([
+  "enhancement",
+  "feature",
+  "kind/feature",
+  "type/feature",
+]);
+
+function classifyIssueLabels(labels) {
+  for (const label of labels) {
+    if (BUG_LABELS.has(label.name)) return { type: "issue_bug", points: POINTS_BUG_ISSUE };
+    if (FEATURE_LABELS.has(label.name))
+      return { type: "issue_feature", points: POINTS_FEATURE_ISSUE };
+  }
+  return { type: "issue_other", points: POINTS_OTHER_ISSUE };
+}
+
+function getLevelForPoints(totalPoints) {
+  let level = CONTRIBUTOR_LEVELS[0];
+  for (let i = CONTRIBUTOR_LEVELS.length - 1; i >= 0; i--) {
+    if (totalPoints >= CONTRIBUTOR_LEVELS[i].minCoins) {
+      level = CONTRIBUTOR_LEVELS[i];
+      break;
+    }
+  }
+  return level;
+}
+
+// ── Search API with pagination (mirrors searchItems in rewards.go:336) ──
+async function searchItems(login, itemType) {
+  const repoFilter = REPOS.map((r) => `repo:${r}`).join(" ");
+  const query = `author:${login} ${repoFilter} type:${itemType}`;
+  const allItems = [];
+
+  for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+    const url = `${API_BASE}/search/issues?q=${encodeURIComponent(query)}&per_page=${SEARCH_PER_PAGE}&page=${page}&sort=created&order=desc`;
+
+    await delay(SEARCH_RATE_LIMIT_DELAY_MS);
+    const data = await ghFetch(url);
+    allItems.push(...(data.items || []));
+
+    if (allItems.length >= data.total_count || (data.items || []).length < SEARCH_PER_PAGE) {
+      break;
+    }
+  }
+
+  return allItems;
+}
+
+// ── Score a single contributor ────────────────────────────────────────
+async function scoreContributor(login) {
+  const breakdown = {
+    bug_issues: 0,
+    feature_issues: 0,
+    other_issues: 0,
+    prs_opened: 0,
+    prs_merged: 0,
+  };
+  let totalPoints = 0;
+
+  // Fetch issues
+  try {
+    const issues = await searchItems(login, "issue");
+    for (const item of issues) {
+      const { type, points } = classifyIssueLabels(item.labels || []);
+      totalPoints += points;
+      if (type === "issue_bug") breakdown.bug_issues++;
+      else if (type === "issue_feature") breakdown.feature_issues++;
+      else breakdown.other_issues++;
+    }
+  } catch (err) {
+    console.warn(`  Warning: issue search failed for ${login}: ${err.message}`);
+  }
+
+  // Fetch PRs
+  try {
+    const prs = await searchItems(login, "pr");
+    for (const item of prs) {
+      // pr_opened always
+      totalPoints += POINTS_PR_OPENED;
+      breakdown.prs_opened++;
+
+      // pr_merged if merged_at is set
+      if (item.pull_request?.merged_at) {
+        totalPoints += POINTS_PR_MERGED;
+        breakdown.prs_merged++;
+      }
+    }
+  } catch (err) {
+    console.warn(`  Warning: PR search failed for ${login}: ${err.message}`);
+  }
+
+  return { totalPoints, breakdown };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+async function main() {
+  console.log("Fetching contributors from repos...");
+
+  // 1. Discover contributors from each repo
+  const contributorMap = new Map(); // login -> avatar_url
+
+  for (const repo of REPOS) {
+    try {
+      const url = `${API_BASE}/repos/${repo}/contributors?per_page=${MAX_CONTRIBUTORS_PER_REPO}`;
+      const contributors = await ghFetch(url);
+      for (const c of contributors) {
+        if (c.type === "User" && !contributorMap.has(c.login)) {
+          contributorMap.set(c.login, c.avatar_url);
+        }
+      }
+      console.log(`  ${repo}: ${contributors.filter((c) => c.type === "User").length} contributors`);
+    } catch (err) {
+      console.warn(`  Warning: failed to fetch contributors for ${repo}: ${err.message}`);
+    }
+  }
+
+  console.log(`\nTotal unique contributors: ${contributorMap.size}`);
+  console.log("Scoring contributors (this takes a while due to Search API rate limits)...\n");
+
+  // 2. Score each contributor
+  const entries = [];
+
+  for (const [login, avatarUrl] of contributorMap) {
+    try {
+      console.log(`  Scoring ${login}...`);
+      const { totalPoints, breakdown } = await scoreContributor(login);
+      const level = getLevelForPoints(totalPoints);
+
+      entries.push({
+        login,
+        avatar_url: avatarUrl,
+        total_points: totalPoints,
+        level: level.name,
+        level_rank: level.rank,
+        breakdown,
+      });
+    } catch (err) {
+      console.warn(`  Warning: failed to score ${login}: ${err.message}`);
+    }
+  }
+
+  // 3. Sort by points descending, then alphabetically
+  entries.sort((a, b) => {
+    if (a.total_points !== b.total_points) return b.total_points - a.total_points;
+    return a.login.localeCompare(b.login);
+  });
+
+  // 4. Assign ranks
+  entries.forEach((entry, i) => {
+    entry.rank = i + 1;
+  });
+
+  // 5. Write output
+  const output = {
+    generated_at: new Date().toISOString(),
+    entries,
+  };
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const outPath = join(__dirname, "..", "public", "data", "leaderboard.json");
+  writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n");
+
+  console.log(`\nDone! Wrote ${entries.length} entries to ${outPath}`);
+  console.log(`Top 5:`);
+  for (const e of entries.slice(0, 5)) {
+    console.log(`  #${e.rank} ${e.login}: ${e.total_points} pts (${e.level})`);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/app/[locale]/ladder/page.tsx
+++ b/src/app/[locale]/ladder/page.tsx
@@ -8,6 +8,7 @@ import {
   Footer,
 } from "../../../components/index";
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 
 export default function MaintainerLadderPage() {
   const t = useTranslations("ladderPage");
@@ -226,8 +227,8 @@ export default function MaintainerLadderPage() {
                 {t("subtitle")}
               </p>
 
-              {/* Tracking Sheet CTA */}
-              <div className="mt-8 flex justify-center">
+              {/* CTAs */}
+              <div className="mt-8 flex flex-col sm:flex-row justify-center gap-4">
                 <div className="relative group">
                   <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 rounded-lg blur opacity-60 group-hover:opacity-100 transition duration-300 animate-pulse"></div>
                   <a
@@ -249,6 +250,15 @@ export default function MaintainerLadderPage() {
                     </div>
                   </a>
                 </div>
+                <Link
+                  href="/leaderboard"
+                  className="flex items-center justify-center gap-2 px-6 py-3 bg-gray-800/60 backdrop-blur-md rounded-lg border border-white/10 hover:border-purple-500/30 hover:bg-gray-800/80 transition-all duration-300"
+                >
+                  <span className="text-lg">🏆</span>
+                  <span className="text-sm font-semibold text-white">
+                    Contributor Leaderboard
+                  </span>
+                </Link>
               </div>
             </div>
           </div>

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  GridLines,
+  StarField,
+  ContributionCallToAction,
+  Navbar,
+  Footer,
+} from "../../../components/index";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+interface LeaderboardBreakdown {
+  bug_issues: number;
+  feature_issues: number;
+  other_issues: number;
+  prs_opened: number;
+  prs_merged: number;
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  login: string;
+  avatar_url: string;
+  total_points: number;
+  level: string;
+  level_rank: number;
+  breakdown: LeaderboardBreakdown;
+}
+
+interface LeaderboardData {
+  generated_at: string;
+  entries: LeaderboardEntry[];
+}
+
+// ── Contributor level colors (mirrors console's CONTRIBUTOR_LEVELS) ───
+
+interface LevelStyle {
+  bg: string;
+  text: string;
+  border: string;
+}
+
+const LEVEL_STYLES: Record<string, LevelStyle> = {
+  Observer: {
+    bg: "bg-gray-500/20",
+    text: "text-gray-400",
+    border: "border-gray-500/30",
+  },
+  Explorer: {
+    bg: "bg-blue-500/20",
+    text: "text-blue-400",
+    border: "border-blue-500/30",
+  },
+  Navigator: {
+    bg: "bg-cyan-500/20",
+    text: "text-cyan-400",
+    border: "border-cyan-500/30",
+  },
+  Pilot: {
+    bg: "bg-green-500/20",
+    text: "text-green-400",
+    border: "border-green-500/30",
+  },
+  Commander: {
+    bg: "bg-purple-500/20",
+    text: "text-purple-400",
+    border: "border-purple-500/30",
+  },
+  Captain: {
+    bg: "bg-amber-500/20",
+    text: "text-amber-400",
+    border: "border-amber-500/30",
+  },
+  Admiral: {
+    bg: "bg-orange-500/20",
+    text: "text-orange-400",
+    border: "border-orange-500/30",
+  },
+  Legend: {
+    bg: "bg-gradient-to-r from-yellow-500/20 via-amber-500/20 to-orange-500/20",
+    text: "text-yellow-400",
+    border: "border-yellow-500/40",
+  },
+};
+
+// ── Medal icons for top 3 ─────────────────────────────────────────────
+
+const GOLD_MEDAL = "🥇";
+const SILVER_MEDAL = "🥈";
+const BRONZE_MEDAL = "🥉";
+
+function RankDisplay({ rank }: { rank: number }) {
+  if (rank === 1)
+    return <span className="text-xl" title="1st place">{GOLD_MEDAL}</span>;
+  if (rank === 2)
+    return <span className="text-xl" title="2nd place">{SILVER_MEDAL}</span>;
+  if (rank === 3)
+    return <span className="text-xl" title="3rd place">{BRONZE_MEDAL}</span>;
+  return <span className="text-sm text-gray-400 tabular-nums">#{rank}</span>;
+}
+
+// ── Level badge ───────────────────────────────────────────────────────
+
+function LevelBadge({ level }: { level: string }) {
+  const style = LEVEL_STYLES[level] || LEVEL_STYLES.Observer;
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${style.bg} ${style.text} ${style.border}`}
+    >
+      {level}
+    </span>
+  );
+}
+
+// ── Breakdown pills ───────────────────────────────────────────────────
+
+function BreakdownPills({ breakdown }: { breakdown: LeaderboardBreakdown }) {
+  const pills = [];
+  if (breakdown.prs_merged > 0)
+    pills.push({ label: `${breakdown.prs_merged} Merged`, color: "text-green-400 bg-green-500/10" });
+  if (breakdown.prs_opened > 0)
+    pills.push({ label: `${breakdown.prs_opened} PRs`, color: "text-blue-400 bg-blue-500/10" });
+  if (breakdown.bug_issues > 0)
+    pills.push({ label: `${breakdown.bug_issues} Bugs`, color: "text-red-400 bg-red-500/10" });
+  if (breakdown.feature_issues > 0)
+    pills.push({ label: `${breakdown.feature_issues} Features`, color: "text-purple-400 bg-purple-500/10" });
+  if (breakdown.other_issues > 0)
+    pills.push({ label: `${breakdown.other_issues} Issues`, color: "text-gray-400 bg-gray-500/10" });
+
+  if (pills.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {pills.map((pill) => (
+        <span
+          key={pill.label}
+          className={`px-2 py-0.5 rounded text-xs font-medium ${pill.color}`}
+        >
+          {pill.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ── Leaderboard data URL ──────────────────────────────────────────────
+const LEADERBOARD_DATA_PATH = "/data/leaderboard.json";
+
+// ── Page component ────────────────────────────────────────────────────
+
+export default function LeaderboardPage() {
+  const [data, setData] = useState<LeaderboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetch(LEADERBOARD_DATA_PATH)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((json: LeaderboardData) => {
+        setData(json);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setIsLoading(false);
+      });
+  }, []);
+
+  const filteredEntries = useMemo(() => {
+    if (!data?.entries) return [];
+    if (!search.trim()) return data.entries;
+    const q = search.toLowerCase();
+    return data.entries.filter((e) => e.login.toLowerCase().includes(q));
+  }, [data, search]);
+
+  const lastUpdated = data?.generated_at
+    ? new Date(data.generated_at).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
+
+  return (
+    <div className="bg-[#0a0a0a] text-white overflow-x-hidden min-h-screen">
+      <Navbar />
+
+      {/* Full page background with starfield */}
+      <div className="fixed inset-0 z-0">
+        <div className="absolute inset-0 bg-[#0a0a0a]"></div>
+        <StarField density="medium" showComets={true} cometCount={3} />
+        <GridLines horizontalLines={21} verticalLines={18} />
+      </div>
+
+      <div className="relative z-10 pt-7">
+        {/* Header Section */}
+        <section className="pt-12 pb-8 sm:pt-28 sm:pb-12 lg:pt-24 lg:pb-8">
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center">
+              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-3">
+                Contributor{" "}
+                <span className="text-gradient animated-gradient bg-gradient-to-r from-purple-600 via-blue-500 to-purple-600">
+                  Leaderboard
+                </span>
+              </h1>
+              <p className="text-xl md:text-2xl text-gray-300 max-w-4xl mx-auto leading-relaxed">
+                Top contributors ranked by activity across KubeStellar Console
+                repositories
+              </p>
+              {lastUpdated && (
+                <p className="mt-3 text-sm text-gray-500">
+                  Last updated: {lastUpdated}
+                </p>
+              )}
+
+              {/* Link to ladder page */}
+              <div className="mt-6 flex justify-center">
+                <Link
+                  href="/ladder"
+                  className="text-sm text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-1.5"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                  View Contributor Ladder
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Leaderboard Section */}
+        <section className="py-8 sm:py-12">
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            {/* Search */}
+            <div className="mb-6">
+              <input
+                type="text"
+                placeholder="Search by GitHub username..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full max-w-md mx-auto block px-4 py-2.5 bg-gray-800/60 backdrop-blur-md border border-white/10 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/30 transition-colors"
+              />
+            </div>
+
+            {/* Loading state */}
+            {isLoading && (
+              <div className="text-center py-16">
+                <div className="animate-spin w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full mx-auto mb-4"></div>
+                <p className="text-gray-400">Loading leaderboard...</p>
+              </div>
+            )}
+
+            {/* Error state */}
+            {error && (
+              <div className="text-center py-16">
+                <p className="text-red-400 mb-2">Failed to load leaderboard</p>
+                <p className="text-gray-500 text-sm">{error}</p>
+              </div>
+            )}
+
+            {/* Empty state */}
+            {!isLoading && !error && filteredEntries.length === 0 && (
+              <div className="text-center py-16">
+                <div className="text-4xl mb-4">🏆</div>
+                <p className="text-gray-400">
+                  {search ? "No contributors match your search" : "No contributor data available yet"}
+                </p>
+              </div>
+            )}
+
+            {/* Leaderboard table */}
+            {!isLoading && !error && filteredEntries.length > 0 && (
+              <div className="bg-gray-800/40 backdrop-blur-md rounded-xl border border-white/10 overflow-hidden">
+                {/* Table header */}
+                <div className="hidden sm:grid sm:grid-cols-[60px_1fr_120px_120px_1fr] gap-4 px-6 py-3 border-b border-white/5 text-xs text-gray-500 uppercase tracking-wider">
+                  <div className="text-center">Rank</div>
+                  <div>Contributor</div>
+                  <div className="text-right">Points</div>
+                  <div className="text-center">Level</div>
+                  <div>Breakdown</div>
+                </div>
+
+                {/* Table rows */}
+                {filteredEntries.map((entry) => (
+                  <div
+                    key={entry.login}
+                    className="grid grid-cols-1 sm:grid-cols-[60px_1fr_120px_120px_1fr] gap-2 sm:gap-4 px-4 sm:px-6 py-4 border-b border-white/5 last:border-0 hover:bg-white/[0.02] transition-colors items-center"
+                  >
+                    {/* Rank */}
+                    <div className="hidden sm:flex justify-center">
+                      <RankDisplay rank={entry.rank} />
+                    </div>
+
+                    {/* Contributor */}
+                    <div className="flex items-center gap-3">
+                      <div className="sm:hidden flex-shrink-0 w-8 text-center">
+                        <RankDisplay rank={entry.rank} />
+                      </div>
+                      {entry.avatar_url ? (
+                        <Image
+                          src={entry.avatar_url}
+                          alt={entry.login}
+                          width={32}
+                          height={32}
+                          className="w-8 h-8 rounded-full flex-shrink-0"
+                          unoptimized
+                        />
+                      ) : (
+                        <div className="w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center flex-shrink-0 text-sm font-medium text-gray-300">
+                          {entry.login[0]?.toUpperCase()}
+                        </div>
+                      )}
+                      <a
+                        href={`https://github.com/${entry.login}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm font-medium text-white hover:text-blue-400 transition-colors truncate"
+                      >
+                        {entry.login}
+                      </a>
+                    </div>
+
+                    {/* Points */}
+                    <div className="text-right tabular-nums font-semibold text-yellow-400 text-sm pl-11 sm:pl-0">
+                      {entry.total_points.toLocaleString()}
+                    </div>
+
+                    {/* Level */}
+                    <div className="flex justify-start sm:justify-center pl-11 sm:pl-0">
+                      <LevelBadge level={entry.level} />
+                    </div>
+
+                    {/* Breakdown */}
+                    <div className="pl-11 sm:pl-0">
+                      <BreakdownPills breakdown={entry.breakdown} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Point values reference */}
+            {!isLoading && !error && filteredEntries.length > 0 && (
+              <div className="mt-8 bg-gray-800/30 backdrop-blur-md rounded-lg border border-white/5 p-6">
+                <h3 className="text-sm font-semibold text-gray-400 mb-3 uppercase tracking-wider">
+                  Point Values
+                </h3>
+                <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="text-green-400 font-mono font-bold">500</span>
+                    <span className="text-gray-400">PR Merged</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-red-400 font-mono font-bold">300</span>
+                    <span className="text-gray-400">Bug Report</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-blue-400 font-mono font-bold">200</span>
+                    <span className="text-gray-400">PR Opened</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-purple-400 font-mono font-bold">100</span>
+                    <span className="text-gray-400">Feature Request</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-400 font-mono font-bold">50</span>
+                    <span className="text-gray-400">Other Issue</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* CTA Section */}
+        <ContributionCallToAction />
+      </div>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a daily GitHub Action (`generate-leaderboard.yml`) that fetches contributor activity from GitHub APIs, scores contributions, and commits `leaderboard.json` to the repo
- Adds a new `/leaderboard` page that renders the generated data with ranked contributors, levels, point breakdown, and search
- Adds a "Contributor Leaderboard" link from the existing `/ladder` page
- Scoring mirrors the KubeStellar Console backend (`rewards.go`): bug report=300, feature request=100, PR opened=200, PR merged=500, other issue=50

## Setup Required
Add `LEADERBOARD_GITHUB_TOKEN` as a repo secret — a classic PAT with `public_repo` scope. This is separate from the console's shared OAuth token to avoid rate limit conflicts.

## Test plan
- [ ] Verify docs build passes
- [ ] Run `GITHUB_TOKEN=<pat> node scripts/generate-leaderboard.mjs` locally to generate data
- [ ] Visit `/en/leaderboard` and confirm table renders with ranks, avatars, points, levels
- [ ] Visit `/en/ladder` and confirm "Contributor Leaderboard" link works
- [ ] After adding repo secret, trigger the workflow manually and verify it commits data