### PR TITLE
🐛 Fix leaderboard workflow: use PAT to push past branch protection

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- The leaderboard workflow's commit step failed because `main` has branch protection (required status checks)
- Fix: pass `LEADERBOARD_GITHUB_TOKEN` to `actions/checkout` so `git push` uses the PAT instead of the default `GITHUB_TOKEN`

## Test plan
- [ ] Re-run workflow after merge — data should commit to main