### PR TITLE
📖 Add direct console.kubestellar.io backlinks

### DIFF
--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -31,7 +31,7 @@ export default function ProductsPage() {
     {
       id: "console",
       logo: "/products/ks-console.png",
-      website: "https://kubestellar.io/docs/console",
+      website: "https://console.kubestellar.io",
       repository: "https://github.com/kubestellar/console",
       name: t("products.console.name"),
       fullName: t("products.console.fullName"),

--- a/src/components/master-page/HeroSection.tsx
+++ b/src/components/master-page/HeroSection.tsx
@@ -181,8 +181,23 @@ export default function HeroSection() {
               </div>
             </div>
 
-            {/* Console Docs Link */}
-            <div className="mt-4 animate-btn-float" style={{ animationDelay: "0.8s" }}>
+            {/* Console Links */}
+            <div className="mt-4 flex flex-wrap items-center gap-4 animate-btn-float" style={{ animationDelay: "0.8s" }}>
+              <a
+                href="https://console.kubestellar.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center text-lg text-purple-400 hover:text-purple-300 transition-colors font-medium"
+              >
+                <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                </svg>
+                Try Console
+                <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
               <IntlLink
                 href="/docs/console/readme"
                 className="inline-flex items-center text-lg text-blue-400 hover:text-blue-300 transition-colors font-medium"
@@ -190,7 +205,7 @@ export default function HeroSection() {
                 <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
-                Console Documentation
+                Documentation
                 <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>


### PR DESCRIPTION
## Summary
- **Products page**: Change console website link from docs page to the live app at console.kubestellar.io
- **Hero section**: Add a "Try Console" link alongside the existing documentation link, pointing directly to console.kubestellar.io

These changes make it easier for visitors to find the live console dashboard and improve SEO for console.kubestellar.io through backlinks from the main kubestellar.io site.

## Test plan
- [ ] Products page "Website" button for Console goes to console.kubestellar.io
- [ ] Hero section shows both "Try Console" and "Documentation" links
- [ ] "Try Console" opens console.kubestellar.io in a new tab
- [ ] Documentation link still goes to /docs/console/readme