### PR TITLE
🐛 Fix docs sidebar flash on navigation

### DIFF
--- a/mdx-components.js
+++ b/mdx-components.js
@@ -1,17 +1,13 @@
 import { DocsLayout } from './src/components/docs/DocsLayout';
-import { buildPageMap } from './src/app/docs/page-map';
 
 // Custom MDX components without nextra-theme-docs
 export function useMDXComponents(components) {
   return {
     // Wrapper component that wraps the entire MDX content with DocsLayout
-    // pageMap can be passed from server-side for project-specific navigation
-    wrapper: ({ children, toc, metadata, sourceCode, pageMap: providedPageMap, filePath, projectId, ...props }) => {
-      // Use provided pageMap (from server) or fall back to default (KubeStellar)
-      const pageMap = providedPageMap || buildPageMap().pageMap;
-
+    // Sidebar is now in the Next.js layout (persists across navigations)
+    wrapper: ({ children, toc, metadata, sourceCode, pageMap: _pageMap, filePath, projectId, ...props }) => {
       return (
-        <DocsLayout pageMap={pageMap} toc={toc} metadata={metadata} filePath={filePath} projectId={projectId}>
+        <DocsLayout toc={toc} metadata={metadata} filePath={filePath} projectId={projectId}>
           {children}
         </DocsLayout>
       );

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,10 +1,13 @@
 import { DocsNavbar, DocsFooter, DocsBanner } from '@/components/docs/index'
 import { DocsProvider } from '@/components/docs/DocsProvider'
+import { SidebarContainer } from '@/components/docs/SidebarContainer'
+import { MobileOverlay } from '@/components/docs/MobileOverlay'
 import { Inter, JetBrains_Mono } from "next/font/google"
 import { Suspense } from 'react'
 import { ThemeProvider } from "next-themes"
 import "../globals.css"
 import { buildPageMap } from './page-map'
+import type { ProjectId } from '@/config/versions'
 
 const inter = Inter({
   variable: "--font-inter",
@@ -26,10 +29,14 @@ type Props = {
   children: React.ReactNode
 }
 
+const ALL_PROJECT_IDS: ProjectId[] = ['kubestellar', 'a2a', 'kubeflex', 'multi-plugin', 'kubestellar-mcp', 'console']
+
 export default async function DocsLayout({ children }: Props) {
-  // Build page map from local docs
-  buildPageMap();
-  
+  // Build page maps for all projects so the sidebar can switch without remounting
+  const allPageMaps = Object.fromEntries(
+    ALL_PROJECT_IDS.map(id => [id, buildPageMap(id).pageMap])
+  ) as Record<ProjectId, ReturnType<typeof buildPageMap>['pageMap']>
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
@@ -40,9 +47,13 @@ export default async function DocsLayout({ children }: Props) {
               <Suspense fallback={<div className="h-16" />}>
                 <DocsNavbar />
               </Suspense>
-              <main className="flex-1">
-                {children}
-              </main>
+              <div className="flex flex-1 relative">
+                <SidebarContainer allPageMaps={allPageMaps} />
+                <MobileOverlay />
+                <div className="flex-1 min-w-0">
+                  {children}
+                </div>
+              </div>
               <DocsFooter />
             </div>
           </DocsProvider>

--- a/src/components/docs/DocsLayout.tsx
+++ b/src/components/docs/DocsLayout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ReactNode } from 'react';
-import { DocsSidebar } from './DocsSidebar';
 import { TableOfContents } from './TableOfContents';
 import { MobileTOC } from './MobileTOC';
 import { MobileHeader } from './MobileSidebarToggle';
@@ -15,15 +14,6 @@ interface TOCItem {
   depth: number;
 }
 
-interface PageMapItem {
-  name: string;
-  route?: string;
-  title?: string;
-  children?: PageMapItem[];
-  frontMatter?: Record<string, unknown>;
-  kind?: string;
-}
-
 interface Metadata {
   title?: string;
   description?: string;
@@ -32,29 +22,17 @@ interface Metadata {
 
 interface DocsLayoutProps {
   children: ReactNode;
-  pageMap: PageMapItem[];
   toc?: TOCItem[];
   metadata?: Metadata;
   filePath?: string;
   projectId?: ProjectId;
 }
 
-export function DocsLayout({ children, pageMap, toc, metadata, filePath, projectId }: DocsLayoutProps) {
-  const { menuOpen, toggleMenu } = useDocsMenu();
+export function DocsLayout({ children, toc, metadata, filePath, projectId }: DocsLayoutProps) {
+  const { toggleMenu } = useDocsMenu();
 
   return (
-    <div className="flex flex-1 relative">
-      {/* Sidebar - Self-contained with all logic */}
-      <DocsSidebar pageMap={pageMap} projectId={projectId} />
-
-      {/* Mobile overlay */}
-      {menuOpen && (
-        <div
-          className="fixed inset-0 bg-black/50 z-20 lg:hidden"
-          onClick={toggleMenu}
-        />
-      )}
-
+    <>
       {/* Main content area */}
       <main className="flex-1 min-w-0 lg:ml-0">
         <div className="mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -92,6 +70,6 @@ export function DocsLayout({ children, pageMap, toc, metadata, filePath, project
 
       {/* Table of Contents - Right sidebar on desktop */}
       <TableOfContents toc={toc} />
-    </div>
+    </>
   );
 }

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useTheme } from 'next-themes';
 import { ChevronRight, ChevronDown, FileText} from 'lucide-react';
 import { RelatedProjects } from './RelatedProjects';
 import { useDocsMenu } from './DocsProvider';
@@ -28,8 +27,6 @@ interface DocsSidebarProps {
 export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps) {
   const pathname = usePathname();
   const sidebarRef = useRef<HTMLElement>(null);
-  const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
   const {
     sidebarCollapsed,
     toggleSidebar,
@@ -41,18 +38,11 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
     navInitialized
   } = useDocsMenu();
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const isDark = mounted && resolvedTheme === 'dark';
   const isLegacyProject = projectId === 'kubestellar' || projectId === 'kubeflex' || projectId === 'multi-plugin';
 
   // Auto-expand legacy menu if viewing a legacy page (not Community, Contributing, News)
   const shouldAutoExpandLegacy = isLegacyProject && !pathname.includes('/community') && !pathname.includes('/contributing') && !pathname.includes('/news');
 
-  // Text colors based on theme
-  const textColor = isDark ? '#e5e7eb' : '#374151'; // gray-200 : gray-700
   // Stable layout values - only recalculate on resize or banner change
   const [layoutValues, setLayoutValues] = useState({ top: '4rem', height: 'calc(100vh - 4rem)' });
 
@@ -198,8 +188,8 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
             // Folder - clickable to toggle
             <button
               onClick={() => toggleCollapse(itemKey)}
-              className="flex-1 flex items-start gap-2 px-3 py-2 text-sm font-thin hover:font-semibold rounded-lg transition-all text-left w-full relative z-10"
-              style={{ paddingLeft: `${depth * 16 + 12}px`, color: textColor }}
+              className="flex-1 flex items-start gap-2 px-3 py-2 text-sm font-thin hover:font-semibold rounded-lg transition-all text-left w-full relative z-10 text-gray-700 dark:text-gray-200"
+              style={{ paddingLeft: `${depth * 16 + 12}px` }}
             >
               <span className="flex-1 wrap-break-word">{displayTitle}</span>
               <span className="ml-auto shrink-0 mt-0.5">
@@ -219,17 +209,13 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
                 ${
                   isActive
                     ? 'font-thin text-blue-500 bg-blue-500/10'
-                    : 'hover:font-semibold'
+                    : 'hover:font-semibold text-gray-700 dark:text-gray-200'
                 }
               `}
-              style={{
-                paddingLeft: `${depth * 16 + 12}px`,
-                color: isActive ? undefined : textColor
-              }}
+              style={{ paddingLeft: `${depth * 16 + 12}px` }}
             >
               <FileText
-                className="w-4 h-4 shrink-0 mt-0.5"
-                style={{ color: isActive ? '#3b82f6' : textColor }}
+                className={`w-4 h-4 shrink-0 mt-0.5 ${isActive ? 'text-blue-500' : 'text-gray-700 dark:text-gray-200'}`}
               />
               <span className="flex-1 wrap-break-word">{displayTitle}</span>
             </Link>
@@ -241,7 +227,7 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
           <div 
             className={`
               relative space-y-1 overflow-hidden transition-all duration-300 ease-in-out
-              ${isCollapsed ? 'max-h-0 opacity-0' : 'max-h-500 opacity-100'}
+              ${isCollapsed ? 'max-h-0 opacity-0' : 'max-h-[2000px] opacity-100'}
             `}
           >
             {/* Vertical line connecting children */}

--- a/src/components/docs/MobileOverlay.tsx
+++ b/src/components/docs/MobileOverlay.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useDocsMenu } from './DocsProvider'
+
+export function MobileOverlay() {
+  const { menuOpen, toggleMenu } = useDocsMenu()
+
+  if (!menuOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-20 lg:hidden"
+      onClick={toggleMenu}
+    />
+  )
+}

--- a/src/components/docs/SidebarContainer.tsx
+++ b/src/components/docs/SidebarContainer.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { DocsSidebar } from './DocsSidebar'
+import type { ProjectId } from '@/config/versions'
+
+interface PageMapItem {
+  name: string
+  route?: string
+  title?: string
+  children?: PageMapItem[]
+  frontMatter?: Record<string, unknown>
+  kind?: string
+}
+
+function getProjectFromPathname(pathname: string): ProjectId {
+  if (pathname.startsWith('/docs/a2a')) return 'a2a'
+  if (pathname.startsWith('/docs/kubeflex')) return 'kubeflex'
+  if (pathname.startsWith('/docs/multi-plugin')) return 'multi-plugin'
+  if (pathname.startsWith('/docs/kubestellar-mcp')) return 'kubestellar-mcp'
+  if (pathname.startsWith('/docs/console')) return 'console'
+  return 'kubestellar'
+}
+
+interface SidebarContainerProps {
+  allPageMaps: Record<ProjectId, PageMapItem[]>
+}
+
+export function SidebarContainer({ allPageMaps }: SidebarContainerProps) {
+  const pathname = usePathname()
+  const projectId = getProjectFromPathname(pathname)
+  const pageMap = allPageMaps[projectId] || allPageMaps['kubestellar']
+
+  return <DocsSidebar pageMap={pageMap} projectId={projectId} />
+}


### PR DESCRIPTION
## Summary
- Move sidebar from page component to Next.js layout so it persists across navigations, eliminating the visible flash/flicker when clicking sidebar items
- Replace JavaScript-based theme color logic (`mounted`/`isDark`/`textColor`) with CSS `dark:` classes to prevent hydration color flash
- Fix invalid `max-h-500` Tailwind class (not a valid utility) to `max-h-[2000px]`

## Root Cause
The `DocsSidebar` was rendered inside each page component (via `Wrapper` → `DocsLayout`), not in the Next.js layout. In App Router, layouts persist across navigations but pages are unmounted/remounted. Every sidebar click caused the sidebar to be destroyed and recreated, triggering:
1. `mounted` state reset → wrong theme colors for one frame
2. `layoutValues` state reset → sidebar position/height jump  
3. Full DOM subtree teardown and rebuild

## Changes
- **New**: `SidebarContainer.tsx` — client component that detects project from pathname and renders `DocsSidebar` with the correct pageMap
- **New**: `MobileOverlay.tsx` — extracted mobile overlay from `DocsLayout`
- **Modified**: `layout.tsx` — builds all project pageMaps server-side, renders sidebar in the persistent layout
- **Modified**: `DocsLayout.tsx` — removed sidebar (now in layout), only renders content area + TOC
- **Modified**: `DocsSidebar.tsx` — removed `useTheme`/`mounted`/`textColor`, uses Tailwind `dark:` classes instead
- **Modified**: `mdx-components.js` — removed unused `buildPageMap` import and `pageMap` prop passing

## Test plan
- [ ] Navigate between docs pages — sidebar should no longer flash
- [ ] Verify sidebar items stay expanded/collapsed across navigations
- [ ] Test project switching (KubeStellar → A2A → Console) — correct sidebar loads
- [ ] Test mobile sidebar toggle — overlay appears/disappears correctly
- [ ] Verify dark/light mode — text colors correct in both themes
- [ ] Build passes with no errors