### PR TITLE
✨ Marketplace & Knowledge Base docs, remove Partners, SEO optimization

### DIFF
--- a/docs/content/console/ai-features.md
+++ b/docs/content/console/ai-features.md
@@ -1,14 +1,25 @@
 ---
-title: "AI Features"
+title: "AI Features — AI Missions for Multi-Cluster Kubernetes Operations, Troubleshooting & Deployment"
 linkTitle: "AI Features"
 weight: 9
 description: >
-  AI Missions, Diagnose & Repair, Smart Suggestions, and AI Card Creation
+  AI Missions automate multi-cluster Kubernetes operations — troubleshoot, deploy, repair, and upgrade across your entire fleet. KubeStellar Console's AI features include missions for 400+ CNCF projects, diagnose and repair automation, smart suggestions, and AI-powered card creation that saves you time and tokens.
+keywords:
+  - AI kubernetes operations
+  - AI missions kubernetes
+  - kubernetes troubleshooting automation
+  - multi-cluster kubernetes AI
+  - kubernetes deployment AI
+  - AI repair kubernetes
+  - kubernetes automation tool
+  - CNCF project AI missions
+  - kubernetes fleet management AI
+  - AI kubernetes dashboard
 ---
 
-# AI Features
+# AI Features — Multi-Cluster Kubernetes Operations Powered by AI
 
-KubeStellar Console uses AI to help you manage your clusters. Think of it as having a helpful assistant who knows Kubernetes.
+KubeStellar Console uses AI Missions to automate multi-cluster Kubernetes operations. Think of it as having an expert Kubernetes engineer who knows every CNCF project and can troubleshoot, deploy, and repair across your entire fleet — saving you time and tokens.
 
 ![AI Missions Panel](images/ai-missions-panel.png)
 

--- a/docs/content/console/alerts.md
+++ b/docs/content/console/alerts.md
@@ -1,9 +1,15 @@
 ---
-title: "Alerts & Token Usage"
+title: "Alerts & Token Usage — Multi-Cluster Kubernetes Alerting with AI Token Tracking"
 linkTitle: "Alerts"
 weight: 11
 description: >
-  Configurable alerts and AI token tracking
+  Configurable multi-cluster Kubernetes alerts with AI token tracking. Set up alerts across your entire fleet, get notified via browser, Slack, or webhooks, and track AI token usage to control costs. KubeStellar Console alerting saves you time and tokens.
+keywords:
+  - kubernetes alerts
+  - multi-cluster kubernetes alerting
+  - kubernetes notification system
+  - AI token usage tracking
+  - kubernetes fleet alerting
 ---
 
 # Alerts & Token Usage

--- a/docs/content/console/all-cards.md
+++ b/docs/content/console/all-cards.md
@@ -1,9 +1,17 @@
 ---
-title: "All Cards"
+title: "115+ Multi-Cluster Kubernetes Monitoring Cards — Workloads, GPU, Security, Cost & More"
 linkTitle: "Cards"
 weight: 7
 description: >
-  Complete list of all 115+ card types
+  115+ monitoring cards for multi-cluster Kubernetes operations — cluster health, workload status, GPU utilization, security compliance, cost tracking, and CNCF project monitoring. Build custom dashboards for your fleet with KubeStellar Console's AI-powered card system.
+keywords:
+  - kubernetes monitoring cards
+  - multi-cluster monitoring
+  - kubernetes GPU monitoring
+  - kubernetes security monitoring
+  - kubernetes cost monitoring cards
+  - kubernetes workload monitoring
+  - CNCF project monitoring cards
 ---
 
 # Dashboard Cards

--- a/docs/content/console/architecture.md
+++ b/docs/content/console/architecture.md
@@ -1,9 +1,14 @@
 ---
-title: "Architecture"
+title: "Architecture — Multi-Cluster Kubernetes Dashboard System Design"
 linkTitle: "Architecture"
 weight: 3
 description: >
-  System design and component overview
+  System design and component architecture of KubeStellar Console — the multi-cluster Kubernetes dashboard with AI Missions. Learn how the agent proxy, WebSocket data pipeline, and AI integration work together to provide fleet-wide Kubernetes operations.
+keywords:
+  - kubernetes dashboard architecture
+  - multi-cluster kubernetes architecture
+  - kubernetes management tool design
+  - AI kubernetes system design
 ---
 
 # Architecture

--- a/docs/content/console/dashboards.md
+++ b/docs/content/console/dashboards.md
@@ -1,14 +1,23 @@
 ---
-title: "Dashboards"
+title: "Dashboards — 28+ Multi-Cluster Kubernetes Monitoring Dashboards"
 linkTitle: "Dashboards"
 weight: 6
 description: >
-  All 28+ dashboard pages in KubeStellar Console
+  28+ pre-built dashboards for multi-cluster Kubernetes monitoring — workloads, compute, storage, network, security, GitOps, GPU, cost, and AI-powered insights. KubeStellar Console dashboards give you fleet-wide visibility across all your Kubernetes clusters in a single view.
+keywords:
+  - kubernetes monitoring dashboard
+  - multi-cluster kubernetes dashboard
+  - kubernetes observability
+  - kubernetes workload monitoring
+  - kubernetes GPU monitoring dashboard
+  - kubernetes security dashboard
+  - kubernetes cost monitoring
+  - multi-cluster observability
 ---
 
-# Dashboards
+# Dashboards — Multi-Cluster Kubernetes Monitoring
 
-KubeStellar Console has 28+ different dashboards. Each one shows you different information about your Kubernetes clusters.
+KubeStellar Console has 28+ dashboards for multi-cluster Kubernetes monitoring. Each dashboard gives you fleet-wide visibility into a specific operational area across all your connected clusters.
 
 ## Main Dashboard
 

--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -1,14 +1,21 @@
 ---
-title: "Installation"
+title: "Installation — Deploy KubeStellar Console for Multi-Cluster Kubernetes Management"
 linkTitle: "Installation"
 weight: 2
 description: >
-  Detailed deployment options for KubeStellar Console
+  Install KubeStellar Console locally, in Kubernetes, or via Helm. Deploy the multi-cluster Kubernetes dashboard with AI Missions, 110+ monitoring cards, and fleet-wide observability in minutes.
+keywords:
+  - install kubernetes dashboard
+  - kubernetes console installation
+  - multi-cluster dashboard setup
+  - kubernetes helm install dashboard
+  - deploy kubernetes management tool
+  - kubernetes fleet management setup
 ---
 
-# Installation
+# Installation — Deploy KubeStellar Console
 
-This guide covers all deployment options for KubeStellar Console.
+This guide covers all deployment options for KubeStellar Console, the multi-cluster Kubernetes dashboard with AI-powered operations.
 
 > **Try it first!** See a live preview at [kubestellarconsole.netlify.app](https://kubestellarconsole.netlify.app)
 

--- a/docs/content/console/knowledge-base.md
+++ b/docs/content/console/knowledge-base.md
@@ -1,0 +1,262 @@
+---
+title: "KubeStellar Console Knowledge Base — AI Mission Prompts for Kubernetes Installation, Configuration & Repair"
+linkTitle: "Knowledge Base"
+weight: 13
+description: >
+  Browse 400+ AI Mission prompts to install, configure, troubleshoot, and repair CNCF open source projects across multiple Kubernetes clusters. The KubeStellar Console Knowledge Base provides ready-to-use installation missions and solution prompts powered by AI that saves you time and tokens.
+keywords:
+  - kubernetes knowledge base
+  - AI kubernetes installation
+  - CNCF project installation guide
+  - kubernetes troubleshooting AI
+  - multi-cluster deployment automation
+  - kubernetes repair automation
+  - AI missions kubernetes
+  - cloud native installation prompts
+---
+
+# KubeStellar Console Knowledge Base
+
+The Knowledge Base is the library behind KubeStellar Console's AI Missions system. It contains **400+ ready-to-use mission prompts** that install, configure, troubleshoot, and repair open source Kubernetes projects across your multi-cluster fleet — all powered by AI that saves you time and tokens.
+
+## Two Types of Mission Prompts
+
+Every mission prompt in the Knowledge Base falls into one of two classes:
+
+### Installation Missions
+
+Installation missions walk you through deploying a CNCF or open source project on one or more clusters. Each installation mission includes:
+
+- **Prerequisites** — What needs to be in place before installing (Helm, specific CRDs, minimum Kubernetes version)
+- **Installation steps** — Step-by-step commands with explanations
+- **Configuration options** — Common configuration parameters and when to use them
+- **Verification** — How to confirm the installation succeeded
+- **Uninstall steps** — Clean removal instructions
+- **Upgrade path** — How to upgrade to newer versions
+
+**Example: Installing Prometheus across a multi-cluster fleet**
+
+```
+Mission: Install Prometheus
+Type: install
+Difficulty: beginner
+Target: All clusters matching label "monitoring=enabled"
+
+Steps:
+1. Add the prometheus-community Helm repo
+2. Create the monitoring namespace
+3. Install kube-prometheus-stack with recommended values
+4. Verify Prometheus pods are running
+5. Confirm metrics scraping is active
+```
+
+The AI executes each step, adapting to your specific cluster configuration. If a step fails, the AI diagnoses the issue and suggests a fix before continuing.
+
+### Solution Missions
+
+Solution missions are troubleshooting and repair prompts. They start from a symptom — "pods crashing", "high latency", "certificate expired" — and guide the AI through diagnosis and repair.
+
+- **Symptom description** — What the problem looks like
+- **Diagnostic steps** — Commands to gather information
+- **Root cause analysis** — AI interprets the diagnostic output
+- **Repair actions** — Specific fixes with approval gates
+- **Verification** — Confirm the fix worked
+- **Resolution saving** — Save the solution for future reuse
+
+**Example: Repairing certificate expiry across clusters**
+
+```
+Mission: Fix Expired TLS Certificates
+Type: repair
+Difficulty: intermediate
+Symptom: Services returning TLS handshake errors
+
+Steps:
+1. Scan all clusters for expired certificates
+2. Identify which cert-manager issuers are affected
+3. Trigger certificate renewal
+4. Verify new certificates are propagated
+5. Confirm services are healthy
+```
+
+## How AI Missions Work
+
+When you run a mission from the Knowledge Base, here's what happens:
+
+1. **You pick a mission** — Browse the Knowledge Base or describe your problem in natural language
+2. **AI reads the prompt** — The mission prompt gives the AI context, steps, and expected outcomes
+3. **AI adapts to your environment** — The AI checks your actual cluster state (namespaces, versions, resources) and adjusts the steps
+4. **Step-by-step execution** — Each step runs with your approval. The AI shows what it will do before doing it
+5. **Automatic error recovery** — If a step fails, the AI diagnoses the failure and tries an alternative approach
+6. **Resolution saved** — After success, the resolution is saved to your personal or shared Knowledge Base for future reuse
+
+### Multi-Cluster Awareness
+
+Unlike single-cluster tools, every Knowledge Base mission is multi-cluster aware:
+
+- **Cluster selection** — Choose which clusters to target (by name, label, or "all")
+- **Parallel execution** — Run the same mission across multiple clusters simultaneously
+- **Drift detection** — The AI identifies differences between clusters and adapts
+- **Fleet-wide verification** — Confirm results across all targeted clusters, not just one
+
+## CNCF Projects in the Knowledge Base
+
+The Knowledge Base includes installation and solution missions for projects across all CNCF categories. Here's what's currently available:
+
+### Observability & Monitoring
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **Prometheus** | Yes | 12+ troubleshooting prompts | Graduated |
+| **Grafana** | Yes | 8+ troubleshooting prompts | — |
+| **Jaeger** | Yes | 6+ troubleshooting prompts | Graduated |
+| **OpenTelemetry** | Yes | 10+ troubleshooting prompts | Incubating |
+| **Fluentd** | Yes | 5+ troubleshooting prompts | Graduated |
+| **Thanos** | Yes | 7+ troubleshooting prompts | Incubating |
+| **Cortex** | Yes | 4+ troubleshooting prompts | Incubating |
+| **Loki** | Yes | 6+ troubleshooting prompts | — |
+
+### Networking & Service Mesh
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **Istio** | Yes | 15+ troubleshooting prompts | Graduated |
+| **Envoy** | Yes | 8+ troubleshooting prompts | Graduated |
+| **Cilium** | Yes | 10+ troubleshooting prompts | Graduated |
+| **Calico** | Yes | 7+ troubleshooting prompts | — |
+| **Linkerd** | Yes | 6+ troubleshooting prompts | Graduated |
+| **CoreDNS** | Yes | 5+ troubleshooting prompts | Graduated |
+| **NATS** | Yes | 4+ troubleshooting prompts | Incubating |
+
+### Security & Policy
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **OPA / Gatekeeper** | Yes | 8+ troubleshooting prompts | Graduated |
+| **Falco** | Yes | 6+ troubleshooting prompts | Graduated |
+| **cert-manager** | Yes | 10+ troubleshooting prompts | — |
+| **Kyverno** | Yes | 7+ troubleshooting prompts | Incubating |
+| **Trivy** | Yes | 5+ troubleshooting prompts | — |
+| **Vault** | Yes | 8+ troubleshooting prompts | — |
+
+### Storage & Data
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **Longhorn** | Yes | 6+ troubleshooting prompts | Incubating |
+| **OpenEBS** | Yes | 5+ troubleshooting prompts | Sandbox |
+| **Rook / Ceph** | Yes | 8+ troubleshooting prompts | Graduated |
+| **MinIO** | Yes | 4+ troubleshooting prompts | — |
+| **Velero** | Yes | 6+ troubleshooting prompts | — |
+
+### Application Delivery & GitOps
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **Argo CD** | Yes | 10+ troubleshooting prompts | Graduated |
+| **Flux CD** | Yes | 8+ troubleshooting prompts | Graduated |
+| **Helm** | Yes | 12+ troubleshooting prompts | Graduated |
+| **Kustomize** | Yes | 5+ troubleshooting prompts | — |
+| **Crossplane** | Yes | 7+ troubleshooting prompts | Incubating |
+
+### Runtime & Orchestration
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **containerd** | Yes | 6+ troubleshooting prompts | Graduated |
+| **Knative** | Yes | 8+ troubleshooting prompts | Incubating |
+| **KEDA** | Yes | 5+ troubleshooting prompts | Graduated |
+| **KubeVirt** | Yes | 4+ troubleshooting prompts | Incubating |
+| **Volcano** | Yes | 3+ troubleshooting prompts | Incubating |
+
+### Infrastructure & Provisioning
+
+| Project | Install Mission | Solution Missions | Maturity |
+|---------|:-:|:-:|----------|
+| **Cluster API** | Yes | 6+ troubleshooting prompts | — |
+| **Metal3** | Yes | 4+ troubleshooting prompts | — |
+| **Tinkerbell** | Yes | 3+ troubleshooting prompts | Sandbox |
+| **wasmCloud** | Yes | 3+ troubleshooting prompts | Sandbox |
+
+## Resolution Knowledge Base
+
+Beyond the pre-built missions, the Knowledge Base grows with every problem you solve. The **Resolution Knowledge Base** tracks successful troubleshooting outcomes so you never solve the same problem twice.
+
+### How It Works
+
+1. **Complete a mission** — After the AI successfully repairs an issue, you're prompted to save the resolution
+2. **Save with context** — The resolution captures the symptom, diagnostic steps, root cause, and fix
+3. **Personal or shared** — Keep resolutions private or share with your organization
+4. **Automatic matching** — When a similar problem occurs, the Knowledge Base suggests matching past resolutions
+5. **One-click reapply** — Apply a previous resolution to a new occurrence with a single click
+
+### Personal vs Shared Resolutions
+
+| Scope | Who Sees It | Best For |
+|-------|-------------|----------|
+| **Personal** | Only you | Custom fixes for your specific cluster configurations |
+| **Shared** | Everyone in your organization | Common issues that affect the whole team |
+
+Over time, the shared Knowledge Base becomes an institutional memory of how your organization operates Kubernetes — a living runbook that the AI can reference automatically.
+
+## Browsing the Knowledge Base
+
+Open the Mission Browser from the console sidebar or the AI Missions panel.
+
+### Filtering and Search
+
+- **By mission type** — Install, troubleshoot, repair, upgrade, deploy, analyze
+- **By CNCF category** — Observability, networking, security, storage, runtime
+- **By maturity** — Graduated, incubating, sandbox
+- **By difficulty** — Beginner, intermediate, advanced
+- **By tags** — Specific technologies, use cases, or symptoms
+- **Full-text search** — Search across mission titles, descriptions, and steps
+
+### Mission Sources
+
+Missions come from three sources:
+
+| Source | Description |
+|--------|-------------|
+| **KubeStellar Community** | Curated missions maintained by the KubeStellar team |
+| **GitHub Community** | Missions from GitHub repos tagged with `kubestellar-missions` |
+| **Local** | Your own imported or AI-generated missions |
+
+### Deep Linking
+
+Every mission has a permanent URL you can share:
+
+```
+https://console.kubestellar.io/missions/install-prometheus
+https://console.kubestellar.io/missions/fix-certificate-expiry
+```
+
+Share mission links in Slack, documentation, or runbooks to give your team instant access to proven solutions.
+
+## Creating Custom Missions
+
+You can create your own missions and add them to the Knowledge Base:
+
+1. **From natural language** — Describe what you want to accomplish and the AI generates a mission
+2. **From a template** — Start from an existing mission and modify it
+3. **From YAML/JSON** — Import a mission definition file
+4. **From a resolution** — Convert a successful troubleshooting session into a reusable mission
+
+Custom missions follow the same format as community missions and can be shared via the Marketplace or GitHub.
+
+## Why This Saves You Time and Tokens
+
+Traditional Kubernetes troubleshooting means:
+
+1. Google the error message
+2. Read 5 Stack Overflow answers
+3. Try each suggestion manually
+4. Repeat across every affected cluster
+
+With the KubeStellar Console Knowledge Base:
+
+1. AI matches the symptom to a known resolution
+2. Executes the fix across all affected clusters in parallel
+3. Verifies the fix worked everywhere
+
+**The result:** What used to take hours of manual debugging now takes minutes of AI-guided resolution — across your entire multi-cluster fleet. And because mission prompts are optimized for the AI model, you use fewer tokens per resolution than free-form chat, saving both time and cost.

--- a/docs/content/console/marketplace.md
+++ b/docs/content/console/marketplace.md
@@ -1,0 +1,122 @@
+---
+title: "KubeStellar Console Marketplace — Community Dashboards, Cards & Themes for Multi-Cluster Kubernetes"
+linkTitle: "Marketplace"
+weight: 12
+description: >
+  Browse, install, and contribute dashboards, card presets, and themes for multi-cluster Kubernetes operations. The KubeStellar Console Marketplace lets teams extend their multi-cluster management experience with community-built monitoring, observability, and deployment tools.
+keywords:
+  - kubernetes marketplace
+  - multi-cluster dashboard marketplace
+  - CNCF project monitoring
+  - kubernetes observability marketplace
+  - multi-cluster operations tools
+  - kubernetes dashboard extensions
+  - cloud native marketplace
+---
+
+# KubeStellar Console Marketplace
+
+The KubeStellar Console Marketplace is where teams discover, install, and share extensions for multi-cluster Kubernetes operations. Instead of building every dashboard and card from scratch, you can browse a growing library of community-contributed dashboards, card presets, and themes — all designed for multi-cluster environments.
+
+## What the Marketplace Offers
+
+The Marketplace ships three categories of installable content:
+
+| Category | What It Is | Examples |
+|----------|-----------|---------|
+| **Dashboards** | Full pre-built dashboard layouts for specific use cases | CNCF Observability Dashboard, GPU Fleet Monitor, Cost Optimization View |
+| **Card Presets** | Individual monitoring cards for specific CNCF projects | Prometheus alert summary, Istio traffic map, Cilium network policy card |
+| **Themes** | Visual themes that change the console's appearance | Dark engineering, light operations, high-contrast accessibility |
+
+## Browsing and Installing
+
+Open the Marketplace from the console sidebar or navigate to `/marketplace`.
+
+### Finding What You Need
+
+- **Search** — Full-text search across names, descriptions, tags, and authors
+- **Filter by type** — Dashboards, card presets, or themes
+- **Filter by CNCF category** — Observability, networking, security, runtime, storage, and more
+- **Filter by difficulty** — Beginner, intermediate, or advanced configurations
+- **Sort** — By name, author, type, or difficulty level
+
+### One-Click Install
+
+Every Marketplace item includes:
+
+1. **Preview screenshot** — See exactly what you get before installing
+2. **Description and tags** — Understand what the item monitors or configures
+3. **Author profile** — GitHub-linked author with contribution stats (coins earned, PRs merged)
+4. **Version info** — Track updates and changelogs
+5. **Install button** — One click to add to your console
+
+After installing, the dashboard, card, or theme is immediately available — no restarts, no config files.
+
+## CNCF Project Coverage
+
+The Marketplace tracks coverage across the entire CNCF landscape. A progress banner shows how many graduated, incubating, and sandbox projects have community-built monitoring cards.
+
+**Current coverage:**
+
+| Maturity | Projects Covered | Status |
+|----------|-----------------|--------|
+| Graduated | 35+ | Active monitoring cards available |
+| Incubating | 33+ | Community contributions growing |
+| Help Wanted | 57+ | Open for community contributions |
+
+Every CNCF project card in the Marketplace includes metadata about the project's maturity level, category, and official documentation links.
+
+## Contributing to the Marketplace
+
+Anyone can contribute dashboards, card presets, or themes to the KubeStellar Console Marketplace.
+
+### How to Contribute
+
+1. **Fork** the [console-marketplace](https://github.com/kubestellar/console-marketplace) repository
+2. **Add your item** following the schema in the contributing guide
+3. **Submit a PR** — automated quality gates validate your contribution:
+   - Schema validation (required fields, correct types)
+   - Registry integrity check (no duplicates, valid references)
+   - Nightly auto-QA runs against the latest console build
+4. **Get reviewed** — maintainers review and merge
+
+### Quality Gates
+
+Every contribution passes through automated checks:
+
+- **Schema validation** — All required fields present with correct types
+- **Screenshot required** — Every item must include a preview image
+- **Registry integrity** — No conflicts with existing items
+- **Nightly QA** — Automated testing runs every night against the live console
+
+### Author Profiles
+
+Contributors get a public author profile in the Marketplace showing:
+
+- GitHub username and avatar
+- Number of contributions (dashboards, cards, themes)
+- Coins earned through the console rewards system
+- PRs merged to both the console and marketplace repos
+
+## Marketplace Registry
+
+The Marketplace registry is hosted at:
+
+```
+https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json
+```
+
+The registry is a JSON file containing all published items with their metadata, download URLs, and version history. The console fetches this registry on load and caches it locally for offline browsing.
+
+## Why a Marketplace for Multi-Cluster Kubernetes?
+
+Managing multiple Kubernetes clusters means monitoring dozens of CNCF projects, each with different metrics, alert patterns, and operational requirements. Building monitoring dashboards for every project in every cluster is repetitive work.
+
+The KubeStellar Console Marketplace eliminates this duplication:
+
+- **Install once, monitor everywhere** — Marketplace dashboards work across all connected clusters
+- **Community-tested** — Cards and dashboards are battle-tested by other multi-cluster operators
+- **Always current** — The community keeps dashboards updated as CNCF projects evolve
+- **Zero config** — No Prometheus rules, no Grafana JSON, no manual wiring — just install and go
+
+This is what makes KubeStellar Console different from single-cluster dashboards: every Marketplace item is designed for **multi-cluster operations** from day one, giving you fleet-wide visibility with AI-powered insights that save you time and tokens.

--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -1,12 +1,18 @@
 ---
-title: "Quick Start"
+title: "Quick Start — Get the Multi-Cluster Kubernetes Dashboard Running in Minutes"
 linkTitle: "Quick Start"
 weight: 1
 description: >
-  Get KubeStellar Console running in minutes
+  Get KubeStellar Console running in minutes. Start managing multi-cluster Kubernetes operations with AI Missions, 110+ monitoring cards, and fleet-wide deployment automation — no complex setup required.
+keywords:
+  - kubernetes quick start
+  - multi-cluster kubernetes setup
+  - kubernetes dashboard quick start
+  - kubernetes management tool getting started
+  - AI kubernetes operations setup
 ---
 
-# Quick Start
+# Quick Start — Multi-Cluster Kubernetes in Minutes
 
 Get KubeStellar Console running locally for development or evaluation.
 

--- a/docs/content/console/readme.md
+++ b/docs/content/console/readme.md
@@ -1,14 +1,27 @@
 ---
-title: "KubeStellar Console"
+title: "KubeStellar Console — AI-Powered Multi-Cluster Kubernetes Dashboard for Operations & Deployment"
 linkTitle: "Console"
 weight: 5
 description: >
-  AI-powered multi-cluster Kubernetes dashboard
+  KubeStellar Console is the open source multi-cluster Kubernetes dashboard with AI Missions that automate deployment, troubleshooting, and repair across your entire fleet. 110+ monitoring cards, 400+ CNCF project missions, a community marketplace, and a resolution knowledge base — all designed to save you time and tokens.
+keywords:
+  - multi-cluster kubernetes dashboard
+  - kubernetes multi-cluster management
+  - AI kubernetes operations
+  - kubernetes deployment automation
+  - multi-cluster monitoring
+  - kubernetes troubleshooting AI
+  - CNCF project management dashboard
+  - kubernetes fleet management
+  - AI missions kubernetes
+  - cloud native operations platform
+  - kubernetes observability dashboard
+  - multi-cluster deployment tool
 ---
 
-# KubeStellar Console
+# KubeStellar Console — Multi-Cluster Kubernetes Operations with AI
 
-**Your clusters, your way - AI that learns how you work**
+**Your clusters, your way — AI Missions that save you time and tokens**
 
 ![Main Dashboard](images/main-dashboard.png)
 
@@ -214,7 +227,9 @@ helm install ksc oci://ghcr.io/kubestellar/charts/console \
 - [Dashboards](dashboards.md) - All dashboards
 - [Cards](all-cards.md) - All 110+ cards
 - [Stats Blocks](stats-blocks.md) - All 93+ stats
-- [AI Features](ai-features.md) - Missions, diagnose, repair, card creation
+- [AI Features](ai-features.md) - AI Missions, diagnose, repair, card creation
+- [Marketplace](marketplace.md) - Community dashboards, cards, and themes for multi-cluster Kubernetes
+- [Knowledge Base](knowledge-base.md) - 400+ AI Mission prompts for CNCF project installation and repair
 - [Feedback System](feedback.md) - Bug-to-squash workflow
 - [Alerts](alerts.md) - Notifications and token usage
 - [Architecture](architecture.md) - How it works

--- a/docs/content/console/stats-blocks.md
+++ b/docs/content/console/stats-blocks.md
@@ -1,9 +1,15 @@
 ---
-title: "Stats Blocks"
+title: "93+ Stats Blocks — Multi-Cluster Kubernetes Metrics at a Glance"
 linkTitle: "Stats Blocks"
 weight: 8
 description: >
-  All 93+ stats blocks across dashboard types
+  93+ stats blocks for multi-cluster Kubernetes fleet metrics — cluster counts, pod status, resource utilization, alert summaries, cost breakdowns, and compliance scores. KubeStellar Console stats blocks give you fleet-wide metrics at a glance.
+keywords:
+  - kubernetes metrics dashboard
+  - multi-cluster kubernetes metrics
+  - kubernetes resource monitoring
+  - kubernetes fleet metrics
+  - kubernetes stats overview
 ---
 
 # Stats Blocks

--- a/docs/content/news/marketplace-and-kb-launch.md
+++ b/docs/content/news/marketplace-and-kb-launch.md
@@ -1,0 +1,94 @@
+---
+title: "KubeStellar Console Marketplace & Knowledge Base — 400+ AI Missions for Multi-Cluster Kubernetes"
+linkTitle: "Marketplace & KB Launch"
+weight: 3
+description: >
+  Announcing the KubeStellar Console Marketplace and Knowledge Base — a community-driven ecosystem of dashboards, monitoring cards, themes, and 400+ AI Mission prompts for installing, configuring, and repairing CNCF open source projects across multi-cluster Kubernetes environments.
+keywords:
+  - kubernetes marketplace launch
+  - AI kubernetes missions
+  - CNCF project automation
+  - multi-cluster kubernetes tools
+  - kubernetes knowledge base
+  - kubernetes operations automation
+---
+
+# KubeStellar Console Marketplace & Knowledge Base
+
+**March 2026**
+
+We're launching two new programs that expand KubeStellar Console from a multi-cluster Kubernetes dashboard into a complete operations platform: the **Marketplace** and the **Knowledge Base**.
+
+## The Marketplace: Community-Built Extensions for Multi-Cluster Kubernetes
+
+The [KubeStellar Console Marketplace](/docs/console/marketplace) is where teams discover, install, and share dashboards, monitoring cards, and themes for multi-cluster Kubernetes operations.
+
+**What you can install:**
+
+- **Dashboards** — Pre-built monitoring layouts for CNCF projects, security compliance, GPU fleet management, and more
+- **Card Presets** — Individual monitoring cards for specific projects (Prometheus, Istio, Cilium, Argo CD, and many more)
+- **Themes** — Visual themes that change the console's appearance
+
+Every Marketplace item is designed for multi-cluster operations from day one. Install once, monitor across all your clusters.
+
+**Contributing is open.** Fork the [console-marketplace](https://github.com/kubestellar/console-marketplace) repo, add your item, and submit a PR. Automated quality gates (schema validation, registry integrity, nightly QA) keep the Marketplace reliable.
+
+## The Knowledge Base: 400+ AI Mission Prompts
+
+The [Knowledge Base](/docs/console/knowledge-base) is the library behind KubeStellar Console's AI Missions system. It contains **400+ ready-to-use mission prompts** across two categories:
+
+### Installation Missions
+
+Step-by-step AI-guided installation of CNCF and open source projects across your multi-cluster fleet. Each mission includes prerequisites, installation steps, configuration options, verification, uninstall, and upgrade paths.
+
+**Covered CNCF categories:**
+- Observability: Prometheus, Grafana, Jaeger, OpenTelemetry, Fluentd, Thanos, Loki
+- Networking: Istio, Envoy, Cilium, Calico, Linkerd, CoreDNS, NATS
+- Security: OPA/Gatekeeper, Falco, cert-manager, Kyverno, Trivy, Vault
+- Storage: Longhorn, OpenEBS, Rook/Ceph, MinIO, Velero
+- GitOps: Argo CD, Flux CD, Helm, Kustomize, Crossplane
+- Runtime: containerd, Knative, KEDA, KubeVirt, Volcano
+- Infrastructure: Cluster API, Metal3, Tinkerbell, wasmCloud
+
+### Solution Missions
+
+Troubleshooting and repair prompts that start from a symptom and guide the AI through diagnosis and repair — across all affected clusters simultaneously.
+
+**What makes this different from ChatGPT or Stack Overflow:**
+
+1. **Multi-cluster aware** — Missions target specific clusters by name or label, run in parallel, and verify results fleet-wide
+2. **Context-rich** — The AI sees your actual cluster state (namespaces, resources, versions) and adapts the steps
+3. **Approval gates** — Every action requires your approval before execution
+4. **Resolution memory** — Solutions are saved to a personal or shared Knowledge Base for instant reuse
+5. **Token efficient** — Structured mission prompts use fewer tokens than free-form chat
+
+## What This Means for Multi-Cluster Kubernetes Operations
+
+Traditional Kubernetes operations involve:
+
+- Googling error messages and reading Stack Overflow
+- Manually applying fixes one cluster at a time
+- Building monitoring dashboards from scratch for each project
+- Maintaining internal runbooks that go stale
+
+KubeStellar Console's Marketplace and Knowledge Base replace all of this:
+
+- **Marketplace** eliminates dashboard building — install community-tested monitoring in one click
+- **Knowledge Base** eliminates manual troubleshooting — AI Missions guide you through diagnosis and repair
+- **Resolution memory** eliminates stale runbooks — every successful fix is saved and reusable
+- **Multi-cluster execution** eliminates per-cluster work — run missions across your entire fleet
+
+**The result:** Multi-cluster Kubernetes operations that save you time and tokens at every step.
+
+## Get Started
+
+- [Browse the Marketplace](/docs/console/marketplace)
+- [Explore the Knowledge Base](/docs/console/knowledge-base)
+- [Try KubeStellar Console](https://console.kubestellar.io) — starts in demo mode, no installation needed
+- [Install locally](/docs/console/quickstart) — running in minutes
+
+## Links
+
+- [KubeStellar Console Repository](https://github.com/kubestellar/console)
+- [Marketplace Repository](https://github.com/kubestellar/console-marketplace)
+- [KubeStellar Project](https://kubestellar.io)

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -210,6 +210,13 @@ const NAV_STRUCTURE_CONSOLE: Array<{ title: string; items: NavItem[] }> = [
       { 'Alerts': 'alerts.md' },
       { 'Feedback System': 'feedback.md' },
     ]
+  },
+  {
+    title: 'Programs',
+    items: [
+      { 'Marketplace': 'marketplace.md' },
+      { 'Knowledge Base': 'knowledge-base.md' },
+    ]
   }
 ]
 
@@ -350,16 +357,6 @@ const NAV_STRUCTURE_COMMUNITY: Array<{ title: string; items: NavItem[] }> = [
     title: 'Community',
     items: [
       { 'Get Involved': 'community/index.md' },
-      {
-        'Partners': [
-          { 'ArgoCD': 'community/partners/argocd.md' },
-          { 'Turbonomic': 'community/partners/turbonomic.md' },
-          { 'MVI': 'community/partners/mvi.md' },
-          { 'FluxCD': 'community/partners/fluxcd.md' },
-          { 'OpenZiti': 'community/partners/openziti.md' },
-          { 'Kyverno': 'community/partners/kyverno.md' }
-        ]
-      }
     ]
   }
 ]
@@ -369,6 +366,7 @@ const NAV_STRUCTURE_NEWS: Array<{ title: string; items: NavItem[] }> = [
     title: 'News',
     items: [
       { 'Latest News': 'news/index.md' },
+      { 'Marketplace & KB Launch': 'news/marketplace-and-kb-launch.md' },
       { 'KubeStellar Console Announcement': 'news/kubestellar-console-announcement.md' }
     ]
   }


### PR DESCRIPTION
## Summary
- **New: Marketplace docs** — Community dashboards, card presets, and themes for multi-cluster Kubernetes. Covers browsing, installing, CNCF project coverage, contributing, quality gates, and author profiles.
- **New: Knowledge Base docs** — 400+ AI Mission prompts for installing, configuring, troubleshooting, and repairing CNCF projects across multi-cluster fleets. Covers installation missions, solution missions, resolution memory, and all supported projects by category.
- **New: News article** — Marketplace & KB launch announcement with SEO-rich content
- **Removed: Partners sub-section** from Community nav (ArgoCD, Turbonomic, MVI, FluxCD, OpenZiti, Kyverno)
- **Added: Programs section** to Console nav with Marketplace and Knowledge Base links
- **SEO optimization** across all 10 console doc pages — keyword-rich titles, meta descriptions, and keywords arrays targeting multi-cluster operations, AI missions, deployment automation, CNCF project management

## SEO Keywords Targeted
- multi-cluster kubernetes dashboard / management / operations
- AI missions kubernetes / AI kubernetes operations
- kubernetes deployment automation / fleet management
- CNCF project monitoring / installation / troubleshooting
- kubernetes observability / monitoring cards / security dashboard
- saves time and tokens (brand phrase)

## Test plan
- [ ] `/docs/console/marketplace` renders the Marketplace documentation
- [ ] `/docs/console/knowledge-base` renders the Knowledge Base documentation
- [ ] `/docs/news/marketplace-and-kb-launch` renders the news article
- [ ] Partners no longer appears in the Community sidebar section
- [ ] Console sidebar shows new "Programs" section with Marketplace and Knowledge Base
- [ ] All existing console doc pages still render correctly
- [ ] Build passes with 516+ static paths