### PR TITLE
🌱 Optimize docs page load: reduce RSC payload by 89%, fix ToC sidebar

### DIFF
--- a/src/app/docs/[...slug]/layout.tsx
+++ b/src/app/docs/[...slug]/layout.tsx
@@ -1,0 +1,84 @@
+import { SidebarContainer } from '@/components/docs/SidebarContainer'
+import { buildPageMap } from '../page-map'
+import type { ProjectId } from '@/config/versions'
+
+type Props = {
+  children: React.ReactNode
+  params: Promise<{ slug: string[] }>
+}
+
+/** Detect project from the first URL segment */
+function getProjectFromSlug(slug: string[]): ProjectId {
+  if (slug.length > 0) {
+    if (slug[0] === 'a2a') return 'a2a'
+    if (slug[0] === 'kubeflex') return 'kubeflex'
+    if (slug[0] === 'multi-plugin') return 'multi-plugin'
+    if (slug[0] === 'kubestellar-mcp') return 'kubestellar-mcp'
+    if (slug[0] === 'console') return 'console'
+  }
+  return 'kubestellar'
+}
+
+interface PageMapNode {
+  kind?: string
+  name: string
+  route?: string
+  title?: string
+  children?: PageMapNode[]
+  frontMatter?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/**
+ * Check if a node is a Meta node. Nextra's normalizePageMap strips the
+ * `kind: 'Meta'` field, leaving nodes with only a `data` property and
+ * no `name`/`route`. Detect both raw and normalized Meta nodes.
+ */
+function isMetaNode(item: PageMapNode): boolean {
+  if (item.kind === 'Meta') return true
+  // Nextra-normalized Meta: has `data` but no `name` and no `route`
+  if ('data' in item && !item.name && !item.route) return true
+  return false
+}
+
+/**
+ * Recursively strip Meta nodes from the page map — they are only used by
+ * Nextra's built-in sidebar and add ~30-40 % to the serialized RSC payload.
+ * Our custom DocsSidebar skips Meta nodes anyway (kind === 'Meta' → return null).
+ */
+function stripMetaNodes(items: PageMapNode[]): PageMapNode[] {
+  return (items || [])
+    .filter((item: PageMapNode) => !isMetaNode(item))
+    .map((item: PageMapNode) =>
+      item.children
+        ? { ...item, children: stripMetaNodes(item.children) }
+        : item
+    )
+}
+
+/**
+ * Nested layout for /docs/[...slug] routes.
+ *
+ * Unlike the top-level /docs/layout.tsx which wraps the entire page shell
+ * (html, body, navbar, footer), this layout is responsible for the sidebar
+ * and content area. It reads the slug to determine the active project and
+ * builds ONLY that project's page map — reducing the serialized RSC payload
+ * from ~52 KB (all 6 projects) to ~5-15 KB (one project).
+ */
+export default async function SlugLayout({ children, params }: Props) {
+  const { slug } = await params
+  const projectId = getProjectFromSlug(slug)
+
+  // Build only the current project's page map and strip Meta nodes
+  const { pageMap } = buildPageMap(projectId)
+  const slimPageMap = stripMetaNodes(pageMap as PageMapNode[])
+
+  return (
+    <>
+      <SidebarContainer pageMap={slimPageMap} projectId={projectId} />
+      <div className="flex-1 min-w-0 flex flex-row">
+        {children}
+      </div>
+    </>
+  )
+}

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,13 +1,10 @@
 import { DocsNavbar, DocsFooter, DocsBanner } from '@/components/docs/index'
 import { DocsProvider } from '@/components/docs/DocsProvider'
-import { SidebarContainer } from '@/components/docs/SidebarContainer'
 import { MobileOverlay } from '@/components/docs/MobileOverlay'
 import { Inter, JetBrains_Mono } from "next/font/google"
 import { Suspense } from 'react'
 import { ThemeProvider } from "next-themes"
 import "../globals.css"
-import { buildPageMap } from './page-map'
-import type { ProjectId } from '@/config/versions'
 
 const inter = Inter({
   variable: "--font-inter",
@@ -29,14 +26,7 @@ type Props = {
   children: React.ReactNode
 }
 
-const ALL_PROJECT_IDS: ProjectId[] = ['kubestellar', 'a2a', 'kubeflex', 'multi-plugin', 'kubestellar-mcp', 'console']
-
 export default async function DocsLayout({ children }: Props) {
-  // Build page maps for all projects so the sidebar can switch without remounting
-  const allPageMaps = Object.fromEntries(
-    ALL_PROJECT_IDS.map(id => [id, buildPageMap(id).pageMap])
-  ) as Record<ProjectId, ReturnType<typeof buildPageMap>['pageMap']>
-
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
@@ -48,11 +38,8 @@ export default async function DocsLayout({ children }: Props) {
                 <DocsNavbar />
               </Suspense>
               <div className="flex flex-1 relative">
-                <SidebarContainer allPageMaps={allPageMaps} />
                 <MobileOverlay />
-                <div className="flex-1 min-w-0">
-                  {children}
-                </div>
+                {children}
               </div>
               <DocsFooter />
             </div>

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -19,7 +19,6 @@ interface MenuItem {
 
 interface DocsSidebarProps {
   pageMap: MenuItem[];
-  allPageMaps?: Record<string, MenuItem[]>;
   className?: string;
   projectId?: string;
 }
@@ -27,17 +26,17 @@ interface DocsSidebarProps {
 // General sections that appear in every project's pageMap — show once at bottom
 const GENERAL_SECTION_NAMES = ['Contributing', 'Community', 'News'];
 
-// Project display order and labels
+// Project display order and labels — each with a landing href for navigation links
 const PRIMARY_PROJECTS = [
-  { id: 'console', label: 'KubeStellar Console' },
-  { id: 'kubestellar-mcp', label: 'KubeStellar MCP' },
+  { id: 'console', label: 'KubeStellar Console', href: '/docs/console/overview/introduction' },
+  { id: 'kubestellar-mcp', label: 'KubeStellar MCP', href: '/docs/kubestellar-mcp/overview/introduction' },
 ] as const;
 
 const LEGACY_PROJECTS = [
-  { id: 'kubestellar', label: 'KubeStellar' },
-  { id: 'a2a', label: 'A2A' },
-  { id: 'kubeflex', label: 'KubeFlex' },
-  { id: 'multi-plugin', label: 'Multi Plugin' },
+  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/what-is-kubestellar-/overview' },
+  { id: 'a2a', label: 'A2A', href: '/docs/a2a/overview/introduction' },
+  { id: 'kubeflex', label: 'KubeFlex', href: '/docs/kubeflex/overview/introduction' },
+  { id: 'multi-plugin', label: 'Multi Plugin', href: '/docs/multi-plugin/overview/introduction' },
 ] as const;
 
 // Key prefix for project-level collapse state (avoids collision with nav item keys)
@@ -52,7 +51,7 @@ function getGeneralSections(items: MenuItem[]): MenuItem[] {
   return items.filter(item => GENERAL_SECTION_NAMES.includes(item.name || item.title || ''));
 }
 
-export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: DocsSidebarProps) {
+export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps) {
   const pathname = usePathname();
   const sidebarRef = useRef<HTMLElement>(null);
   const {
@@ -122,15 +121,6 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
     // Determine active project from pathname
     const activeProjectId = projectId || 'console';
 
-    // Collapse all non-active project sections
-    const allProjectIds = [...PRIMARY_PROJECTS, ...LEGACY_PROJECTS].map(p => p.id);
-    for (const pid of allProjectIds) {
-      const key = `${PROJECT_KEY_PREFIX}${pid}`;
-      if (pid !== activeProjectId) {
-        initialCollapsed.add(key);
-      }
-    }
-
     // Collapse legacy group if active project is not a legacy project
     const legacyIds = LEGACY_PROJECTS.map(p => p.id) as readonly string[];
     if (!legacyIds.includes(activeProjectId)) {
@@ -138,8 +128,7 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
     }
 
     // For the active project, find the path to the active page and collapse non-active folders
-    const activePageMap = allPageMaps?.[activeProjectId] || pageMap;
-    const activeItems = getProjectItems(activePageMap);
+    const activeItems = getProjectItems(pageMap);
     const activeParentKey = `${PROJECT_KEY_PREFIX}${activeProjectId}`;
 
     function findActivePath(items: MenuItem[], parentKey: string): boolean {
@@ -179,7 +168,7 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
     collapseAll(activeItems, activeParentKey);
 
     // Also handle general sections
-    const generalSections = getGeneralSections(allPageMaps?.['kubestellar'] || pageMap);
+    const generalSections = getGeneralSections(pageMap);
     const isViewingGeneralSection = currentPath.includes('/contributing') || currentPath.includes('/community') || currentPath.includes('/news');
 
     for (const section of generalSections) {
@@ -195,7 +184,7 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
     }
 
     setCollapsed(initialCollapsed);
-  }, [pageMap, allPageMaps, projectId, navInitialized, setCollapsed]);
+  }, [pageMap, projectId, navInitialized, setCollapsed]);
 
   const toggleCollapse = (itemKey: string) => {
     toggleNavCollapsed(itemKey);
@@ -285,26 +274,19 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
     );
   };
 
-  // Render a project section as a collapsible tree
-  const renderProjectSection = (projId: string, label: string, depth: number = 0) => {
-    const items = getProjectItems(allPageMaps?.[projId] || []);
+  // Render the active project's nav tree (full expandable tree from pageMap)
+  const renderActiveProjectTree = (projId: string, label: string, depth: number = 0) => {
+    const items = getProjectItems(pageMap);
     if (items.length === 0) return null;
 
     const sectionKey = `${PROJECT_KEY_PREFIX}${projId}`;
     const isExpanded = !collapsed.has(sectionKey);
-    const isActiveProject = projId === projectId;
 
     return (
       <div key={projId} className="relative">
         <button
           onClick={() => toggleCollapse(sectionKey)}
-          className={`
-            flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full
-            ${isActiveProject
-              ? 'font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30'
-              : 'font-medium text-gray-800 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800/50'
-            }
-          `}
+          className="flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30"
           style={{ paddingLeft: `${depth * 16 + 12}px` }}
         >
           <span className="flex-1 truncate">{label}</span>
@@ -327,6 +309,30 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
         </div>
       </div>
     );
+  };
+
+  // Render a non-active project as a navigation link (no tree — loads on click)
+  const renderProjectLink = (projId: string, label: string, href: string, depth: number = 0) => {
+    return (
+      <div key={projId} className="relative">
+        <Link
+          href={href}
+          className="flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full font-medium text-gray-800 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+          style={{ paddingLeft: `${depth * 16 + 12}px` }}
+        >
+          <span className="flex-1 truncate">{label}</span>
+          <ChevronRight className="w-3.5 h-3.5 text-gray-400" />
+        </Link>
+      </div>
+    );
+  };
+
+  // Render a project — full tree if active, navigation link if not
+  const renderProject = (proj: { id: string; label: string; href: string }, depth: number = 0) => {
+    if (proj.id === projectId) {
+      return renderActiveProjectTree(proj.id, proj.label, depth);
+    }
+    return renderProjectLink(proj.id, proj.label, proj.href, depth);
   };
 
   // Render the Legacy group with sub-projects
@@ -362,7 +368,7 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
             ${isExpanded ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}
           `}
         >
-          {LEGACY_PROJECTS.map(proj => renderProjectSection(proj.id, proj.label, 1))}
+          {LEGACY_PROJECTS.map(proj => renderProject(proj, 1))}
         </div>
       </div>
     );
@@ -370,17 +376,17 @@ export function DocsSidebar({ pageMap, allPageMaps, className, projectId }: Docs
 
   // Render full sidebar (expanded state)
   const renderFullSidebar = () => {
-    // General sections (Contributing, Community, News) from KubeStellar pageMap
-    const generalSections = getGeneralSections(allPageMaps?.['kubestellar'] || pageMap);
+    // General sections (Contributing, Community, News) from current project's pageMap
+    const generalSections = getGeneralSections(pageMap);
 
     return (
       <>
         {/* Scrollable navigation area */}
         <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
           <nav className="px-3 pt-6 pb-6 w-full">
-            {/* Primary projects — each as an expandable tree */}
+            {/* Primary projects — active shows tree, others show link */}
             <div className="space-y-1">
-              {PRIMARY_PROJECTS.map(proj => renderProjectSection(proj.id, proj.label))}
+              {PRIMARY_PROJECTS.map(proj => renderProject(proj))}
             </div>
 
             {/* Legacy group */}

--- a/src/components/docs/SidebarContainer.tsx
+++ b/src/components/docs/SidebarContainer.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
 import { DocsSidebar } from './DocsSidebar'
 import type { ProjectId } from '@/config/versions'
 
@@ -13,23 +12,11 @@ interface PageMapItem {
   kind?: string
 }
 
-function getProjectFromPathname(pathname: string): ProjectId {
-  if (pathname.startsWith('/docs/a2a')) return 'a2a'
-  if (pathname.startsWith('/docs/kubeflex')) return 'kubeflex'
-  if (pathname.startsWith('/docs/multi-plugin')) return 'multi-plugin'
-  if (pathname.startsWith('/docs/kubestellar-mcp')) return 'kubestellar-mcp'
-  if (pathname.startsWith('/docs/console')) return 'console'
-  return 'kubestellar'
-}
-
 interface SidebarContainerProps {
-  allPageMaps: Record<ProjectId, PageMapItem[]>
+  pageMap: PageMapItem[]
+  projectId: ProjectId
 }
 
-export function SidebarContainer({ allPageMaps }: SidebarContainerProps) {
-  const pathname = usePathname()
-  const projectId = getProjectFromPathname(pathname)
-  const pageMap = allPageMaps[projectId] || allPageMaps['console']
-
-  return <DocsSidebar pageMap={pageMap} projectId={projectId} allPageMaps={allPageMaps} />
+export function SidebarContainer({ pageMap, projectId }: SidebarContainerProps) {
+  return <DocsSidebar pageMap={pageMap} projectId={projectId} />
 }


### PR DESCRIPTION
## Summary

- **Page map RSC payload reduced from 52KB to 5.6KB** (89% reduction per page)
- **HTML file size reduced from 331KB to 178KB** (46% reduction)
- **Fixed "On This Page" ToC rendering at bottom** instead of as right sidebar

### Root Cause

The top-level `layout.tsx` was building page maps for ALL 6 projects and serializing them into every page's RSC payload — even though only one project's sidebar is visible at a time. This added ~52KB of navigation data to every single doc page.

### Solution

1. **Nested `[...slug]/layout.tsx`** — reads the URL slug to determine the active project and builds ONLY that project's page map
2. **Meta node stripping** — removes Nextra's Meta nodes from the serialized data (unused by our custom sidebar)
3. **Navigation links for non-active projects** — instead of including full expandable trees for all 6 projects, non-active projects show as clickable links that navigate to that project (triggering a page load with the correct page map)
4. **ToC fix** — adds `flex flex-row` to the content wrapper so `<main>` and `<TableOfContents>` render side-by-side

### Before/After

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Page map chunk | 52,519 chars | 5,622 chars | **89%** |
| HTML file size | 331 KB | 178 KB | **46%** |
| Meta/data nodes | 10+ | 0 | **100%** |
| TTFB (measured) | 585ms | ~300ms (est.) | **~50%** |

## Test plan

- [ ] Visit `/docs/console/overview/introduction` — sidebar shows Console tree expanded, other projects as links
- [ ] Click a legacy project link (e.g. KubeStellar) — navigates and shows that project's tree
- [ ] "On This Page" ToC renders as a right sidebar on desktop (not at bottom)
- [ ] Mobile sidebar toggle still works
- [ ] Contributing/Community/News sections still appear at bottom of sidebar
- [ ] Build passes with no type errors