### PR TITLE
fix: broken link to KubeStellar overview page

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -222,7 +222,7 @@
     },
     {
       "title": "KubeStellar",
-      "href": "/docs/what-is-kubestellar/overview",
+      "href": "/docs/readme",
       "description": "Multi-cluster configuration management",
       "secondary": true
     },


### PR DESCRIPTION
## Description

Fixed broken link in `public/config/shared.json`.

The link `/docs/what-is-kubestellar/overview` was broken. Changed to `/docs/readme` which is the correct path for the KubeStellar overview page.

## Related Issue

Fixes #1243