### PR TITLE
🐛fix: correct href for KubeStellar in legacy projects

### DIFF
--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -33,7 +33,7 @@ const PRIMARY_PROJECTS = [
 ] as const;
 
 const LEGACY_PROJECTS = [
-  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/what-is-kubestellar-/overview' },
+  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/what-is-kubestellar/overview' },
   { id: 'a2a', label: 'A2A', href: '/docs/a2a/overview/introduction' },
   { id: 'kubeflex', label: 'KubeFlex', href: '/docs/kubeflex/overview/introduction' },
   { id: 'multi-plugin', label: 'Multi Plugin', href: '/docs/multi-plugin/overview/introduction' },


### PR DESCRIPTION
### 📌 Fixes

Fixes #1243

---

### 📝 Summary of Changes

- Fixed a broken sidebar link for the KubeStellar legacy project.
- Updated the href to point to the correct route: `/docs/what-is-kubestellar/overview`.
- No other changes were made.

---

### Changes Made

- [x] Fixed incorrect href in `DocsSidebar.tsx` for the KubeStellar legacy project.
- [ ] No refactoring or additional updates.
- [ ] No tests added (not applicable for this UI fix).

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (not applicable).
- [ ] I have updated the documentation (not applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---

### Screenshots or Logs (if applicable)
<img width="1918" height="1017" alt="2026-03-08_14-11" src="https://github.com/user-attachments/assets/558e8ba1-d0c9-4e79-8005-3752481fea70" />

Before


<img width="1912" height="1011" alt="2026-03-08_14-13" src="https://github.com/user-attachments/assets/db188891-149f-4774-a911-d442eaadc248" />
After


---

### 👀 Reviewer Notes

This PR only fixes a broken link in the sidebar for the KubeStellar legacy project. No other files or functionality were changed.
