### PR TITLE
🌱 Increase link checker timeout to 30 minutes

### DIFF
--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -25,7 +25,7 @@
 # distinguishes real broken links from transient failures, and creates/updates
 # a GitHub issue with actionable results.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"8cd35c3b0b951b75db54e598e0713cd35d85d4a027f8acf01c3e235478ab6ab5","compiler_version":"v0.53.4"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"d03f5fd9b34896e4383341fceced532159442456541b92295cb86427793363da","compiler_version":"v0.53.4"}
 
 name: "Link Checker"
 "on":
@@ -674,7 +674,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 15
+        timeout-minutes: 30
         run: |
           set -o pipefail
           # shellcheck disable=SC1003
@@ -1032,7 +1032,7 @@ jobs:
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_TIMEOUT_MINUTES: "15"
+          GH_AW_TIMEOUT_MINUTES: "30"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -27,7 +27,7 @@ tools:
   web-fetch:
   bash: [ ":*" ]
 
-timeout-minutes: 15
+timeout-minutes: 30
 ---
 
 # Link Checker


### PR DESCRIPTION
## Summary
- Link checker timed out at 15 minutes scanning all external URLs in the docs repo
- Increase timeout to 30 minutes to allow full scan completion
- Typo checker succeeded at 6.5 minutes — no change needed

## Test plan
- [ ] Manually trigger Link Checker after merge to verify it completes