### PR TITLE
🐛fix(ui): add custom dark variant support in globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --breakpoint-lgcustom: 900px;
   --breakpoint-xl: 1200px;


### PR DESCRIPTION
### 📌 Fixes

Fixes #1247

---

### 📝 Summary of Changes

- Fixed sidebar elements being nearly invisible in light mode.
- Root cause: Tailwind v4 requires an explicit `@custom-variant dark` directive in CSS to use class-based dark mode. Without it, the `dark:` prefix defaults to `prefers-color-scheme`, causing dark-mode text colors to apply on light backgrounds when the OS theme differs from the site theme.

---

### Changes Made

- [x] Added `@custom-variant dark (&:where(.dark, .dark *));` to `globals.css` so Tailwind v4 `dark:` classes respect the `.dark` class on `<html>` (set by next-themes).

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (not applicable).
- [ ] I have updated the documentation (not applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---

### Screenshots or Logs (if applicable)

<img width="1912" height="1012" alt="2026-03-10_16-09" src="https://github.com/user-attachments/assets/c69777b0-da53-4504-b3be-5754fce78622" />

Before

<img width="1914" height="1010" alt="2026-03-10_16-10" src="https://github.com/user-attachments/assets/e9f27b07-c8f0-4449-a73f-f786597c20e6" />

After
---

### 👀 Reviewer Notes

The core fix is a single line in `globals.css`. Without `@custom-variant dark`, Tailwind v4 uses `@media (prefers-color-scheme: dark)` instead of the `.dark` class, which means toggling the theme in the UI has no effect on Tailwind dark: classes.