### PR TITLE
🐛 Fix MDX sanitizer stripping prose words starting with "on"

### DIFF
--- a/src/lib/transformMdx.ts
+++ b/src/lib/transformMdx.ts
@@ -38,8 +38,11 @@ export function convertHtmlScriptsToJsxComments(input: string): string {
   s = s.replace(/<script\b[^>]*\/>/gi, "");
   s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
 
+  // Strip HTML event-handler attributes (onclick, onload, etc.).
+  // Require `=` after the attribute name so normal prose words like
+  // "onto", "once", "one", "only" are NOT removed.
   s = s.replace(
-    /\s+on[a-z]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|\{[^}]*\}|[^\s>]+))?/gi,
+    /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|\{[^}]*\}|[^\s>]+)/gi,
     ""
   );
   s = s.replace(/\sstyle\s*=\s*(?:"[\s\S]*?"|'[\s\S]*?')/gi, "");


### PR DESCRIPTION
## Summary

- **Root cause**: The `on[a-z]+` regex in `transformMdx.ts` (line 42) was intended to strip HTML event-handler attributes (`onclick`, `onload`, etc.) but used an optional `=` match (`(?:...)?`), causing it to also strip normal English words like "onto", "once", "one", "only" from all rendered docs pages
- **Fix**: Make the `=` sign mandatory in the regex so only actual `attribute=value` patterns are removed
- **Impact**: Every docs page containing words starting with "on" was affected — the deploy page was the most visibly broken (reported in #1262), but this was a site-wide rendering bug

### Before (live site)
> "Deploy workloads by dragging them cluster groups"
> "Cluster groups make it easy to deploy the same workload to multiple clusters at."

### After (fix)
> "Deploy workloads by dragging them **onto** cluster groups"
> "Cluster groups make it easy to deploy the same workload to multiple clusters at **once**."

Fixes #1262

## Test plan

- [x] Verified regex fix with unit tests (onclick/onload/onmouseover still stripped; onto/once/one/only/ongoing/online preserved)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Verify deploy preview renders the deploy page correctly