### PR TITLE
fix: add missing kubectl-multi intro page

### DIFF
--- a/docs/content/multi-plugin/overview/introduction.md
+++ b/docs/content/multi-plugin/overview/introduction.md
@@ -1,6 +1,6 @@
 # kubectl-multi Overview
 
-**kubectl-multi** is a comprehensive kubectl plugin for multi-cluster operations with KubeStellar. This plugin extends kubectl to work seamlessly across all KubeStellar managed clusters, providing unified views and operations while filtering out workflow staging clusters (WDS).
+**kubectl-multi** is a comprehensive kubectl plugin for multi-cluster operations with KubeStellar. This plugin extends kubectl to work seamlessly across all KubeStellar managed clusters, providing unified views and operations while filtering out Workload Description Space (WDS) clusters.
 
 ## What is kubectl-multi?
 


### PR DESCRIPTION
hey, saw the broken link issue and noticed the intro page was missing. added the introduction.md file to fix the link from /docs/multi-plugin/overview/introduction.

let me know if you need any changes!