### PR TITLE
📖 Fix #1275, #1274, #1273: Consolidate docs, add ocm-status-addon, fix nav

### DIFF
--- a/docs/content/console/architecture.md
+++ b/docs/content/console/architecture.md
@@ -13,6 +13,8 @@ keywords:
 
 # Architecture
 
+> This is the canonical architecture reference for KubeStellar Console. The [console README](https://github.com/kubestellar/console#architecture) links here.
+
 KubeStellar Console uses a modern, modular architecture designed for extensibility and real-time updates.
 
 ## The 7 Components
@@ -37,43 +39,24 @@ The console consists of 7 components working together. See [Configuration](confi
 
 ## System Overview
 
-```
-  ┌──────────────────┐
-  │  GitHub OAuth    │  ← OAuth Authorization Server (user identity only)
-  │  (Authorization  │
-  │   Server)        │
-  └────────┬─────────┘
-           │ 3. issues access token
-           │ (in exchange for auth code)
-           │
-┌──────────▼──────────────────────────────────────────────────────┐
-│                  KubeStellar Console Backend (:8080)              │
-│                                                                  │
-│   API Handlers    Auth (OAuth Client)   Claude AI   WebSocket    │
-│   (REST/WS)       exchanges code→token  (Proactive) Events       │
-│                   issues session JWT                             │
-└──────────┬──────────────────────────┬───────────────────────────┘
-           │ 1. initiates OAuth flow   │
-           │    + REST/WebSocket API   │ uses kubeconfig credentials
-           ▼                           ▼
-┌────────────────────┐    ┌────────────────────────────────────────┐
-│   User Browser     │    │           MCP Bridge                   │
-│   React + Vite SPA │    │  kubestellar-ops + kubestellar-deploy  │
-│         │          │    │  (Claude Code Plugins)                 │
-│  2. user authorizes│    └───────────────────┬────────────────────┘
-│     on GitHub,     │                        │
-│     gets JWT back  │                        │ kubeconfig
-│         │          │                        ▼
-│         │ WebSocket│         ┌────────────────────────────────────────┐
-└─────────┼──────────┘         │          Kubernetes Clusters           │
-          │                    │  [cluster-1]  [cluster-2]  ...         │
-          ▼                    └────────────────────────────────────────┘
-┌────────────────────┐                        ▲
-│   kc-agent (:8585) │  kubectl / kubeconfig  │
-│   Local Agent      │────────────────────────┘
-│   (runs on user's  │
-│    machine)        │
-└────────────────────┘
+```mermaid
+graph TB
+    GitHub["GitHub OAuth<br/>(Authorization Server)"]
+    Backend["KubeStellar Console Backend :8080<br/>API Handlers · Auth (OAuth Client) · Claude AI · WebSocket"]
+    Browser["User Browser<br/>React + Vite SPA"]
+    MCP["MCP Bridge<br/>kubestellar-ops + kubestellar-deploy"]
+    K8s["Kubernetes Clusters<br/>cluster-1 · cluster-2 · ..."]
+    Agent["kc-agent :8585<br/>Local Agent (user's machine)"]
+
+    Browser -- "1. initiates OAuth flow" --> Backend
+    Browser -- "2. user authorizes on GitHub" --> GitHub
+    GitHub -- "3. issues access token<br/>(in exchange for auth code)" --> Backend
+    Backend -- "session JWT" --> Browser
+    Browser -- "WebSocket" --> Agent
+    Backend -- "REST / WebSocket API" --> Browser
+    Backend -- "kubeconfig credentials" --> MCP
+    MCP -- "kubeconfig" --> K8s
+    Agent -- "kubectl / kubeconfig" --> K8s
 ```
 
 **Credential flows:**

--- a/docs/content/kubestellar/ocm-status-addon-intro.md
+++ b/docs/content/kubestellar/ocm-status-addon-intro.md
@@ -1,0 +1,24 @@
+# OCM Status Addon
+
+The [OCM Status Addon](https://github.com/kubestellar/ocm-status-addon) is a status reporting add-on for [Open Cluster Management](https://open-cluster-management.io/concepts/addon/) (OCM). It enables KubeStellar to collect and report the status of workloads running on managed clusters back to the hub (the KubeStellar ITS).
+
+## How It Works
+
+The OCM Status Addon consists of two roles packaged in a single container image:
+
+- **Controller** — runs in the OCM hub (the KubeStellar ITS). Manages the lifecycle of the agent on each managed cluster.
+- **Agent** — runs on each managed cluster (WEC). Watches workload resources and reports their status back to the hub.
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| **Container image** | [ghcr.io/kubestellar/ocm-status-addon](https://github.com/orgs/kubestellar/packages/container/package/ocm-status-addon) |
+| **Helm chart** | [ghcr.io/kubestellar/ocm-status-addon-chart](https://github.com/orgs/kubestellar/packages/container/package/ocm-status-addon-chart) |
+| **Source code** | [github.com/kubestellar/ocm-status-addon](https://github.com/kubestellar/ocm-status-addon) |
+
+## Relationship to KubeStellar
+
+The OCM Status Addon is deployed automatically when an ITS (Inventory and Transport Space) is created via the [Core Helm chart](core-chart.md). It is a required component for status reporting in the legacy KubeStellar architecture.
+
+For more details on packaging, container images, and the Helm chart, see [Packaging and Delivery](packaging.md#ocm-status-addon).

--- a/docs/content/legacy-components.md
+++ b/docs/content/legacy-components.md
@@ -1,0 +1,17 @@
+# Legacy Components
+
+The KubeStellar project includes several legacy components that form the foundation of the original multi-cluster configuration management system. These components are still maintained for existing deployments but are being superseded by the [KubeStellar Console](/docs/console/overview/introduction) and [KubeStellar MCP](/docs/kubestellar-mcp/overview/introduction) for new installations.
+
+## Components
+
+| Component | Description |
+|-----------|-------------|
+| [**KubeStellar**](/docs/what-is-kubestellar/overview) | The core multi-cluster configuration management engine using OCM transport |
+| [**A2A**](/docs/a2a/overview/introduction) | Agent-to-Agent protocol support for KubeStellar |
+| [**KubeFlex**](/docs/kubeflex/overview/introduction) | Lightweight Kube API Server instances and control planes as a service |
+| [**Multi-Plugin**](/docs/multi-plugin/overview/introduction) | kubectl plugin for managing multiple KubeStellar control planes |
+
+## When to Use Legacy vs. New Components
+
+- **New deployments**: Use [KubeStellar Console](https://console.kubestellar.io) with the [KubeStellar MCP](/docs/kubestellar-mcp/overview/introduction) plugin for AI-powered multi-cluster management.
+- **Existing deployments**: Legacy components continue to work and are maintained. Migration guides will be provided as the new architecture stabilizes.

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -228,6 +228,7 @@ const NAV_STRUCTURE_KUBESTELLAR: Array<{ title: string; items: NavItem[] }> = [
     items: [
       { 'Overview': 'readme.md' },
       { 'Architecture': 'kubestellar/architecture.md' },
+      { 'OCM Status Addon': 'kubestellar/ocm-status-addon-intro.md' },
       { 'Release Notes': 'kubestellar/release-notes.md' },
       { 'Roadmap': 'kubestellar/roadmap.md' }
     ]
@@ -532,6 +533,11 @@ export function buildPageMap(projectId: ProjectId = 'kubestellar') {
   // Route map entry only - sidebar renders this separately above projects
   if (projectId === 'kubestellar' && allDocFiles.includes('intro.md')) {
     routeMap['introduction'] = 'intro.md'
+  }
+
+  // Add legacy components overview page (accessible at /docs/legacy-components)
+  if (allDocFiles.includes('legacy-components.md')) {
+    routeMap['legacy-components'] = 'legacy-components.md'
   }
 
   // Add top-level meta - only include our defined navigation structure

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -51,6 +51,20 @@ function getGeneralSections(items: MenuItem[]): MenuItem[] {
   return items.filter(item => GENERAL_SECTION_NAMES.includes(item.name || item.title || ''));
 }
 
+// Find the first navigable route in a menu item's children
+function getFirstChildRoute(item: MenuItem): string | undefined {
+  if (!item.children) return undefined;
+  for (const child of item.children) {
+    if (child.kind === 'Meta' || child.kind === 'Separator') continue;
+    if (child.route && child.route !== '#') return child.route;
+    const nested = getFirstChildRoute(child);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+const LEGACY_OVERVIEW_HREF = '/docs/legacy-components';
+
 export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps) {
   const pathname = usePathname();
   const sidebarRef = useRef<HTMLElement>(null);
@@ -221,22 +235,49 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
           )}
 
           {/* Folder or Page */}
-          {hasChildren ? (
-            <button
-              onClick={() => toggleCollapse(itemKey)}
-              className="flex items-center gap-2 px-3 py-1.5 text-[13px] font-normal text-gray-700 dark:text-gray-100 hover:text-gray-900 dark:hover:text-gray-50 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors text-left w-full relative z-10"
-              style={{ paddingLeft: `${depth * 16 + 12}px` }}
-            >
-              <span className="flex-1 truncate">{displayTitle}</span>
-              <span className="ml-auto shrink-0">
-                {isCollapsed ? (
-                  <ChevronRight className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300 transition-transform duration-200" />
-                ) : (
-                  <ChevronDown className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300 transition-transform duration-200" />
-                )}
-              </span>
-            </button>
-          ) : (
+          {hasChildren ? (() => {
+            const firstRoute = getFirstChildRoute(item);
+            return firstRoute ? (
+              <div
+                className="flex items-center gap-0 px-3 py-1.5 text-[13px] font-normal text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors w-full relative z-10"
+                style={{ paddingLeft: `${depth * 16 + 12}px` }}
+              >
+                <Link
+                  href={firstRoute}
+                  onClick={() => { if (isCollapsed) toggleCollapse(itemKey); }}
+                  className="flex-1 truncate hover:text-gray-900 dark:hover:text-gray-50"
+                >
+                  {displayTitle}
+                </Link>
+                <button
+                  onClick={(e) => { e.stopPropagation(); toggleCollapse(itemKey); }}
+                  className="ml-auto shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  aria-label={isCollapsed ? 'Expand section' : 'Collapse section'}
+                >
+                  {isCollapsed ? (
+                    <ChevronRight className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300 transition-transform duration-200" />
+                  ) : (
+                    <ChevronDown className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300 transition-transform duration-200" />
+                  )}
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => toggleCollapse(itemKey)}
+                className="flex items-center gap-2 px-3 py-1.5 text-[13px] font-normal text-gray-700 dark:text-gray-100 hover:text-gray-900 dark:hover:text-gray-50 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors text-left w-full relative z-10"
+                style={{ paddingLeft: `${depth * 16 + 12}px` }}
+              >
+                <span className="flex-1 truncate">{displayTitle}</span>
+                <span className="ml-auto shrink-0">
+                  {isCollapsed ? (
+                    <ChevronRight className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300 transition-transform duration-200" />
+                  ) : (
+                    <ChevronDown className="w-3.5 h-3.5 text-gray-500 dark:text-gray-300 transition-transform duration-200" />
+                  )}
+                </span>
+              </button>
+            );
+          })() : (
             <Link
               href={item.route || '#'}
               className={`
@@ -346,25 +387,34 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
 
     return (
       <div className="relative pt-1">
-        <button
-          onClick={() => toggleCollapse(LEGACY_GROUP_KEY)}
+        <div
           className={`
-            flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full font-semibold
+            flex items-center gap-0 px-3 py-2 text-[13px] rounded-md transition-colors w-full font-semibold
             ${isActiveLegacy
               ? 'text-blue-600 dark:text-blue-100 bg-blue-50'
               : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
             }
           `}
         >
-          <span>Legacy Components</span>
-          <span className="ml-auto shrink-0">
+          <Link
+            href={LEGACY_OVERVIEW_HREF}
+            onClick={() => { if (!isExpanded) toggleCollapse(LEGACY_GROUP_KEY); }}
+            className="flex-1 truncate"
+          >
+            Legacy Components
+          </Link>
+          <button
+            onClick={(e) => { e.stopPropagation(); toggleCollapse(LEGACY_GROUP_KEY); }}
+            className="ml-auto shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
+          >
             {isExpanded ? (
               <ChevronDown className="w-3 h-3" />
             ) : (
               <ChevronRight className="w-3 h-3" />
             )}
-          </span>
-        </button>
+          </button>
+        </div>
 
         <div
           className={`


### PR DESCRIPTION
## Summary
- **#1275**: Replace ASCII art with mermaid diagram in console architecture page; add canonical reference note
- **#1274**: Add `ocm-status-addon-intro.md` page to the KubeStellar "What is KubeStellar?" nav section
- **#1273**: Create `legacy-components.md` overview page; make sidebar section headers (Contributing, Community, News, Legacy Components) navigate to their overview page when clicked, with a separate chevron toggle for expand/collapse

Closes #1275, closes #1274, closes #1273

## Test plan
- [ ] Verify mermaid diagram renders correctly on the console architecture page
- [ ] Verify ocm-status-addon page is accessible via sidebar under "What is KubeStellar?"
- [ ] Verify clicking "Legacy Components" in the sidebar navigates to the overview page
- [ ] Verify clicking "Contributing", "Community", "News" section headers navigates to their first child page
- [ ] Verify chevron buttons still toggle expand/collapse independently
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)