### PR TITLE
🐛 Fix console OAuth installation docs step ordering

### DIFF
--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -193,24 +193,31 @@ To enable GitHub login (for multi-user deployments or to test the full auth flow
 
 4. Copy the **Client ID** and generate a **Client Secret**
 
-### 2. Configure Environment
+### 2. Clone the Repository
 
-Create a `.env` file in the project root with only these two variables:
+```bash
+git clone https://github.com/kubestellar/console.git
+cd console
+```
+
+### 3. Configure Environment
+
+Create a `.env` file **inside the cloned `console/` directory** (the repo root) with your OAuth credentials:
 
 ```bash
 GITHUB_CLIENT_ID=your_client_id
 GITHUB_CLIENT_SECRET=your_client_secret
 ```
 
-### 3. Start the Console
+> **Important**: The `.env` file must be in the same directory as `startup-oauth.sh`. The script loads it from its own directory, so creating it elsewhere will not work.
+
+### 4. Start the Console
 
 ```bash
-git clone https://github.com/kubestellar/console.git
-cd console
 ./startup-oauth.sh
 ```
 
-Open http://localhost:5174 and sign in with GitHub.
+Open http://localhost:8080 and sign in with GitHub.
 
 > **Tip**: Once running, click your profile avatar → the **Developer** panel shows your OAuth status, console version, and quick links.
 


### PR DESCRIPTION
## Summary
- Fixes the "Run from Source with OAuth" section in the console installation docs where the steps were in the wrong order: users were told to create a `.env` file (step 2) before cloning the repo (step 3), which fails because the directory doesn't exist yet.
- Reorders to: (1) create OAuth app, (2) clone repo, (3) create `.env` inside the cloned directory, (4) run `startup-oauth.sh`.
- Fixes the URL from `http://localhost:5174` to `http://localhost:8080` (the default production mode port).
- Adds a note clarifying that `.env` must be in the same directory as `startup-oauth.sh`.

Ref: kubestellar/console#2463

## Test plan
- [ ] Verify the "Run from Source with OAuth" section steps read in logical order
- [ ] Verify the URL says `http://localhost:8080` (not 5174)
- [ ] Preview the rendered page on Netlify deploy preview