### PR TITLE
🐛 Fix mermaid diagram not rendering on architecture page

### DIFF
--- a/src/lib/Mermaid.tsx
+++ b/src/lib/Mermaid.tsx
@@ -15,7 +15,7 @@ export const MermaidComponent = ({ children }: MermaidProps) => {
 
   useEffect(() => {
     if (ref.current && chart) {
-      ref.current.innerHTML = "";
+      ref.current.innerHTML = chart;
       mermaid.run({
         nodes: [ref.current],
       });


### PR DESCRIPTION
## Summary
- Fix `MermaidComponent` clearing `innerHTML` to empty string before calling `mermaid.run()`, which left mermaid with nothing to parse
- Change `innerHTML = ""` to `innerHTML = chart` so mermaid can find and render the diagram text

## Test plan
- [ ] Build passes
- [ ] Visit `/docs/console/overview/architecture` — mermaid diagram renders visibly