### PR TITLE
🐛 Fix mermaid diagram rendering and add coding agent components

### DIFF
--- a/docs/content/console/architecture.md
+++ b/docs/content/console/architecture.md
@@ -41,22 +41,27 @@ The console consists of 7 components working together. See [Configuration](confi
 
 ```mermaid
 graph TB
-    GitHub["GitHub OAuth<br/>(Authorization Server)"]
-    Backend["KubeStellar Console Backend :8080<br/>API Handlers · Auth (OAuth Client) · Claude AI · WebSocket"]
-    Browser["User Browser<br/>React + Vite SPA"]
-    MCP["MCP Bridge<br/>kubestellar-ops + kubestellar-deploy"]
-    K8s["Kubernetes Clusters<br/>cluster-1 · cluster-2 · ..."]
-    Agent["kc-agent :8585<br/>Local Agent (user's machine)"]
+    GitHub["GitHub OAuth"]
+    Backend["Console Backend :8080"]
+    Browser["User Browser"]
+    MCP["MCP Bridge"]
+    K8s["Kubernetes Clusters"]
+    Agent["kc-agent :8585"]
+    CLI["Claude Code CLI"]
+    API["GPT API"]
 
-    Browser -- "1. initiates OAuth flow" --> Backend
-    Browser -- "2. user authorizes on GitHub" --> GitHub
-    GitHub -- "3. issues access token<br/>(in exchange for auth code)" --> Backend
+    Browser -- "OAuth flow" --> Backend
+    Browser -- "authorize" --> GitHub
+    GitHub -- "access token" --> Backend
     Backend -- "session JWT" --> Browser
+    Backend -- "REST / WebSocket" --> Browser
     Browser -- "WebSocket" --> Agent
-    Backend -- "REST / WebSocket API" --> Browser
-    Backend -- "kubeconfig credentials" --> MCP
+    Backend -- "kubeconfig" --> MCP
     MCP -- "kubeconfig" --> K8s
-    Agent -- "kubectl / kubeconfig" --> K8s
+    Agent -- "kubectl" --> K8s
+    Agent -- "MCP protocol" --> CLI
+    CLI -- "kubestellar-ops" --> K8s
+    API -- "read-only queries" --> Backend
 ```
 
 **Credential flows:**

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -477,6 +477,11 @@ export default async function Page(props: PageProps) {
   // Sanitize HTML for MDX
   let processedData = sanitizeHtmlForMdx(preProcessedText)
   processedData = convertHtmlScriptsToJsxComments(processedData)
+  // Convert ```mermaid code fences to <Mermaid> JSX so the component renders
+  processedData = processedData.replace(
+    /```mermaid\n([\s\S]*?)```/g,
+    (_match, chart: string) => `<Mermaid>{\`${chart.trimEnd()}\`}</Mermaid>`
+  )
 
   const rawJs = await compileMdx(processedData, { filePath })
   const { default: MDXContent, toc, metadata } = evaluate(rawJs, component)

--- a/src/lib/Mermaid.tsx
+++ b/src/lib/Mermaid.tsx
@@ -1,34 +1,68 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import mermaid from "mermaid";
 
-mermaid.initialize({ startOnLoad: false, theme: "neutral" });
+mermaid.initialize({ startOnLoad: false });
 
 type MermaidProps = {
   children: string;
 };
 
+/** Monotonic counter to generate unique IDs for mermaid.render() */
+let nextId = 0;
+
+/** Detect whether the page is currently in dark mode */
+function isDarkMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    document.documentElement.classList.contains("dark") ||
+    document.documentElement.getAttribute("data-theme") === "dark" ||
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
 export const MermaidComponent = ({ children }: MermaidProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const chart = children;
 
-  useEffect(() => {
-    if (ref.current && chart) {
-      ref.current.innerHTML = chart;
-      mermaid.run({
-        nodes: [ref.current],
-      });
-    }
+  const renderChart = useCallback(() => {
+    if (!ref.current || !chart) return;
+    const theme = isDarkMode() ? "dark" : "default";
+    mermaid.initialize({ startOnLoad: false, theme });
+    const id = `mermaid-${nextId++}`;
+    mermaid
+      .render(id, chart)
+      .then(({ svg }) => {
+        if (ref.current) {
+          ref.current.innerHTML = svg;
+        }
+      })
+      .catch(console.error);
   }, [chart]);
+
+  useEffect(() => {
+    renderChart();
+
+    // Re-render when the user toggles light/dark mode
+    const observer = new MutationObserver(renderChart);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme"],
+    });
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    mq.addEventListener("change", renderChart);
+
+    return () => {
+      observer.disconnect();
+      mq.removeEventListener("change", renderChart);
+    };
+  }, [renderChart]);
 
   if (!chart) {
     return null;
   }
 
-  return (
-    <div className="mermaid" ref={ref}>
-      {chart}
-    </div>
-  );
+  return <div className="mermaid" ref={ref} />;
 };


### PR DESCRIPTION
## Summary
- **Fix mermaid rendering**: The `MermaidComponent` was broken — `innerHTML` corrupted `<br/>` tags in mermaid syntax, and the `@theguild/remark-mermaid` plugin was installed but never wired up. Fixed by:
  - Using `mermaid.render()` API which takes raw chart string directly
  - Adding preprocessing in `page.tsx` to convert ` ```mermaid ` code fences to `<Mermaid>` JSX before `compileMdx()`
- **Theme-aware rendering**: Detects dark/light mode and re-renders on toggle via MutationObserver + `prefers-color-scheme` media query
- **Updated architecture diagram**: Shortened node labels (fixes truncation), added Claude Code CLI and GPT API nodes

## Test plan
- [ ] Build passes
- [ ] Visit `/docs/console/overview/architecture` in dark mode — diagram renders with readable colors
- [ ] Toggle to light mode — diagram re-renders with appropriate theme
- [ ] No text truncation in any node