### PR TITLE
🐛 Fix mermaid dark mode: use CSS filter instead of broken mermaid.initialize()

### DIFF
--- a/src/lib/Mermaid.tsx
+++ b/src/lib/Mermaid.tsx
@@ -1,68 +1,34 @@
 "use client";
 
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef } from "react";
 import mermaid from "mermaid";
 
-mermaid.initialize({ startOnLoad: false });
+mermaid.initialize({ startOnLoad: false, theme: "default" });
 
 type MermaidProps = {
   children: string;
 };
 
-/** Monotonic counter to generate unique IDs for mermaid.render() */
-let nextId = 0;
-
-/** Detect whether the page is currently in dark mode */
-function isDarkMode(): boolean {
-  if (typeof window === "undefined") return false;
-  return (
-    document.documentElement.classList.contains("dark") ||
-    document.documentElement.getAttribute("data-theme") === "dark" ||
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-  );
-}
-
 export const MermaidComponent = ({ children }: MermaidProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const chart = children;
 
-  const renderChart = useCallback(() => {
-    if (!ref.current || !chart) return;
-    const theme = isDarkMode() ? "dark" : "default";
-    mermaid.initialize({ startOnLoad: false, theme });
-    const id = `mermaid-${nextId++}`;
-    mermaid
-      .render(id, chart)
-      .then(({ svg }) => {
-        if (ref.current) {
-          ref.current.innerHTML = svg;
-        }
-      })
-      .catch(console.error);
-  }, [chart]);
-
   useEffect(() => {
-    renderChart();
-
-    // Re-render when the user toggles light/dark mode
-    const observer = new MutationObserver(renderChart);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme"],
-    });
-
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    mq.addEventListener("change", renderChart);
-
-    return () => {
-      observer.disconnect();
-      mq.removeEventListener("change", renderChart);
-    };
-  }, [renderChart]);
+    if (ref.current && chart) {
+      ref.current.removeAttribute("data-processed");
+      ref.current.textContent = chart;
+      mermaid.run({ nodes: [ref.current] }).catch(console.error);
+    }
+  }, [chart]);
 
   if (!chart) {
     return null;
   }
 
-  return <div className="mermaid" ref={ref} />;
+  return (
+    <div
+      className="mermaid dark:invert dark:hue-rotate-180"
+      ref={ref}
+    />
+  );
 };


### PR DESCRIPTION
## Summary
- `mermaid.initialize()` caches theme from first call and ignores subsequent calls, making runtime theme switching impossible
- Fix: always render with `default` (light) theme, use Tailwind `dark:invert dark:hue-rotate-180` CSS classes for dark mode
- Much simpler component — removed MutationObserver, theme detection, callback complexity

## Test plan
- [ ] Build passes
- [ ] Dark mode: diagram renders with inverted colors, readable text
- [ ] Light mode: diagram renders with standard light theme colors
- [ ] Toggle between modes: diagram adapts instantly via CSS (no JS re-render needed)