### PR TITLE
📖 Fix dark mode CSS, consolidate architecture docs, clarify MCP bundling

### DIFF
--- a/docs/content/console/_architecture-diagram.md
+++ b/docs/content/console/_architecture-diagram.md
@@ -1,0 +1,24 @@
+```mermaid
+graph TB
+    GitHub["GitHub OAuth"]
+    Backend["Console Backend :8080"]
+    Browser["User Browser"]
+    MCP["MCP Bridge"]
+    K8s["Kubernetes Clusters"]
+    Agent["kc-agent :8585"]
+    CLI["Claude Code CLI"]
+    API["GPT API"]
+
+    Browser -- "OAuth flow" --> Backend
+    Browser -- "authorize" --> GitHub
+    GitHub -- "access token" --> Backend
+    Backend -- "session JWT" --> Browser
+    Backend -- "REST / WebSocket" --> Browser
+    Browser -- "WebSocket" --> Agent
+    Backend -- "kubeconfig" --> MCP
+    MCP -- "kubeconfig" --> K8s
+    Agent -- "kubectl" --> K8s
+    Agent -- "MCP protocol" --> CLI
+    CLI -- "kubestellar-ops" --> K8s
+    API -- "read-only queries" --> Backend
+```

--- a/docs/content/console/architecture.md
+++ b/docs/content/console/architecture.md
@@ -39,30 +39,7 @@ The console consists of 7 components working together. See [Configuration](confi
 
 ## System Overview
 
-```mermaid
-graph TB
-    GitHub["GitHub OAuth"]
-    Backend["Console Backend :8080"]
-    Browser["User Browser"]
-    MCP["MCP Bridge"]
-    K8s["Kubernetes Clusters"]
-    Agent["kc-agent :8585"]
-    CLI["Claude Code CLI"]
-    API["GPT API"]
-
-    Browser -- "OAuth flow" --> Backend
-    Browser -- "authorize" --> GitHub
-    GitHub -- "access token" --> Backend
-    Backend -- "session JWT" --> Browser
-    Backend -- "REST / WebSocket" --> Browser
-    Browser -- "WebSocket" --> Agent
-    Backend -- "kubeconfig" --> MCP
-    MCP -- "kubeconfig" --> K8s
-    Agent -- "kubectl" --> K8s
-    Agent -- "MCP protocol" --> CLI
-    CLI -- "kubestellar-ops" --> K8s
-    API -- "read-only queries" --> Backend
-```
+{% include-markdown "_architecture-diagram.md" %}
 
 **Credential flows:**
 - **GitHub OAuth** (user identity): Browser → GitHub → Backend. The user (Resource Owner) authorizes the console to read their GitHub profile. The Backend (OAuth Client) exchanges the authorization code for a token, verifies identity, and issues a session JWT to the browser.
@@ -99,7 +76,7 @@ The Backend is the OAuth Client in the OAuth 2.0 flow. It receives the authoriza
 
 ### MCP Bridge
 
-A separate process (bundled in the console image) that exposes the kubestellar-mcp tools over HTTP/WebSocket so the Backend can query cluster state. The MCP Bridge uses the **kubeconfig** on the server to authenticate to Kubernetes clusters. It does not participate in the GitHub OAuth flow.
+A separate process that is spawned by the console executable at startup. The MCP Bridge code is compiled into the same binary as the Backend, but runs as its own child process. It exposes the kubestellar-mcp tools over HTTP/WebSocket so the Backend can query cluster state. The MCP Bridge uses the **kubeconfig** on the server to authenticate to Kubernetes clusters. It does not participate in the GitHub OAuth flow.
 
 ### Claude Code Plugins
 

--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -35,44 +35,18 @@ This typically takes under 45 seconds. No OAuth or GitHub credentials required �
 
 ## System Components
 
-KubeStellar Console has **6 components** that work together:
+KubeStellar Console has **6 components** that work together. For the full architectural deep-dive, data flow diagrams, and component interactions, see the [Architecture](architecture.md) page.
 
-```
-  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐   ┌──────────────┐
-  │  1. GitHub  │   │ 2. Frontend │   │ 3. Backend  │   │   4. Agent   │
-  │  OAuth App  │──▶│  (React UI) │◀─▶│    (Go)     │──▶│ (MCP Bridge) │
-  │ (optional)  │   │             │   │             │   │              │
-  │  Login via  │   │  Dashboard, │   │  API server,│   │  Talks to    │
-  │  GitHub     │   │  cards, AI  │   │  auth, data │   │  clusters    │
-  └─────────────┘   └─────────────┘   └─────────────┘   └───────┬──────┘
-                                                                │
-  ┌─────────────────────────────────────────────────────────────┤
-  │                 5. Claude Code Plugins                      │
-  │                                                             │
-  │  ┌─────────────────────┐   ┌──────────────────────────┐     │
-  │  │   kubestellar-ops   │   │   kubestellar-deploy     │     │
-  │  │  - List clusters    │   │  - Deploy apps           │     │
-  │  │  - Find pod issues  │   │  - GitOps sync           │     │
-  │  │  - Check security   │   │  - Scale apps            │     │
-  │  │  - Analyze RBAC     │   │  - Check drift           │     │
-  │  └─────────────────────┘   └──────────────────────────┘     │
-  └─────────────────────────────────────────────────────────────┤
-                                                                │
-  ┌─────────────────────────────────────────────────────────────▼───┐
-  │                         6. Kubeconfig                           │
-  │     ~/.kube/config with access to your clusters                 │
-  │     [cluster-1]   [cluster-2]   [cluster-3]   [cluster-n]       │
-  └─────────────────────────────────────────────────────────────────┘
-```
+{% include-markdown "_architecture-diagram.md" %}
 
 ### Component Summary
 
 | # | Component | What it does | Required? |
 |---|-----------|--------------|-----------|
 | 1 | **GitHub OAuth App** | Lets users sign in with GitHub | Optional — without it, a local `dev-user` session is created |
-| 2 | **Frontend** | React web app you see in browser | Yes — bundled in console image |
-| 3 | **Backend** | Go server that handles API calls | Yes — bundled in console image |
-| 4 | **Agent (MCP Bridge)** | Connects backend to your clusters | Yes — bundled in console image |
+| 2 | **Frontend** | React web app you see in browser | Yes — included in the console executable |
+| 3 | **Backend** | Go server that handles API calls | Yes — included in the console executable |
+| 4 | **Agent (MCP Bridge)** | Connects backend to your clusters | Yes — spawned as a child process by the console executable |
 | 5 | **Claude Code Plugins** | kubestellar-ops + kubestellar-deploy tools | Yes — [Claude Marketplace](#step-1-install-claude-code-plugins) or Homebrew |
 | 6 | **Kubeconfig** | Your cluster credentials | Yes — your existing `~/.kube/config` |
 

--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -34,10 +34,10 @@ Typically under 45 seconds. No GitHub OAuth credentials required — a local `de
 |-----------|------------|-----------|
 | kubestellar-mcp plugins | Connect to your clusters | Yes |
 | kubeconfig | Your cluster credentials | Yes |
-| Frontend + Backend | The console itself | Yes (bundled) |
+| Frontend + Backend | The console itself | Yes (included in the console executable) |
 | GitHub OAuth App | Lets users sign in via GitHub | Optional |
 
-See [Installation](installation.md) for the full architecture diagram.
+See the [Architecture](architecture.md) page for the full system diagram and component details.
 
 ## Prerequisites
 

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -284,7 +284,7 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
                 flex items-center gap-2 px-3 py-1.5 text-[13px] rounded-md transition-colors relative z-10 w-full
                 ${
                   isActive
-                    ? 'font-medium text-blue-600 dark:text-blue-100 bg-blue-50'
+                    ? 'font-medium text-blue-600 dark:text-blue-100 bg-blue-50 dark:bg-blue-900/30'
                     : 'font-normal text-gray-700 dark:text-gray-100 hover:text-gray-900 dark:hover:text-gray-50 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }
               `}
@@ -329,7 +329,7 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
       <div key={projId} className="relative">
         <button
           onClick={() => toggleCollapse(sectionKey)}
-          className="flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full font-semibold text-blue-600 dark:text-blue-100 bg-blue-50"
+          className="flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full font-semibold text-blue-600 dark:text-blue-100 bg-blue-50 dark:bg-blue-900/30"
           style={{ paddingLeft: `${depth * 16 + 12}px` }}
         >
           <span className="flex-1 truncate">{label}</span>
@@ -391,7 +391,7 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
           className={`
             flex items-center gap-0 px-3 py-2 text-[13px] rounded-md transition-colors w-full font-semibold
             ${isActiveLegacy
-              ? 'text-blue-600 dark:text-blue-100 bg-blue-50'
+              ? 'text-blue-600 dark:text-blue-100 bg-blue-50 dark:bg-blue-900/30'
               : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
             }
           `}
@@ -458,7 +458,7 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
                 className={`
                   flex items-center gap-2 px-3 py-2 text-[13px] rounded-md transition-colors text-left w-full font-medium
                   ${isDocsGuide
-                    ? 'text-blue-600 dark:text-blue-100 bg-blue-50'
+                    ? 'text-blue-600 dark:text-blue-100 bg-blue-50 dark:bg-blue-900/30'
                     : 'text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'
                   }
                 `}


### PR DESCRIPTION
## Summary
- **Fix dark mode CSS (#1280)**: Added `dark:bg-blue-900/30` to all `bg-blue-50` instances in `DocsSidebar.tsx` — the "Legacy Components" heading (and other active sidebar items) no longer shows a light background when the site is in dark mode
- **Consolidate architecture diagrams (#1285)**: Extracted the mermaid system diagram into a shared partial (`_architecture-diagram.md`) included via `{% include-markdown %}` on both the Architecture and Installation pages. Updated quickstart.md to link directly to the Architecture page instead of Installation for the diagram. The mermaid diagram supports dark mode via the existing `MermaidComponent` (`dark:invert dark:hue-rotate-180`)
- **Clarify MCP bundling wording (#1286)**: Replaced ambiguous "bundled in console image" with clear descriptions: the MCP Bridge is "spawned as a child process by the console executable" (architecture.md) and component table entries now say "included in the console executable" / "spawned as a child process by the console executable" (installation.md, quickstart.md)

## Test plan
- [ ] Verify dark mode renders correctly on Legacy Components section and all active sidebar items
- [ ] Verify architecture mermaid diagram renders on both Architecture and Installation pages
- [ ] Verify mermaid diagram honors dark mode (inverted colors)
- [ ] Verify MCP bundling wording is clear and unambiguous
- [ ] Build passes: `npm run build` and `npm run lint`

Fixes #1280, #1285, #1286