### PR TITLE
🐛 Fixed Legacy section highlighted when unfocused

### DIFF
--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -24,7 +24,10 @@ interface DocsSidebarProps {
 }
 
 // General sections that appear in every project's pageMap — show once at bottom
-const GENERAL_SECTION_NAMES = ['Contributing', 'Community', 'News'];
+const GENERAL_SECTION_SLUGS = ['contributing', 'community', 'news'] as const;
+const GENERAL_SECTION_NAMES = GENERAL_SECTION_SLUGS.map(
+  (slug) => slug.charAt(0).toUpperCase() + slug.slice(1),
+);
 
 // Project display order and labels — each with a landing href for navigation links
 const PRIMARY_PROJECTS = [
@@ -42,8 +45,14 @@ const LEGACY_PROJECTS = [
 // Key prefix for project-level collapse state (avoids collision with nav item keys)
 const PROJECT_KEY_PREFIX = '__project_';
 const LEGACY_GROUP_KEY = '__legacy';
+const GENERAL_SECTION_PATH_REGEX = new RegExp(
+  `^/docs/(${GENERAL_SECTION_SLUGS.join('|')})(/|$)`,
+);
 
-const GENERAL_SECTION_PATH_REGEX = /^\/docs\/(contributing|community|news)(\/|$)/;
+function getGeneralSectionSlugFromPath(path: string): string | null {
+  const match = path.match(GENERAL_SECTION_PATH_REGEX);
+  return match?.[1] ?? null;
+}
 
 function getProjectItems(items: MenuItem[]): MenuItem[] {
   return items.filter(item => !GENERAL_SECTION_NAMES.includes(item.name || item.title || ''));
@@ -187,11 +196,13 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
 
     // Also handle general sections
     const generalSections = getGeneralSections(pageMap);
-    const isViewingGeneralSection = currentPath.includes('/contributing') || currentPath.includes('/community') || currentPath.includes('/news');
+    const currentGeneralSectionSlug = getGeneralSectionSlugFromPath(currentPath);
+    const isViewingGeneralSection = Boolean(currentGeneralSectionSlug);
 
     for (const section of generalSections) {
       const sectionKey = section.name;
-      const isCurrent = isViewingGeneralSection && currentPath.includes('/' + (section.name || '').toLowerCase());
+      const sectionSlug = (section.name || section.title || '').toLowerCase();
+      const isCurrent = isViewingGeneralSection && sectionSlug === currentGeneralSectionSlug;
       if (!isCurrent) {
         initialCollapsed.add(sectionKey);
       }
@@ -203,6 +214,18 @@ export function DocsSidebar({ pageMap, className, projectId }: DocsSidebarProps)
 
     setCollapsed(initialCollapsed);
   }, [pageMap, projectId, navInitialized, setCollapsed]);
+
+  // Keep legacy group collapsed while browsing general sections
+  useEffect(() => {
+    if (!GENERAL_SECTION_PATH_REGEX.test(pathname)) return;
+
+    setCollapsed(prev => {
+      if (prev.has(LEGACY_GROUP_KEY)) return prev;
+      const next = new Set(prev);
+      next.add(LEGACY_GROUP_KEY);
+      return next;
+    });
+  }, [pathname, setCollapsed]);
 
   const toggleCollapse = (itemKey: string) => {
     toggleNavCollapsed(itemKey);


### PR DESCRIPTION
### 📌 Fixes

Fixes #1296 

---

### 📝 Summary of Changes

Fixed DocsSidebar so that footer components being active doesn't trigger highlighting of "legacy" heading 

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed DocsSidebar.tsx
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---
