### PR TITLE
✨ doc: Add console demo mode architecture

### DIFF
--- a/docs/content/console/demo-mode.md
+++ b/docs/content/console/demo-mode.md
@@ -55,7 +55,7 @@ registered at startup from
 
 The registry produces data for clusters, pod issues, deployment issues,
 events, security findings, GPU nodes, Helm releases, operators, and
-services.  For example, the demo cluster list contains 12 realistic
+services.  For example, the demo cluster list contains a set of realistic
 clusters (EKS, GKE, AKS, OKE, OpenShift, etc.) with plausible
 configurations.
 
@@ -106,9 +106,10 @@ The decision path for each dashboard card is:
 ```
 
 The card component then reports its state up to `CardWrapper` via the
-`useCardLoadingState` or `useReportCardDataState` hook.  `CardWrapper`
-reads the `isDemoData` flag and, when it is `true`, renders the yellow
-outline and **Demo** badge.
+`useCardLoadingState` or `useReportCardDataState` hook.  Inside the hooks
+the flag is called `isDemoFallback`; the card passes it to `CardWrapper`
+as the `isDemoData` prop.  When `isDemoData` is `true`, `CardWrapper`
+renders the yellow outline and **Demo** badge.
 
 ### Loading vs. Demo Data
 

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -197,6 +197,7 @@ const NAV_STRUCTURE_CONSOLE: Array<{ title: string; items: NavItem[] }> = [
       { 'Quick Start': 'quickstart.md' },
       { 'Installation': 'installation.md' },
       { 'Architecture': 'architecture.md' },
+      { 'Demo Mode': 'demo-mode.md' },
       { 'Configuration': 'configuration.md' },
     ]
   },


### PR DESCRIPTION
## Summary

- Adds `docs/content/console/demo-mode.md` documenting the console's demo mode architecture
- Explains the three-level priority system that controls when demo mode activates (forced on Netlify, user toggle, token fallback)
- Documents where demo data comes from (unified registry, per-hook fallbacks, per-card files)
- Describes the card-level decision flow: loading skeleton → live data vs demo fallback
- Notes cross-tab synchronisation and the expected data-consistency caveat (different cards may show different totals for the same logical metric because demo data is generated independently)

Closes #1302

## Test plan

- [ ] Verify the new page renders correctly in the docs site
- [ ] Confirm frontmatter weight places it logically in the console section nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)