### PR TITLE
🐛 Fix GitHub stats dropdown showing zeros

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,10 +15,12 @@ export default function Navbar() {
   const [isCommunityOpen, setIsCommunityOpen] = useState(false);
   const [isGithubOpen, setIsGithubOpen] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Fallback values shown when GitHub API is rate-limited (60 req/hr unauthenticated).
+  // Update these periodically to keep them roughly current.
   const [githubStats, setGithubStats] = useState({
-    stars: "0",
-    forks: "0",
-    watchers: "0",
+    stars: "30",
+    forks: "25",
+    watchers: "1",
   });
 
   const t = useTranslations("navigation");

--- a/src/components/docs/DocsNavbar.tsx
+++ b/src/components/docs/DocsNavbar.tsx
@@ -31,10 +31,12 @@ export default function DocsNavbar() {
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  // Fallback values shown when GitHub API is rate-limited (60 req/hr unauthenticated).
+  // Update these periodically to keep them roughly current.
   const [githubStats, setGithubStats] = useState({
-    stars: "0",
-    forks: "0",
-    watchers: "0",
+    stars: "30",
+    forks: "25",
+    watchers: "1",
   });
 
   // const searchParams = useSearchParams()


### PR DESCRIPTION
## Summary
- Uses actual `kubestellar/console` repo stats (30 stars, 25 forks, 1 watcher) as fallback defaults instead of "0" in both `DocsNavbar.tsx` and `Navbar.tsx`
- GitHub's unauthenticated API rate limit is 60 requests/hour — most visitors hit this and see the default values
- The client-side fetch still runs and updates with live data when the API responds successfully

Closes #1300

## Test plan
- [ ] Verify GitHub dropdown shows non-zero fallback values on first render
- [ ] Verify live stats replace fallbacks when API responds (e.g. in dev with fresh rate limit)