### PR TITLE
📖 Add kubestellar/docs to leaderboard scoring repos

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -35,6 +35,7 @@ const REPOS = [
   "kubestellar/console",
   "kubestellar/console-marketplace",
   "kubestellar/console-kb",
+  "kubestellar/docs",
 ];
 
 // ── Contributor levels ────────────────────────────────────────────────


### PR DESCRIPTION
Contributions to kubestellar/docs were not counted in the leaderboard. Adds it to the REPOS list. Also updated console backend to org:kubestellar in kubestellar/console#2981.