### PR TITLE
🌱 Remove btwshivam and MAVRICK-1 from OWNERS and maintainer workflows

### DIFF
--- a/.github/workflows/maintainer-metrics.md
+++ b/.github/workflows/maintainer-metrics.md
@@ -14,12 +14,10 @@ on:
         required: true
         type: choice
         options:
-          - btwshivam
           - clubanderson
           - dumb0002
           - francostellari
           - kproche
-          - mavrick-1
           - mikespreitzer
           - oksaumya
           - onkar717
@@ -188,12 +186,10 @@ safe-outputs:
 
               // Maintainer email mapping
               const maintainerEmails = {
-                'btwshivam': 'shivam200446@gmail.com',
                 'clubanderson': 'andy@clubanderson.com',
                 'dumb0002': 'Braulio.Dumba@ibm.com',
                 'francostellari': 'stellari@us.ibm.com',
                 'kproche': 'kproche@us.ibm.com',
-                'mavrick-1': 'mavrickrishi@gmail.com',
                 'mikespreitzer': 'mspreitz@us.ibm.com',
                 'oksaumya': 'saumyakr2006@gmail.com',
                 'onkar717': 'onkarwork2234@gmail.com',
@@ -273,12 +269,10 @@ Your task is to **generate ONE metrics email** for the selected maintainer using
 
 **Email mapping:**
 
-- btwshivam → shivam200446@gmail.com
 - clubanderson → andy@clubanderson.com
 - dumb0002 → Braulio.Dumba@ibm.com
 - francostellari → stellari@us.ibm.com
 - kproche → kproche@us.ibm.com
-- mavrick-1 → mavrickrishi@gmail.com
 - mikespreitzer → mspreitz@us.ibm.com
 - oksaumya → saumyakr2006@gmail.com
 - onkar717 → onkarwork2234@gmail.com

--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -21,12 +21,10 @@ jobs:
         run: |
           # List of all maintainers
           MAINTAINERS=(
-            "btwshivam"
             "clubanderson"
             "dumb0002"
             "francostellari"
             "kproche"
-            "mavrick-1"
             "mikespreitzer"
             "oksaumya"
             "onkar717"

--- a/OWNERS
+++ b/OWNERS
@@ -2,14 +2,10 @@ approvers:
   - clubanderson
   - KPRoche
   - mahimonga
-  - btwshivam
-  - MAVRICK-1
   - oksaumya
 
 reviewers:
   - clubanderson
   - KPRoche
   - mahimonga
-  - btwshivam
-  - MAVRICK-1
   - oksaumya


### PR DESCRIPTION
## Summary
- Remove `btwshivam` (Shivam Kumar) and `MAVRICK-1` (Rishi Mondal) from OWNERS (approvers + reviewers)
- Remove from maintainer-metrics workflow dispatch options and email mapping
- Remove from run-all-maintainer-audits workflow list

> **Note:** `maintainer-metrics.lock.yml` is auto-generated from the `.md` file and will update on next `gh aw compile`.

## Test plan
- [ ] Verify OWNERS file no longer lists removed users
- [ ] Verify maintainer-metrics workflow dropdown no longer shows removed users
- [ ] Verify run-all-maintainer-audits no longer triggers for removed users