### PR TITLE
🌱 Remove mahimonga and onkar717 from OWNERS and maintainer workflows

### DIFF
--- a/.github/workflows/maintainer-metrics.md
+++ b/.github/workflows/maintainer-metrics.md
@@ -20,7 +20,6 @@ on:
           - kproche
           - mikespreitzer
           - oksaumya
-          - onkar717
           - pdettori
           - waltforme
 
@@ -192,7 +191,6 @@ safe-outputs:
                 'kproche': 'kproche@us.ibm.com',
                 'mikespreitzer': 'mspreitz@us.ibm.com',
                 'oksaumya': 'saumyakr2006@gmail.com',
-                'onkar717': 'onkarwork2234@gmail.com',
                 'pdettori': 'dettori@us.ibm.com',
                 'waltforme': 'jun.duan@ibm.com'
               };
@@ -275,7 +273,6 @@ Your task is to **generate ONE metrics email** for the selected maintainer using
 - kproche → kproche@us.ibm.com
 - mikespreitzer → mspreitz@us.ibm.com
 - oksaumya → saumyakr2006@gmail.com
-- onkar717 → onkarwork2234@gmail.com
 - pdettori → dettori@us.ibm.com
 - waltforme → jun.duan@ibm.com
 

--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -27,7 +27,6 @@ jobs:
             "kproche"
             "mikespreitzer"
             "oksaumya"
-            "onkar717"
             "pdettori"
             "waltforme"
           )

--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,9 @@
 approvers:
   - clubanderson
   - KPRoche
-  - mahimonga
   - oksaumya
 
 reviewers:
   - clubanderson
   - KPRoche
-  - mahimonga
   - oksaumya


### PR DESCRIPTION
## Summary
- Remove `mahimonga` from OWNERS (approvers + reviewers)
- Remove `onkar717` from maintainer-metrics workflow and run-all-maintainer-audits

## Test plan
- [ ] Verify OWNERS file updated
- [ ] Verify workflow files updated