### PR TITLE
🌱 Remove oksaumya from OWNERS and maintainer workflows

### DIFF
--- a/.github/workflows/maintainer-metrics.md
+++ b/.github/workflows/maintainer-metrics.md
@@ -19,7 +19,6 @@ on:
           - francostellari
           - kproche
           - mikespreitzer
-          - oksaumya
           - pdettori
           - waltforme
 
@@ -190,7 +189,6 @@ safe-outputs:
                 'francostellari': 'stellari@us.ibm.com',
                 'kproche': 'kproche@us.ibm.com',
                 'mikespreitzer': 'mspreitz@us.ibm.com',
-                'oksaumya': 'saumyakr2006@gmail.com',
                 'pdettori': 'dettori@us.ibm.com',
                 'waltforme': 'jun.duan@ibm.com'
               };
@@ -272,7 +270,6 @@ Your task is to **generate ONE metrics email** for the selected maintainer using
 - francostellari → stellari@us.ibm.com
 - kproche → kproche@us.ibm.com
 - mikespreitzer → mspreitz@us.ibm.com
-- oksaumya → saumyakr2006@gmail.com
 - pdettori → dettori@us.ibm.com
 - waltforme → jun.duan@ibm.com
 

--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -26,7 +26,6 @@ jobs:
             "francostellari"
             "kproche"
             "mikespreitzer"
-            "oksaumya"
             "pdettori"
             "waltforme"
           )

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 approvers:
   - clubanderson
   - KPRoche
-  - oksaumya
 
 reviewers:
   - clubanderson
   - KPRoche
-  - oksaumya


### PR DESCRIPTION
## Summary
- Remove `oksaumya` from OWNERS (approvers + reviewers)
- Remove from maintainer-metrics workflow and run-all-maintainer-audits

## Test plan
- [ ] Verify OWNERS file updated
- [ ] Verify workflow files updated