### PR TITLE
🌱 Remove ezrasilvera from SECURITY_CONTACTS.md

### DIFF
--- a/SECURITY_CONTACTS.md
+++ b/SECURITY_CONTACTS.md
@@ -11,6 +11,5 @@ TO [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-
 
 clubanderson<br/>
 MikeSpreitzer<br/>
-ezrasilvera<br/>
 pdettori<br/>
 <!--security-contacts-end-->


### PR DESCRIPTION
## Summary
- Removes `ezrasilvera` from security contacts list as they are no longer active

## Test plan
- [ ] Verify SECURITY_CONTACTS.md renders correctly with remaining contacts