### PR TITLE
🐛 Add AI Missions Setup to sidebar nav and auto-refetch leaderboard

### DIFF
--- a/docs/content/console/ai-features.md
+++ b/docs/content/console/ai-features.md
@@ -23,6 +23,8 @@ KubeStellar Console uses AI Missions to automate multi-cluster Kubernetes operat
 
 ![AI Missions Panel](images/ai-missions-panel.png)
 
+> **Getting started?** See the [AI Missions Setup](ai-missions-setup.md) guide for step-by-step instructions on configuring API keys, selecting a model, and running your first mission.
+
 ---
 
 ## AI Missions

--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -419,6 +419,7 @@ See [kubestellar-mcp troubleshooting](/docs/kubestellar-mcp/overview/introductio
 ## Related Documentation
 
 - **[kubestellar-mcp Documentation](/docs/kubestellar-mcp/overview/introduction)** - Full guide to kubestellar-ops and kubestellar-deploy plugins
+- **[AI Missions Setup](ai-missions-setup.md)** - Configure AI providers, select a model, and run your first mission
 - **[Architecture](architecture.md)** - How the console components work together
 - **[Configuration](configuration.md)** - AI mode, token limits, and customization
 - **[Quick Start](quickstart.md)** - Get running in 5 minutes

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -188,14 +188,7 @@ export default function LeaderboardPage() {
   const [search, setSearch] = useState("");
   const [countdown, setCountdown] = useState("");
 
-  // Tick countdown every minute
-  useEffect(() => {
-    setCountdown(getCountdown());
-    const id = setInterval(() => setCountdown(getCountdown()), COUNTDOWN_TICK_MS);
-    return () => clearInterval(id);
-  }, []);
-
-  useEffect(() => {
+  const fetchLeaderboard = useCallback(() => {
     fetch(LEADERBOARD_DATA_PATH)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -210,6 +203,34 @@ export default function LeaderboardPage() {
         setIsLoading(false);
       });
   }, []);
+
+  // Tick countdown every minute and auto-refetch when a refresh window arrives
+  useEffect(() => {
+    setCountdown(getCountdown());
+    let lastRefreshHour = -1;
+    const id = setInterval(() => {
+      setCountdown(getCountdown());
+      // Re-fetch data when we cross a scheduled refresh boundary
+      const currentHour = new Date().getUTCHours();
+      const currentMinute = new Date().getUTCMinutes();
+      /** Grace period (minutes) after a scheduled refresh to trigger a re-fetch. */
+      const REFETCH_GRACE_MINUTES = 5;
+      if (
+        REFRESH_HOURS_UTC.includes(currentHour) &&
+        currentMinute < REFETCH_GRACE_MINUTES &&
+        lastRefreshHour !== currentHour
+      ) {
+        lastRefreshHour = currentHour;
+        fetchLeaderboard();
+      }
+    }, COUNTDOWN_TICK_MS);
+    return () => clearInterval(id);
+  }, [fetchLeaderboard]);
+
+  // Initial data fetch
+  useEffect(() => {
+    fetchLeaderboard();
+  }, [fetchLeaderboard]);
 
   const filteredEntries = useMemo(() => {
     if (!data?.entries) return [];

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -208,6 +208,7 @@ const NAV_STRUCTURE_CONSOLE: Array<{ title: string; items: NavItem[] }> = [
       { 'Cards': 'all-cards.md' },
       { 'Stats Blocks': 'stats-blocks.md' },
       { 'AI Features': 'ai-features.md' },
+      { 'AI Missions Setup': 'ai-missions-setup.md' },
       { 'Alerts': 'alerts.md' },
       { 'Feedback System': 'feedback.md' },
     ]


### PR DESCRIPTION
## Summary

- **Add AI Missions Setup page to console sidebar navigation** — The `ai-missions-setup.md` page existed but was missing from `NAV_STRUCTURE_CONSOLE` in `page-map.ts`, making it invisible in the sidebar. Added it under Features, after AI Features.
- **Add cross-links from AI Features and Installation pages** — Users can now discover the AI Missions Setup guide from related pages.
- **Auto-refetch leaderboard data at scheduled refresh times** — The countdown timer previously counted down to 0 but the page never re-fetched data. Now the leaderboard automatically re-fetches when a scheduled GitHub Actions refresh window arrives.

Fixes #1321
Fixes #1322
Fixes #1333

## Test plan

- [ ] Verify AI Missions Setup appears in the console docs sidebar under Features > AI Features
- [ ] Verify the cross-link callout appears at the top of the AI Features page
- [ ] Verify the AI Missions Setup link appears in Installation > Related Documentation
- [ ] Verify the leaderboard page auto-refreshes data when the countdown reaches a scheduled refresh hour