### PR TITLE
📖 Add console version indicator to docs overview page

### DIFF
--- a/docs/content/console/console-overview.md
+++ b/docs/content/console/console-overview.md
@@ -8,6 +8,9 @@ description: >
 
 # KubeStellar Console
 
+!!! info "Console Version"
+    **Current Console Release: v0.3.17** — The console has its own release cycle, independent from KubeStellar core releases. The docs site version picker reflects KubeStellar core versions (e.g., v0.29.0), not console versions. These console docs always reflect the latest console release. See [releases](https://github.com/kubestellar/console/releases) for the full changelog.
+
 The KubeStellar Console is a modern, AI-powered multi-cluster management interface that provides real-time monitoring, intelligent insights, and a customizable dashboard experience for managing Kubernetes clusters at scale.
 
 ![Dashboard Overview](images/dashboard-overview-mar05.jpg)


### PR DESCRIPTION
## Summary
- Adds a visible version callout (v0.3.17) to the console docs overview page
- Explains that the console has its own release cycle independent from KubeStellar core
- Clarifies that the docs site version picker shows KubeStellar core versions, not console versions

Addresses kubestellar/console#4551 — MikeSpreitzer reported confusion between the console version (v0.3.17) and the docs site version picker (which shows KubeStellar core versions like v0.29.0).

## Test plan
- [ ] Verify the admonition renders correctly in mkdocs preview
- [ ] Confirm the GitHub releases link works