### PR TITLE
fix: add robots.txt, sitemap.xml, and SEO metadata

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -20,6 +20,8 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
 });
 
+const SITE_URL = "https://kubestellar.io";
+
 export async function generateMetadata({
   params,
 }: {
@@ -28,9 +30,42 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "metadata" });
 
+  const title = t("title");
+  const description = t("description");
+
   return {
-    title: t("title"),
-    description: t("description"),
+    title,
+    description,
+    metadataBase: new URL(SITE_URL),
+    alternates: {
+      canonical: `/${locale}`,
+    },
+    openGraph: {
+      type: "website",
+      locale: locale === "en" ? "en_US" : locale,
+      url: `${SITE_URL}/${locale}`,
+      siteName: "KubeStellar",
+      title,
+      description,
+      images: [
+        {
+          url: "/KubeStellar-with-Logo.png",
+          width: 1200,
+          height: 630,
+          alt: "KubeStellar - Multi-Cluster Kubernetes Orchestration",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ["/KubeStellar-with-Logo.png"],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
   };
 }
 

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { DocsNavbar, DocsFooter, DocsBanner } from '@/components/docs/index'
 import { DocsProvider } from '@/components/docs/DocsProvider'
 import { MobileOverlay } from '@/components/docs/MobileOverlay'
@@ -17,9 +18,47 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
 })
 
-export const metadata = {
-  title: 'KubeStellar - Multi-Cluster Kubernetes Orchestration',
-  description: 'Official documentation for KubeStellar - Multi-cluster orchestration platform',
+const SITE_URL = 'https://kubestellar.io'
+const SITE_TITLE = 'KubeStellar Docs - Multi-Cluster Kubernetes Orchestration'
+const SITE_DESCRIPTION =
+  'Official documentation for KubeStellar. Learn how to orchestrate workloads across multiple Kubernetes clusters with intelligent distribution, unified management, and seamless multi-cluster operations.'
+
+export const metadata: Metadata = {
+  title: {
+    default: SITE_TITLE,
+    template: '%s | KubeStellar Docs',
+  },
+  description: SITE_DESCRIPTION,
+  metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: '/docs',
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: `${SITE_URL}/docs`,
+    siteName: 'KubeStellar',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    images: [
+      {
+        url: '/KubeStellar-with-Logo.png',
+        width: 1200,
+        height: 630,
+        alt: 'KubeStellar - Multi-Cluster Kubernetes Orchestration',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    images: ['/KubeStellar-with-Logo.png'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 type Props = {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = 'https://kubestellar.io'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,188 @@
+import type { MetadataRoute } from 'next'
+import fs from 'fs'
+import path from 'path'
+import { PROJECTS, type ProjectId } from '@/config/versions'
+
+const SITE_URL = 'https://kubestellar.io'
+
+/** Weekly update frequency for docs content */
+const DOCS_CHANGE_FREQ = 'weekly' as const
+/** Monthly update frequency for marketing pages */
+const MARKETING_CHANGE_FREQ = 'monthly' as const
+
+/** Priority for the homepage */
+const HOMEPAGE_PRIORITY = 1.0
+/** Priority for top-level marketing pages */
+const MARKETING_PRIORITY = 0.8
+/** Priority for docs landing / project root pages */
+const DOCS_ROOT_PRIORITY = 0.9
+/** Priority for individual docs pages */
+const DOCS_PAGE_PRIORITY = 0.7
+
+/**
+ * Recursively find all .md and .mdx files in a directory.
+ * Returns paths relative to the given base directory.
+ */
+function findMarkdownFiles(dir: string, baseDir: string = dir): string[] {
+  const files: string[] = []
+
+  if (!fs.existsSync(dir)) {
+    return files
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      // Skip hidden directories, node_modules, common-subs (partials), and images
+      if (
+        !entry.name.startsWith('.') &&
+        !entry.name.startsWith('_') &&
+        entry.name !== 'node_modules' &&
+        entry.name !== 'common-subs' &&
+        entry.name !== 'images'
+      ) {
+        files.push(...findMarkdownFiles(fullPath, baseDir))
+      }
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) &&
+      !entry.name.startsWith('_')
+    ) {
+      const relativePath = path.relative(baseDir, fullPath).replace(/\\/g, '/')
+      files.push(relativePath)
+    }
+  }
+
+  return files
+}
+
+/**
+ * Convert a markdown file path to its URL route for a given project.
+ * Uses the same slug logic as page-map.ts navigation structures.
+ */
+function filePathToRoute(filePath: string, projectId: ProjectId): string {
+  // Remove file extension
+  let route = filePath.replace(/\.(md|mdx)$/i, '')
+
+  // Remove trailing /index (index files map to the parent folder route)
+  route = route.replace(/\/index$/, '')
+
+  // For project sub-paths (a2a, kubeflex, etc.), strip the project prefix
+  // since content is already scoped to the project directory
+  const project = PROJECTS[projectId]
+  const projectBase = project.basePath ? `/docs/${project.basePath}` : '/docs'
+
+  return `${projectBase}/${route}`
+}
+
+/**
+ * Get the last modified date for a file, falling back to current date.
+ */
+function getLastModified(filePath: string): Date {
+  try {
+    const stats = fs.statSync(filePath)
+    return stats.mtime
+  } catch {
+    return new Date()
+  }
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = []
+  const contentRoot = path.join(process.cwd(), 'docs', 'content')
+
+  // --- Homepage ---
+  entries.push({
+    url: SITE_URL,
+    lastModified: new Date(),
+    changeFrequency: MARKETING_CHANGE_FREQ,
+    priority: HOMEPAGE_PRIORITY,
+  })
+
+  // --- Marketing / locale pages ---
+  const marketingPages = [
+    '/en',
+    '/en/products',
+    '/en/partners',
+    '/en/programs',
+    '/en/leaderboard',
+    '/en/marketplace',
+    '/en/quick-installation',
+    '/en/contribute-handbook',
+    '/en/ladder',
+    '/en/playground',
+  ]
+
+  for (const page of marketingPages) {
+    entries.push({
+      url: `${SITE_URL}${page}`,
+      lastModified: new Date(),
+      changeFrequency: MARKETING_CHANGE_FREQ,
+      priority: MARKETING_PRIORITY,
+    })
+  }
+
+  // --- Docs landing page ---
+  entries.push({
+    url: `${SITE_URL}/docs`,
+    lastModified: new Date(),
+    changeFrequency: DOCS_CHANGE_FREQ,
+    priority: DOCS_ROOT_PRIORITY,
+  })
+
+  // --- KubeStellar docs (root content) ---
+  const ksFiles = findMarkdownFiles(contentRoot)
+    .filter((f) => {
+      // Only include files directly in the root or under kubestellar/, ui-docs/,
+      // contributing/, community/, news/ — NOT project sub-dirs
+      const projectDirs = ['a2a', 'kubeflex', 'multi-plugin', 'kubestellar-mcp', 'console']
+      const topDir = f.split('/')[0]
+      return !projectDirs.includes(topDir)
+    })
+
+  for (const file of ksFiles) {
+    const fullPath = path.join(contentRoot, file)
+    const route = filePathToRoute(file, 'kubestellar')
+
+    entries.push({
+      url: `${SITE_URL}${route}`,
+      lastModified: getLastModified(fullPath),
+      changeFrequency: DOCS_CHANGE_FREQ,
+      priority: DOCS_PAGE_PRIORITY,
+    })
+  }
+
+  // --- Project-specific docs ---
+  const projectIds: ProjectId[] = ['a2a', 'kubeflex', 'multi-plugin', 'kubestellar-mcp', 'console']
+
+  for (const projectId of projectIds) {
+    const projectContentPath = path.join(contentRoot, PROJECTS[projectId].basePath)
+
+    // Add project root entry
+    entries.push({
+      url: `${SITE_URL}/docs/${PROJECTS[projectId].basePath}`,
+      lastModified: new Date(),
+      changeFrequency: DOCS_CHANGE_FREQ,
+      priority: DOCS_ROOT_PRIORITY,
+    })
+
+    const projectFiles = findMarkdownFiles(projectContentPath)
+
+    for (const file of projectFiles) {
+      const fullPath = path.join(projectContentPath, file)
+      const route = filePathToRoute(file, projectId)
+
+      entries.push({
+        url: `${SITE_URL}${route}`,
+        lastModified: getLastModified(fullPath),
+        changeFrequency: DOCS_CHANGE_FREQ,
+        priority: DOCS_PAGE_PRIORITY,
+      })
+    }
+  }
+
+  return entries
+}


### PR DESCRIPTION
## Summary
- Adds `src/app/robots.ts` — Next.js App Router convention that generates `/robots.txt` allowing all crawlers and pointing to the sitemap
- Adds `src/app/sitemap.ts` — dynamically enumerates all 148+ doc pages across all projects (KubeStellar, A2A, KubeFlex, Multi-Plugin, KubeStellar MCP, Console) plus marketing/locale pages, with last-modified timestamps from the filesystem
- Enhances `src/app/docs/layout.tsx` metadata with OpenGraph (`og:title`, `og:description`, `og:image`), Twitter Card (`summary_large_image`), canonical URL, and a structured title template (`%s | KubeStellar Docs`)
- Enhances `src/app/[locale]/layout.tsx` metadata with the same OpenGraph/Twitter Card improvements, using the existing i18n translations

## Test plan
- [x] `npm run build` passes with no errors — both `/robots.txt` and `/sitemap.xml` routes appear in build output as static pages
- [ ] Verify `/robots.txt` returns valid robots directives after deploy
- [ ] Verify `/sitemap.xml` lists all expected doc URLs after deploy
- [ ] Verify page source includes `og:title`, `og:description`, `og:image` meta tags
- [ ] Verify Twitter Card meta tags are present in page source