### PR TITLE
Fix typos and broken links across documentation

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,14 @@
 # Typos configuration
 # https://github.com/crate-ci/typos
 
+[files]
+extend-exclude = [
+    "*.svg",
+    "public/data/contributors/",
+    "public/data/leaderboard.json",
+    "messages/",
+]
+
 [default.extend-words]
 # KubeStellar terms
 KubeStellar = "KubeStellar"
@@ -23,6 +31,17 @@ GKE = "GKE"
 # Common false positives
 ND = "ND"
 IST = "IST"
+
+# Technical terms
+Hashi = "Hashi"
+RTO = "RTO"
+IFoS = "IFoS"
+Fo = "Fo"
+
+# Contributor usernames (not typos)
+MAVRICK = "MAVRICK"
+mavrick = "mavrick"
+Parth = "Parth"
 
 # Add repo-specific false positives here:
 # word = "word"

--- a/docs/content/GOVERNANCE.md
+++ b/docs/content/GOVERNANCE.md
@@ -129,7 +129,7 @@ Maintainer who is accused of a CoC violation.
 Committee; most maintainer-run projects do not.  Remember to place a link
 to the private Maintainer mailing list or alias in the code-of-conduct file.-->
 
-[Code of Conduct](coc-inc.md)
+[Code of Conduct](contributing/coc-inc.md)
 violations by community members will be discussed and resolved
 on the [private Maintainer mailing list](https://groups.google.com/u/1/g/kubestellar-dev-private).
 
@@ -142,7 +142,7 @@ contributors to handle it. The Maintainers will review who is assigned to this
 at least once a year.
 
 The Security Response Team is responsible for handling all reports of security 
-holes and breaches according to the [security policy](security/security-inc.md).
+holes and breaches according to the [security policy](contributing/security/security-inc.md).
 
 ## Voting
 

--- a/docs/content/console/console-features.md
+++ b/docs/content/console/console-features.md
@@ -1874,8 +1874,6 @@ The console can now upgrade itself when deployed via Helm — no manual `helm up
 
 ## Pod Exec Terminal (New in March 2026)
 
-![Pod Exec Terminal](images/pod-exec-terminal-mar14.png)
-
 Interactive shell sessions directly from the console — no need to switch to `kubectl exec`.
 
 ### Features

--- a/docs/content/contributing/CONTRIBUTINGKS.md
+++ b/docs/content/contributing/CONTRIBUTINGKS.md
@@ -19,7 +19,7 @@ Please read the following guidelines if you're interested in contributing to Kub
 ### Contributing Code -- Prerequisites
 
 
-Please make sure that your environment has all the necessary versions as spelled out in the prerequisites section of our [user guide](docs/content/kubestellar/pre-reqs.md)
+Please make sure that your environment has all the necessary versions as spelled out in the prerequisites section of our [user guide](../kubestellar/pre-reqs.md)
 
 ### Issues
 
@@ -74,7 +74,7 @@ A recommended format for final commit messages is as follows:
 In conformance with CNCF expectations, we will only merge commits that indicate your agreement with the [Developer Certificate of Origin](#certificate-of-origin). The CNCF defines how to do this, and there are two cases: one for developers working for an organization that is a CNCF member, and one for contributors acting as individuals. For the latter, assent is indicated by doing a Git "sign-off" on the commit. 
 
 
-See [Git Commit Signoff and Signing](docs/content/kubestellar/pr-signoff.md) for more information on how to do that.
+See [Git Commit Signoff and Signing](../kubestellar/pr-signoff.md) for more information on how to do that.
 
 ### Pull Requests
 [View active Pull Requests on GitHub](https://github.com/kubestellar/kubestellar/pulls)
@@ -187,14 +187,14 @@ If you have any questions about contributing, don't hesitate to reach out to us 
 ## Testing Locally
 
 
-Our [Getting Started](docs/content/kubestellar/get-started.md) guide shows a user how to install a simple "kick the tires" instance of KubeStellar using a helm chart and kind.
+Our [Getting Started](../kubestellar/get-started.md) guide shows a user how to install a simple "kick the tires" instance of KubeStellar using a helm chart and kind.
 
 To set up and test a development system, please refer to the _test/e2e/README.md_ file in the GitHub repository.
 After running any of those e2e (end to end) tests you will be left with a running system that can be exercised further.
 
 ### Testing changes to the helm chart
 
-If you are interested in modifying the Helm chart itself, look at the User Guide page on the [Core Helm chart](docs/content/kubestellar/core-chart.md) for more information on its many options before you begin, notably on how to specify using a local version of the script.
+If you are interested in modifying the Helm chart itself, look at the User Guide page on the [Core Helm chart](../kubestellar/core-chart.md) for more information on its many options before you begin, notably on how to specify using a local version of the script.
 
 ### Testing the script against an upcoming release
 
@@ -204,7 +204,7 @@ appear in the new release.
 
 ## Licensing
 
-KubeStellar is [Apache 2.0 licensed](LICENSE) and we accept contributions via GitHub pull requests.
+KubeStellar is [Apache 2.0 licensed](https://github.com/kubestellar/docs/blob/main/LICENSE) and we accept contributions via GitHub pull requests.
 
 ## Certificate of Origin
 

--- a/docs/content/contributing/contribute.md
+++ b/docs/content/contributing/contribute.md
@@ -25,7 +25,7 @@ If you are contributing via the GitHub web interface, navigate to the **Settings
 
 ![signoff-via-github-ui](../images/signoff-via-github-ui.png)
 
-If you are contributing via the command line terminal, run the `git commit --signoff --message [commit message]` or `git commit -s -m [commit message]` command when making each commit. For more detailed information about signing and signing off on commits, including steps to create signing keys and use both the `-s` and `-S` options, see [Sign-off and Signing Contributions](pr-signoff.md).
+If you are contributing via the command line terminal, run the `git commit --signoff --message [commit message]` or `git commit -s -m [commit message]` command when making each commit. For more detailed information about signing and signing off on commits, including steps to create signing keys and use both the `-s` and `-S` options, see [Sign-off and Signing Contributions](../kubestellar/pr-signoff.md).
 
 
 
@@ -48,7 +48,7 @@ Read the resources to gain a better understanding of the contribution processes.
 - **Security**
     - **[Policy](../contributing/security/security-inc.md)** Security Policies
     - **[Contacts](../contributing/security/security_contacts-inc.md)** Who to contact with security concerns
-- **[Testing](testing.md)** How to use the preconfigured tests in the repository
+- **[Testing](../kubestellar/testing.md)** How to use the preconfigured tests in the repository
 - **[Packaging](../kubestellar/packaging.md)** How the components of KubeStellar are organized
 - **[Release Process](../kubestellar/release.md)** All the steps involved in creating and publishing a new release of KubeStellar
 - **[Release Testing](../kubestellar/release-testing.md)** Steps involved in testing a release or release candidate before merging it into the main branch.

--- a/docs/content/contributing/documentation/docs-styleguide.md
+++ b/docs/content/contributing/documentation/docs-styleguide.md
@@ -48,7 +48,7 @@ For a more detailed guidance on writing alt-texts, we recommend checking out [We
 
 We also recommend keeping the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation.
 
-That said, accessibility is an ever-evolving area in technical content. As an open-source contributor, familiarizing yourself with accessibility standards will help you make more thoughtful and inclusive descisions, whether in documentation, or other areas of your work.
+That said, accessibility is an ever-evolving area in technical content. As an open-source contributor, familiarizing yourself with accessibility standards will help you make more thoughtful and inclusive decisions, whether in documentation, or other areas of your work.
 
 If you want to deepen your understanding of accessibility, we recommend checking out the following resources:
 

--- a/docs/content/contributing/operations/code-management.md
+++ b/docs/content/contributing/operations/code-management.md
@@ -127,7 +127,7 @@ Your selected Action workflow will execute and the results will be available whe
 
 ## Create a Pull Request (PR) from your Github repo branch in order to request review and approval from the Kubestellar team
 
-Take a look at [the contribution guidelines](../contributing-inc.md).
+Take a look at [the contribution guidelines](../documentation/contributing-inc.md).
 
 You can create a Pull Request from your Github web repository by selecting the "Compare & pull request" button.
 

--- a/docs/content/kubeflex/contributors.md
+++ b/docs/content/kubeflex/contributors.md
@@ -97,6 +97,6 @@ LATEST_TAG=<tag used for image> make ko-build-push-cmupdate
    if it succeeds. If not then there is a problem that needs to be
    remedied and a newer release made.
 
-1. The goreleaser workflow will also create a branch named `brew` with some changes (to the homebrew instsall script) that need to get merged into `main`. Make a PR to merge `brew` into `main`, and get it approved and merged.
+1. The goreleaser workflow will also create a branch named `brew` with some changes (to the homebrew install script) that need to get merged into `main`. Make a PR to merge `brew` into `main`, and get it approved and merged.
 
 1. To avoid leaving a time bomb, delete that `brew` branch after it was merged into `main` (the goreleaser will fail to create the new `brew` branch if one already exists).

--- a/docs/content/kubeflex/users.md
+++ b/docs/content/kubeflex/users.md
@@ -304,7 +304,7 @@ cp1    True     True    5d18h
 ```
 
 In the above example, `SYNCED=True` means that all resources required to run the control plane
-have been succssfully applied on the hosting cluster, and `READY=True` means that the Kube APIServer
+have been successfully applied on the hosting cluster, and `READY=True` means that the Kube APIServer
 for the control plane is available. You may also use `kubectl describe` to get more info about the
 control plane.
 
@@ -633,7 +633,7 @@ Delete a context within your kubeconfig file. If the context deleted is your cur
 With post-create hooks you can automate applying kubernetes templates on the hosting cluster or on
 a hosted control plane right after the creation of a control plane. Some relevant use cases are:
 
-- Applying OpenShift CRDs on a control plane to be used as a Workload Description Space (WDS) for deplying
+- Applying OpenShift CRDs on a control plane to be used as a Workload Description Space (WDS) for deploying
 workloads to OpenShift clusters.
 
 - Starting a new controller in the namespace of a control plane in the hosting cluster that interacts
@@ -823,7 +823,7 @@ Variables are specified using Helm-like syntax:
 
 Note that the double quotes are required for a valid yaml.
 
-Currently avilable built-in objects are:
+Currently available built-in objects are:
 
 - "{{.Namespace}}" - the namespace hosting the control plane
 - "{{.ControlPlaneName}}" - the name of the control plane

--- a/docs/content/kubestellar/architecture.md
+++ b/docs/content/kubestellar/architecture.md
@@ -264,7 +264,7 @@ There are two controllers in the KubeStellar controller manager:
       client to inventory space).
 
     - This controller maintains an internal data structure called the
-      `BindingPolicyResover` that tracks what `Binding` _should_
+      `BindingPolicyResolver` that tracks what `Binding` _should_
       correspond to each `BindingPolicy`, and uses it to make that so.
 
 - Status controller - one client connected to the WDS and one
@@ -291,7 +291,7 @@ references to workload objects and the concrete list of references to
 inventory objects that were selected by the policy.
 
 The Binding Controller is centered on its workqueue and an internal
-data structure, called a `BindingPolicyResover`, that represents the
+data structure, called a `BindingPolicyResolver`, that represents the
 set of `Binding` objects that _should_ exist based on the controller's
 inputs. The controller has informers for all of its inputs: a static
 collection for the control objects (`BindingPolicy` and inventory
@@ -300,10 +300,10 @@ for the workload objects. The controller also has informers for its
 output objects (i.e., `Binding` objects). Every notification from an
 informer is handled by putting a relevant object reference into the
 work queue. Working on a reference to an input involves updating the
-`BindingPolicyResover` and enqueuing a reference to any output object
+`BindingPolicyResolver` and enqueuing a reference to any output object
 (`Binding`) that might need a change. Working on a reference to a
 `Binding` involves comparing what is actually in that `Binding` with
-what the `BindingPolicyResover` says should be there, and
+what the `BindingPolicyResolver` says should be there, and
 creating/updating/deleting the `Binding` if there is a difference.
 
 The Binding Controller also provides two informer-like services that
@@ -329,7 +329,7 @@ handler and the work queue as follows:
     - Starts Informer
     - Stores informer and lister in a map indexed by GVR
 - Waits for all caches to sync
-- Gets the list of all `BindingPolicy` objects and, for each one, invokes the `BindingPolicyResover` method for the presence of the `BindingPolicy`.
+- Gets the list of all `BindingPolicy` objects and, for each one, invokes the `BindingPolicyResolver` method for the presence of the `BindingPolicy`.
 - Starts N workers to process work queue
 
 The informer and watches specific resources on the WDS API Server; on
@@ -343,14 +343,14 @@ handling functions (`AddFunc`, `UpdateFunc`, `DeleteFunc`)
 For a `BindingPolicy` that is deleted or being deleted, sync consists of the following steps.
 
 1. Ensure the absence of the KubeStellar finalizer on the `BindingPolicy`.
-1. Invoke the `BindingPolicyResover` method for the absence of the `BindingPolicy`.
+1. Invoke the `BindingPolicyResolver` method for the absence of the `BindingPolicy`.
 
 For a `BindingPolicy` that is neither deleted nor being deleted, sync consists of the following steps.
 
 1. Ensure the presence of the KubeStellar finalizer on the `BindingPolicy`.
-1. Invoke the `BindingPolicyResover` method for the presence of the `BindingPolicy`.
+1. Invoke the `BindingPolicyResolver` method for the presence of the `BindingPolicy`.
 1. Find all the WECs (which are represented by inventory objects) that match the `BindingPolicy`.
-1. Invoke the `BindingPolicyResover` method that associates a BindingPolicy's name with its current set of matching WECs.
+1. Invoke the `BindingPolicyResolver` method that associates a BindingPolicy's name with its current set of matching WECs.
 1. Enqueue a reference to every workload object.
 
 #### Sync Workload Object
@@ -379,7 +379,7 @@ Otherwise the controller proceeds as follows, independently for each
 
 #### Sync Binding
 
-If the `BindingPolicyResover` is unaware of the existence of a
+If the `BindingPolicyResolver` is unaware of the existence of a
 corresponding `BindingPolicy` then almost nothing needs to be done:
 the `BindingPolicy` is either being created or deleted and there will
 be more syncing done due to other events. All that need be done here
@@ -392,7 +392,7 @@ nothing more is done.
 In the remaining cases, the controller takes the following steps.
 
 1. The controller generates the proper `BindingSpec` from the
-   information in the `BindingPolicyResover`. The controller compares
+   information in the `BindingPolicyResolver`. The controller compares
    that with the `BindingSpec` (if any) from the `Binding` lister. If
    there is a difference then the controller updates the `Binding`
    object and has the resolver notify the registered handlers for

--- a/docs/content/kubestellar/core-chart-argocd.md
+++ b/docs/content/kubestellar/core-chart-argocd.md
@@ -139,7 +139,7 @@ argocd:
     syncPolicy: auto # default: manual
 ```
 
-Alternatively, the same result can be achieved from Helm CLI by using the followig minimal argument (note that the default values are not explicitely set):
+Alternatively, the same result can be achieved from Helm CLI by using the following minimal argument (note that the default values are not explicitly set):
 
 ```shell
 --set-json='argocd.applications=[ { "name": "scenario-6", "repoURL": "https://github.com/kubestellar/kubestellar.git", "path": "hack/argo/nginx", "destinationWDS": "wds1", "destinationNamespace": "nginx-sa" } ]'

--- a/docs/content/kubestellar/core-chart.md
+++ b/docs/content/kubestellar/core-chart.md
@@ -98,7 +98,7 @@ InstallPCHs: true
 # - a mandatory unique name
 # - an optional type, which could be host, vcluster, or external (default to vcluster, if not specified)
 # - an optional install_clusteradm flag, which could be true  or false  (default to true) to enable/disable the installation of OCM in the control plane
-# - an optional bootstrapSecret secion to be used for Control Plabes of type external (more details below)
+# - an optional bootstrapSecret section to be used for Control Plabes of type external (more details below)
 ITSes: # ==> installs ocm (optional) + ocm-status-addon
 
 # List the Workload Description Spaces (WDSes) to be created by the chart
@@ -151,7 +151,7 @@ ITSes: # all the CPs in this list will execute the its.yaml PCH
 
 where `name` must specify a name unique among all the control planes in that KubeFlex deployment, the optional `type` can be vcluster (default), host, or external, see [here](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md) for more information, and the optional `install_clusteradm`can be either true (default) or false to enable or disable the installation of OCM in the control plane.
 
-When the ITS `type` is `external`, the `bootstrapSecret` sub-section can be used to indicate the bootstrap secret used by KubeFlex to connect to the external cluster. Specifically, it can be used to specify any combination of (a) the name of the secret, (b) the namespace containing the secret, and (c) the name of the key containg the kubeconfig of the external cluster if they need to be different from their default value.
+When the ITS `type` is `external`, the `bootstrapSecret` sub-section can be used to indicate the bootstrap secret used by KubeFlex to connect to the external cluster. Specifically, it can be used to specify any combination of (a) the name of the secret, (b) the namespace containing the secret, and (c) the name of the key containing the kubeconfig of the external cluster if they need to be different from their default value.
 
 If the secret was created using the [create-external-bootstrap-secret.sh](https://github.com/kubestellar/kubestellar/tree/v{{ config.ks_latest_release }}/scripts/create-external-bootstrap-secret.sh) script and the value passed to the argument `--controlplane` matches the name of the Control Plane specified by the Helm chart, then the sub-section `bootstrapSecret` is not required because all default values will identify the bootstrap secret created by the script. More specifically, if an external kind cluster was created with the command `kind create cluster --name its1` and the `create-external-bootstrap-secret.sh --controlplane its1 --verbose` command was used to create the bootstrap secret, then it would be enough to inform the Helm chart with `--set-json='ITSes=[{"name":"its1","type":"external"}]'`.
 

--- a/docs/content/kubestellar/knownissue-cpu-insufficient-for-its1.md
+++ b/docs/content/kubestellar/knownissue-cpu-insufficient-for-its1.md
@@ -25,7 +25,7 @@ On Mac computers, Docker runs all of your containers in a virtual machine. Examp
 
 For example, the colima default VM is configured to use `--cpu 2 --memory 4` --- which is insufficient for Kubestellar components on KinD clusters. In fact, KinD inherit **colima** resources when created.
 
-To solve this issue, increase colima resource capacity to increase KinD clusters resource capcity:
+To solve this issue, increase colima resource capacity to increase KinD clusters resource capacity:
 
 1. Stop colima VM
 

--- a/docs/content/kubestellar/knownissue-helm-ghcr.md
+++ b/docs/content/kubestellar/knownissue-helm-ghcr.md
@@ -7,7 +7,7 @@ When following the
 the command to instantiate KubeStellar's core Helm chart. The error
 message is as follows.
 
-> Error: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Akubestellar%2Fkubestellar%2Fcore-chart%3Apull&service=ghcr.io: 403 Fobidden
+> Error: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Akubestellar%2Fkubestellar%2Fcore-chart%3Apull&service=ghcr.io: 403 Forbidden
 
 This is [Issue 2544](https://github.com/kubestellar/kubestellar/issues/2544).
 

--- a/docs/content/kubestellar/pr-signoff.md
+++ b/docs/content/kubestellar/pr-signoff.md
@@ -156,7 +156,7 @@ This is not recommended for individual contributors, because the commits that it
 Whether it's editing files from Kubestellar.io or directly from the Kubestellar Github, there are a couple steps to follow that streamlines the workflow of your PR:
 
 1. Changes made to any file are automatically committed to a new branch in your fork.
-    - After clicking **Commit changes...**, write your commit message summary line and any extended desription that you want. Then click **Propose changes**, review your changes, and then create the PR.
+    - After clicking **Commit changes...**, write your commit message summary line and any extended description that you want. Then click **Propose changes**, review your changes, and then create the PR.
     - When making the PR, make sure to specify the type of PR at the beginning of the PR's title (i.e. :bug: if it addresses a bug-type issue)
 
 1. If the PR addresses a specific issue that has already been opened in GitHub, make sure to include the open issue number in **Related Issue(s)** (i.e. `Fixes #NNNN`); this will cause GitHub to automatically close the Issue once the PR is merged. If you have finished addressing an open issue without getting it automatically closed then explicitly close it.

--- a/docs/content/kubestellar/release-notes.md
+++ b/docs/content/kubestellar/release-notes.md
@@ -81,7 +81,7 @@ The major changes since 0.25.1 are as follows.
 - The demo environment creation script is much more reliable, mainly due to no longer attempting concurrent operations. Still, external network/server hiccups can cause the script to fail.
 - This release removes the thrashing of workload objects in the WEC in the case where the transport controller's `max-num-wrapped` is 1.
 - This release adds reporting, in `BindingPolicy` and `Binding` status, of whether any of the referenced `StatusCollector` objects do not exist.
-- This release changes the schema for a `BindingPolicy` so that the request for sigleton status return is made/not-made independently in each `DownsyncPolicyClause` rather than once on the whole `BindingPolicySpec`. The schema for `Binding` objects is changed correspondingly. **This is a breaking change in the YAML schema for Binding[Policy] objects that request singleton status return.**
+- This release changes the schema for a `BindingPolicy` so that the request for singleton status return is made/not-made independently in each `DownsyncPolicyClause` rather than once on the whole `BindingPolicySpec`. The schema for `Binding` objects is changed correspondingly. **This is a breaking change in the YAML schema for Binding[Policy] objects that request singleton status return.**
 
 ### Remaining limitations in 0.26.0
 
@@ -119,7 +119,7 @@ This release adds the option for the core Helm chart to not take responsibility 
 
 This release removes the thrashing of workload objects in the WEC in the case where the transport controller's `max-num-wrapped` is 1.
 
-This release changes the schema for a `BindingPolicy` so that the request for sigleton status return is made/not-made independently in each `DownsyncPolicyClause` rather than once on the whole `BindingPolicySpec`. The schema for `Binding` objects is changed correspondingly.
+This release changes the schema for a `BindingPolicy` so that the request for singleton status return is made/not-made independently in each `DownsyncPolicyClause` rather than once on the whole `BindingPolicySpec`. The schema for `Binding` objects is changed correspondingly.
 
 ### Remaining limitations in 0.26.0-alpha.1 and 0.26.0-alpha.2
 

--- a/docs/content/kubestellar/teardown.md
+++ b/docs/content/kubestellar/teardown.md
@@ -170,7 +170,7 @@ KubeStellar core Helm chart.
 
 ## Deleting Remaining Stuff in the KubeFlex hosting cluster
 
-### Delete Helm chart instances in the KubeFlex hosting cluter
+### Delete Helm chart instances in the KubeFlex hosting cluster
 
 Look at the Helm chart instances in the KubeFlex hosting cluster. You
 might use a command like the following.
@@ -194,7 +194,7 @@ more instances of it will be in that list. In this case you can simply
 delete those Helm chart instances. If the core chart was not used to
 install KubeFlex in its hosting cluster then you will need to delete
 the `kubeflex-system` Helm chart instance. That will probably not
-delete the postgress chart instance. If that remains, delete it too.
+delete the postgres chart instance. If that remains, delete it too.
 
 Following is an example of a command that deletes a Helm chart
 instance.

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -66,7 +66,7 @@ For a complete walkthrough, see the [Quick Start Guide](kubestellar/get-started.
 - **Slack**: [`#kubestellar-dev`](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
 - **Mailing Lists**: [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) and [kubestellar-users](https://groups.google.com/g/kubestellar-users)
 - **YouTube**: [Community meetings and demos](https://www.youtube.com/@kubestellar)
-- **Contributing**: [Contribution guide](contributing/contributing-inc.md)
+- **Contributing**: [Contribution guide](contributing/documentation/contributing-inc.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Fix 20+ typos across 12 documentation files (architecture, teardown, core-chart, release-notes, kubeflex docs, contributing docs)
- Fix 10+ broken relative links in GOVERNANCE.md, CONTRIBUTINGKS.md, contribute.md, code-management.md, readme.md
- Remove broken image reference for non-existent pod-exec-terminal screenshot
- Update `_typos.toml` with file exclusions (SVGs, contributor data, translations) and false-positive suppression for technical terms

### Typos fixed
| File | Typo | Fix |
|------|------|-----|
| architecture.md (x10) | `Resover` | `Resolver` |
| teardown.md | `cluter`, `postgress` | `cluster`, `postgres` |
| core-chart-argocd.md | `followig`, `explicitely` | `following`, `explicitly` |
| release-notes.md (x2) | `sigleton` | `singleton` |
| core-chart.md | `secion`, `containg` | `section`, `containing` |
| knownissue-cpu-insufficient-for-its1.md | `capcity` | `capacity` |
| knownissue-helm-ghcr.md | `Fobidden` | `Forbidden` |
| kubeflex/contributors.md | `instsall` | `install` |
| kubeflex/users.md | `succssfully`, `deplying`, `avilable` | `successfully`, `deploying`, `available` |
| pr-signoff.md | `desription` | `description` |
| docs-styleguide.md | `descisions` | `decisions` |

### Links fixed
| File | Issue |
|------|-------|
| GOVERNANCE.md | `coc-inc.md` → `contributing/coc-inc.md` |
| GOVERNANCE.md | `security/security-inc.md` → `contributing/security/security-inc.md` |
| CONTRIBUTINGKS.md (x4) | `docs/content/kubestellar/...` → `../kubestellar/...` |
| contribute.md | `pr-signoff.md` → `../kubestellar/pr-signoff.md` |
| contribute.md | `testing.md` → `../kubestellar/testing.md` |
| code-management.md | `../contributing-inc.md` → `../documentation/contributing-inc.md` |
| readme.md | `contributing/contributing-inc.md` → `contributing/documentation/contributing-inc.md` |
| console-features.md | Removed broken `pod-exec-terminal-mar14.png` image reference |

Closes #1354
Closes #1355

## Test plan
- [x] `typos --format brief` returns zero errors on the full repo
- [x] Verified all fixed relative links resolve to existing files
- [ ] CI build passes