### PR TITLE
Add contribution radar chart to leaderboard profiles

### DIFF
--- a/src/app/[locale]/leaderboard/[username]/page.tsx
+++ b/src/app/[locale]/leaderboard/[username]/page.tsx
@@ -141,6 +141,306 @@ const REPO_COLORS: Record<string, string> = {
   "console-marketplace": "text-orange-400 bg-orange-500/10",
 };
 
+// ── Radar Chart ──────────────────────────────────────────────────────
+
+/** Number of axes in the radar chart */
+const RADAR_AXIS_COUNT = 6;
+/** Radar chart radius in SVG units */
+const RADAR_RADIUS = 120;
+/** Center coordinate for the radar chart SVG */
+const RADAR_CENTER = 150;
+/** Number of concentric grid rings */
+const RADAR_GRID_RINGS = 4;
+/** Minimum score threshold to display a dimension (avoids empty-looking charts) */
+const RADAR_MIN_DISPLAY_SCORE = 0.08;
+
+/**
+ * The 6 contribution dimensions, each with keywords that map topics to that axis.
+ * Keywords are matched case-insensitively against topic cluster names.
+ */
+const RADAR_DIMENSIONS = [
+  {
+    label: "Operations",
+    keywords: [
+      "cluster", "health", "monitor", "kubectl", "k8s", "node", "kubeconfig",
+      "context", "multicluster", "connect", "deployment", "deploy", "unhealthy",
+      "api", "handler", "endpoint", "backend", "server", "route", "store",
+      "resource", "compute", "capacity", "provision", "helm", "gitops",
+      "cicd", "pipeline", "release", "rollout", "startup", "dependency",
+      "build", "npm", "pull",
+    ],
+  },
+  {
+    label: "Dashboard",
+    keywords: [
+      "dashboard", "card", "widget", "layout", "grid", "drag", "drop",
+      "chart", "graph", "visualize", "bar", "line", "pie", "sparkline",
+      "drilldown", "timeseries", "css", "style", "theme", "ui", "component",
+      "sidebar", "collapse", "popup", "icon", "panel", "display", "view",
+      "tab", "settings", "preference", "onboard", "tour", "wizard",
+      "marketplace", "install",
+    ],
+  },
+  {
+    label: "Agents",
+    keywords: [
+      "agent", "kagent", "kagenti", "mcp", "protocol", "ai", "assist",
+      "automate", "llm", "model", "provider", "openai", "claude", "gemini",
+      "fallback", "inference", "vllm",
+    ],
+  },
+  {
+    label: "Missions",
+    keywords: [
+      "mission", "mission-control", "browser", "deploy", "workflow",
+      "objective", "goal", "task", "export", "yaml", "markdown", "json",
+      "history", "pagination",
+    ],
+  },
+  {
+    label: "Testing",
+    keywords: [
+      "test", "coverage", "nightly", "e2e", "playwright", "jest", "spec",
+      "fixture", "mock", "stub", "fork", "ci", "workflow", "automation",
+    ],
+  },
+  {
+    label: "Security",
+    keywords: [
+      "rbac", "auth", "oauth", "login", "session", "token", "permission",
+      "role", "security", "vulnerability", "scan", "compliance", "trivy",
+      "kubescape", "validation", "encryption", "middleware", "policy",
+    ],
+  },
+] as const;
+
+/**
+ * Compute radar scores from topic clusters.
+ * Each dimension gets a score proportional to the issue count of topics
+ * whose names match that dimension's keywords.
+ */
+function computeRadarScores(topics: TopicCluster[]): number[] {
+  if (!topics || topics.length === 0) {
+    return new Array(RADAR_AXIS_COUNT).fill(0);
+  }
+
+  const rawScores = new Array(RADAR_AXIS_COUNT).fill(0);
+
+  for (const topic of topics) {
+    const topicWords = topic.name.toLowerCase().split(/[\s,]+/);
+
+    for (let i = 0; i < RADAR_DIMENSIONS.length; i++) {
+      const dimension = RADAR_DIMENSIONS[i];
+      let matchStrength = 0;
+
+      for (const keyword of dimension.keywords) {
+        for (const word of topicWords) {
+          if (word.includes(keyword) || keyword.includes(word)) {
+            matchStrength++;
+          }
+        }
+      }
+
+      if (matchStrength > 0) {
+        rawScores[i] += topic.issue_count * matchStrength;
+      }
+    }
+  }
+
+  // Normalize to 0..1 range
+  const maxScore = Math.max(...rawScores, 1);
+  return rawScores.map((s) => Math.max(s / maxScore, 0));
+}
+
+/**
+ * Calculate a point on the radar chart given an axis index, score (0..1),
+ * and chart parameters.
+ */
+function radarPoint(
+  axisIndex: number,
+  score: number,
+  radius: number,
+  center: number,
+): { x: number; y: number } {
+  /** Offset so first axis points straight up (negative Y) */
+  const ANGLE_OFFSET = -Math.PI / 2;
+  const angle =
+    ANGLE_OFFSET + (2 * Math.PI * axisIndex) / RADAR_AXIS_COUNT;
+  return {
+    x: center + radius * score * Math.cos(angle),
+    y: center + radius * score * Math.sin(angle),
+  };
+}
+
+/**
+ * Pure SVG radar/spider chart showing contribution distribution
+ * across 6 dimensions.
+ */
+function ContributionRadarChart({ topics }: { topics: TopicCluster[] }) {
+  const scores = useMemo(() => computeRadarScores(topics), [topics]);
+  const hasData = scores.some((s) => s > RADAR_MIN_DISPLAY_SCORE);
+
+  // Build the polygon path for the data shape
+  const dataPoints = scores.map((score, i) =>
+    radarPoint(i, Math.max(score, RADAR_MIN_DISPLAY_SCORE), RADAR_RADIUS, RADAR_CENTER),
+  );
+  const dataPath = dataPoints
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+    .join(" ") + " Z";
+
+  // Grid ring paths (concentric polygons)
+  const gridRings = Array.from({ length: RADAR_GRID_RINGS }, (_, ringIdx) => {
+    const fraction = (ringIdx + 1) / RADAR_GRID_RINGS;
+    const ringPoints = Array.from({ length: RADAR_AXIS_COUNT }, (_, axisIdx) =>
+      radarPoint(axisIdx, fraction, RADAR_RADIUS, RADAR_CENTER),
+    );
+    return ringPoints
+      .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+      .join(" ") + " Z";
+  });
+
+  // Axis lines from center to outer edge
+  const axisEndpoints = Array.from({ length: RADAR_AXIS_COUNT }, (_, i) =>
+    radarPoint(i, 1, RADAR_RADIUS, RADAR_CENTER),
+  );
+
+  /** Label offset distance beyond the outer edge */
+  const LABEL_OFFSET_RADIUS = 145;
+
+  // Label positions (slightly outside the outer ring)
+  const labelPositions = Array.from({ length: RADAR_AXIS_COUNT }, (_, i) =>
+    radarPoint(i, 1, LABEL_OFFSET_RADIUS, RADAR_CENTER),
+  );
+
+  return (
+    <div className="bg-gray-800/40 backdrop-blur-md rounded-xl border border-white/10 p-6">
+      <h2 className="text-lg font-semibold text-white mb-1">
+        Expertise Areas
+      </h2>
+      <p className="text-sm text-gray-400 mb-4">
+        {hasData
+          ? "Contribution distribution across console domains"
+          : "Not enough topic data for contribution mapping"}
+      </p>
+
+      <div className="flex justify-center">
+        <svg
+          viewBox="0 0 300 300"
+          className="w-full max-w-[320px] h-auto"
+          role="img"
+          aria-label="Radar chart showing contribution distribution across 6 expertise areas"
+        >
+          {/* Grid rings */}
+          {gridRings.map((path, i) => (
+            <path
+              key={`ring-${i}`}
+              d={path}
+              fill="none"
+              stroke="rgba(255, 255, 255, 0.08)"
+              strokeWidth="1"
+            />
+          ))}
+
+          {/* Axis lines */}
+          {axisEndpoints.map((point, i) => (
+            <line
+              key={`axis-${i}`}
+              x1={RADAR_CENTER}
+              y1={RADAR_CENTER}
+              x2={point.x}
+              y2={point.y}
+              stroke="rgba(255, 255, 255, 0.1)"
+              strokeWidth="1"
+            />
+          ))}
+
+          {/* Data polygon fill */}
+          <path
+            d={dataPath}
+            fill="rgba(34, 211, 238, 0.15)"
+            stroke="rgba(34, 211, 238, 0.6)"
+            strokeWidth="2"
+          />
+
+          {/* Data points (dots on vertices) */}
+          {dataPoints.map((point, i) => (
+            <circle
+              key={`dot-${i}`}
+              cx={point.x}
+              cy={point.y}
+              r="4"
+              fill={scores[i] > RADAR_MIN_DISPLAY_SCORE ? "rgba(34, 211, 238, 0.9)" : "rgba(107, 114, 128, 0.4)"}
+              stroke={scores[i] > RADAR_MIN_DISPLAY_SCORE ? "rgba(34, 211, 238, 1)" : "rgba(107, 114, 128, 0.6)"}
+              strokeWidth="1"
+            />
+          ))}
+
+          {/* Axis labels */}
+          {labelPositions.map((pos, i) => (
+            <text
+              key={`label-${i}`}
+              x={pos.x}
+              y={pos.y}
+              textAnchor="middle"
+              dominantBaseline="central"
+              className="fill-amber-400 text-[11px] font-medium"
+              style={{ fontFamily: "inherit" }}
+            >
+              {RADAR_DIMENSIONS[i].label}
+            </text>
+          ))}
+
+          {/* Score percentages near each vertex */}
+          {dataPoints.map((point, i) => {
+            const pct = Math.round(scores[i] * 100);
+            if (pct === 0) return null;
+            /** Slight inward offset for the percentage label */
+            const SCORE_LABEL_INSET = 0.75;
+            const labelPt = radarPoint(i, SCORE_LABEL_INSET, RADAR_RADIUS, RADAR_CENTER);
+            return (
+              <text
+                key={`pct-${i}`}
+                x={labelPt.x}
+                y={labelPt.y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="fill-cyan-300/70 text-[9px]"
+              >
+                {pct}%
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* Legend row */}
+      {hasData && (
+        <div className="flex flex-wrap justify-center gap-3 mt-4">
+          {RADAR_DIMENSIONS.map((dim, i) => {
+            const pct = Math.round(scores[i] * 100);
+            return (
+              <div key={dim.label} className="flex items-center gap-1.5">
+                <div
+                  className="w-2 h-2 rounded-full"
+                  style={{
+                    backgroundColor: pct > 0 ? "rgba(34, 211, 238, 0.8)" : "rgba(107, 114, 128, 0.4)",
+                  }}
+                />
+                <span className="text-[10px] text-gray-400">
+                  {dim.label}
+                  {pct > 0 && (
+                    <span className="text-cyan-400 ml-1">{pct}%</span>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Heatmap Cell ──────────────────────────────────────────────────────
 
 function HeatmapCell({
@@ -621,6 +921,9 @@ export default function ContributorProfilePage({
                   </h2>
                   <TimelineSparkline timeline={profile.activity_timeline} />
                 </div>
+
+                {/* ── Expertise Areas (Radar Chart) ──────── */}
+                <ContributionRadarChart topics={profile.topics || []} />
 
                 {/* ── Topic Focus ─────────────────────────── */}
                 <div className="bg-gray-800/40 backdrop-blur-md rounded-xl border border-white/10 p-6">


### PR DESCRIPTION
## Summary

- Adds a pure SVG radar/spider chart ("Expertise Areas") to each contributor's leaderboard profile page
- Shows contribution distribution across 6 console domains: **Operations**, **Dashboard**, **Agents**, **Missions**, **Testing**, and **Security**
- Scores are computed client-side by keyword-matching the contributor's existing topic cluster names against each dimension's keyword set
- Dark-theme-compatible design: cyan/teal polygon fill, amber axis labels, concentric grid rings, percentage annotations, and a legend row
- Zero new dependencies — built entirely with inline SVG and React

## Implementation details

- The radar chart appears between the Activity Timeline and Topic Focus sections on `/leaderboard/[username]` pages
- All numeric literals use named constants per project conventions (RADAR_AXIS_COUNT, RADAR_RADIUS, RADAR_CENTER, etc.)
- Handles edge cases: empty topics, no matching keywords, topics with mixed domain coverage
- Fully accessible with `role="img"` and `aria-label` on the SVG element

## Test plan

- [ ] Visit a contributor profile page (e.g. `/en/leaderboard/ghanshyam2005singh`) and verify the radar chart renders
- [ ] Check that dimension scores match the contributor's topic focus (e.g., a contributor focused on missions should show high Missions score)
- [ ] Verify the chart renders gracefully for contributors with few or no topics
- [ ] Confirm dark theme compatibility — labels and chart should be clearly visible
- [ ] Build passes: `npm run build` succeeds with no errors
- [ ] Lint passes: `npm run lint` succeeds with no warnings