### PR TITLE
📖 fixed news link in docsnavbar

### DIFF
--- a/src/components/docs/DocsNavbar.tsx
+++ b/src/components/docs/DocsNavbar.tsx
@@ -460,7 +460,7 @@ export default function DocsNavbar() {
                 Programs
               </Link>
               <Link
-                href="/docs/news"
+                href="/docs/news/latest-news"
                 className={dropdownItemClasses}
               >
                 <svg className="w-5 h-5 mr-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
### 📌 Fixes

The News link in the docs navbar dropdown was missing the latest-news part of the endpoint