### PR TITLE
docs(console): comprehensive install + troubleshooting + architecture docs (#1384-#1411)

### DIFF
--- a/docs/content/console/architecture.md
+++ b/docs/content/console/architecture.md
@@ -210,3 +210,84 @@ The Frontend stores ephemeral UI state and caches in the browser's `localStorage
 | **Wizard state** | Mission Control wizard progress | Expires after 7 days of inactivity |
 
 **AI Missions are stored entirely in localStorage**, not in the SQLite database. Mission definitions (including the mission name, type, target clusters, and deployment state) are written to `localStorage` keys such as `kubestellar-missions-active` and `kubestellar-missions-history`. The mission catalog cache (fetched from the console-kb repository) is stored under `kc-mission-cache` with a 6-hour TTL. Because this data lives in the browser, missions are **not shared between users or devices** — each browser maintains its own set of active and historical missions.
+
+## Multi-cluster data flow — the short version
+
+If you only read one section of this page, read this one. The console
+reaches **your** clusters through a clear split of responsibilities:
+
+1. **Your browser** talks to the **Frontend** (React SPA) — only over
+   HTTPS. No kubeconfig lives in the browser.
+2. The **Backend** (Go) handles API, auth, and the SQLite store. It does
+   **not** talk to your clusters directly.
+3. The **MCP Bridge** (in-process with the Backend) hosts the
+   `kubestellar-ops` / `kubestellar-deploy` MCP servers and reads the
+   server-side kubeconfig to answer cluster-data queries.
+4. **kc-agent** runs on **your workstation**, reads *your* local
+   kubeconfig, and exposes kubectl execution over WebSocket (to the
+   browser) and MCP (to AI coding agents). This is how a hosted console
+   like `console.kubestellar.io` can execute `kubectl` against clusters
+   that only *you* can reach.
+
+**Control plane vs data plane:**
+
+| Plane | What flows through it | Components |
+|---|---|---|
+| **Control plane** (read) | Cluster inventory, pod/node/workload listings, metrics snapshots — displayed in cards and dashboards | Backend ↔ MCP Bridge ↔ `kubestellar-ops` / `kubestellar-deploy` ↔ your clusters |
+| **Data plane** (write + interactive) | Terminal `kubectl`, AI Mission apply steps, interactive edits | Browser ↔ kc-agent (WebSocket) ↔ your kubeconfig ↔ your clusters |
+
+This split is why **in-cluster Helm installs need you to run `kc-agent`
+locally**: the cluster can query itself through the MCP Bridge, but it
+cannot reach *other* clusters on your laptop network without the local
+agent. See [Installation → kc-agent health](installation.md#kc-agent-health-helm--in-cluster-mode-only).
+
+## Demo data vs real cluster data
+
+The console deliberately ships with **demo data** so every feature has
+something to render even when no real cluster is wired up. It's important
+to know which one you're looking at.
+
+### When you see demo data
+
+- You opened `https://console.kubestellar.io` (hosted demo — **always**
+  demo data).
+- You ran a local install with no kubeconfig, no OAuth, and no
+  `GOOGLE_DRIVE_API_KEY` / `CLAUDE_API_KEY` — many cards fall back to
+  demo mode individually.
+- A card's upstream API returned an error or timed out and the card's
+  hook fell back to the bundled fixture.
+
+### How the UI tells you
+
+Every card that can fall back to demo data surfaces the state explicitly:
+
+- A yellow **"Demo"** badge in the card header.
+- A yellow dashed outline around the card body.
+- In the Developer panel (profile avatar → Developer), a per-card
+  "demo / live" indicator.
+
+If a card shows neither the badge nor the outline, it is rendering **live
+data** from the cluster it is labeled with. Cards never silently mix demo
+and live data within a single view.
+
+### Hosted demo capability boundary
+
+`console.kubestellar.io` is a **strict read-only demonstration** of the
+UI. It is not a degraded version of the product — it is a different
+product surface with a hard capability ceiling:
+
+| Feature | Hosted demo | Local / Helm install |
+|---|---|---|
+| Click through every card, dashboard, wizard | Yes | Yes |
+| See AI Mission plans | Yes (plan only) | Yes |
+| **Apply** an AI Mission | **No** | Yes |
+| **Execute** `kubectl` in the terminal | **No** | Yes (via kc-agent) |
+| Edit / install / uninstall anything | **No** | Yes |
+| Persistent session | **No** (periodic forced logout) | Yes |
+| Real cluster inventory | **No** (fixtures only) | Yes |
+
+The periodic forced logout on the hosted demo is **intentional** — it
+resets state so the next visitor sees a clean demo. If any of the "No"
+rows above are a problem for you, follow the
+[Quick Start](quickstart.md) or [Installation](installation.md) path
+instead.

--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -21,6 +21,30 @@ This guide covers all deployment options for KubeStellar Console, the multi-clus
 
 ---
 
+## Prerequisites and resource requirements
+
+Before installing into a Kubernetes cluster, make sure your target meets
+these requirements. For local-only evaluation (curl one-liner or run from
+source) you only need the entries marked **Local**.
+
+| Requirement | Minimum | Notes |
+|---|---|---|
+| Kubernetes version | **1.28+** | Matches the Pod Security `restricted` profile the chart targets. Tested on 1.28 – 1.31. |
+| Default StorageClass | One must exist | Needed when `persistence.enabled=true` (the default). Disable persistence on clusters without one. See [Troubleshooting → PVC stuck Pending](troubleshooting.md#pod-stuck-pending-on-a-persistentvolumeclaim). |
+| Node CPU (request) | 250 m | Burstable — no hard limit set by the chart. |
+| Node memory (request) | 256 Mi | Startup probe takes ~30 s on cold start. |
+| Node memory (recommended) | 512 Mi+ | Real clusters with many contexts. |
+| Ephemeral / PVC storage | 1 Gi | SQLite database + backup snapshots. |
+| Service port | **8080** | The service listens on 8080, not 80. Port-forward with `8080:8080`. |
+| Namespace PodSecurity | `baseline` or `restricted` OK | The chart is compliant with `restricted` out of the box. |
+| GitHub OAuth App | Optional | Only required for multi-user logins; omit for demo or single-user local. |
+| **Local**: Go | 1.24+ | Only for "run from source". |
+| **Local**: Node.js | 20+ | Only for "run from source". |
+| **Local**: kubectl | latest | |
+| **Local**: kubeconfig | ≥ 1 context | `kubectl config get-contexts` must list at least one context. |
+
+---
+
 ## Fastest Path
 
 > **Prerequisites**: You must install the kubestellar-mcp plugins **before** running this command — they are not installed by `start.sh`. See [Step 1: Install Claude Code Plugins](#step-1-install-claude-code-plugins) first.
@@ -358,6 +382,264 @@ The console reads clusters from your kubeconfig. To access multiple clusters:
    ```bash
    kubectl config get-contexts
    ```
+
+## Kind quickstart (zero to browser)
+
+A full local path from nothing to a running console in a Kind cluster.
+Tested on Kind v0.27 and Kubernetes 1.31.
+
+```bash
+# 1. Create a Kind cluster
+kind create cluster --name kc-demo
+
+# 2. Pre-pull the console image into Kind to avoid deploy.sh timeouts
+docker pull ghcr.io/kubestellar/console:latest
+kind load docker-image ghcr.io/kubestellar/console:latest --name kc-demo
+
+# 3. Install the chart with no overrides — JWT secret auto-generates,
+#    everything else falls back to demo mode.
+kubectl create namespace kubestellar-console
+
+helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
+  -n kubestellar-console \
+  --wait --timeout 10m
+
+# 4. Verify (see "Verification commands" below for full checks)
+kubectl -n kubestellar-console rollout status deploy \
+  -l app.kubernetes.io/name=kubestellar-console
+
+# 5. Port-forward — service port is 8080, NOT 80
+kubectl -n kubestellar-console port-forward svc/kc-kubestellar-console 8080:8080
+```
+
+Open [http://localhost:8080](http://localhost:8080). Because no GitHub OAuth
+was configured, you'll land directly in demo mode.
+
+**Tear down:**
+
+```bash
+helm uninstall kc -n kubestellar-console
+kind delete cluster --name kc-demo
+```
+
+If `helm install` fails with `context deadline exceeded`, see
+[Troubleshooting → deploy.sh timeouts](troubleshooting.md#deploysh-fails-with-context-deadline-exceeded)
+— pre-pulling and loading the image (step 2 above) is the standard workaround.
+
+## Minikube quickstart (zero to browser)
+
+Same idea as Kind, on Minikube. Tested on Minikube v1.35 with the default
+`docker` driver.
+
+```bash
+# 1. Create a Minikube profile
+minikube start -p kc-demo --memory=4096 --cpus=2
+
+# 2. Load the image into Minikube's Docker
+minikube -p kc-demo image load ghcr.io/kubestellar/console:latest
+
+# 3. Install the chart
+kubectl create namespace kubestellar-console
+
+helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
+  -n kubestellar-console \
+  --wait --timeout 10m
+
+# 4. Verify
+kubectl -n kubestellar-console rollout status deploy \
+  -l app.kubernetes.io/name=kubestellar-console
+
+# 5. Port-forward
+kubectl -n kubestellar-console port-forward svc/kc-kubestellar-console 8080:8080
+```
+
+Open [http://localhost:8080](http://localhost:8080).
+
+Minikube ships with a default `standard` StorageClass, so the default
+`persistence.enabled=true` works without any extra setup. If you're on a
+stripped-down profile without storage, add `--set persistence.enabled=false`
+and `--set backup.enabled=false`.
+
+**Tear down:**
+
+```bash
+helm uninstall kc -n kubestellar-console
+minikube delete -p kc-demo
+```
+
+## Verification commands
+
+After any install, run these to confirm everything is healthy. These are
+the same commands [Troubleshooting](troubleshooting.md#pre-port-forward-diagnostics)
+tells you to run **before** opening a support issue.
+
+```bash
+NS=kubestellar-console
+
+# 1. Deployment rolled out
+kubectl -n "$NS" rollout status deploy \
+  -l app.kubernetes.io/name=kubestellar-console --timeout=180s
+
+# 2. Pods Ready 1/1
+kubectl -n "$NS" get pods -l app.kubernetes.io/name=kubestellar-console
+
+# 3. PVC bound (if persistence.enabled=true — the default)
+kubectl -n "$NS" get pvc
+
+# 4. Service exists on port 8080 and has at least one endpoint
+kubectl -n "$NS" get svc,endpoints
+
+# 5. No errors in the last 200 log lines
+kubectl -n "$NS" logs -l app.kubernetes.io/name=kubestellar-console \
+  --tail=200 --all-containers
+
+# 6. HTTP health check through the port-forward
+kubectl -n "$NS" port-forward svc/kc-kubestellar-console 8080:8080 &
+sleep 2
+curl -sSf http://localhost:8080/api/health && echo OK
+```
+
+### kc-agent health (Helm / in-cluster mode only)
+
+kc-agent runs **on your workstation**, not in the cluster. After starting
+`kc-agent`, verify it:
+
+```bash
+# Process is running and listening on 8585
+lsof -nP -iTCP:8585 -sTCP:LISTEN
+
+# Agent responds to a health probe
+curl -sSf http://127.0.0.1:8585/healthz && echo OK
+```
+
+If kc-agent is not running, the console will show an "Agent Not Connected"
+banner. See [Troubleshooting → Agent Not Connected](troubleshooting.md#agent-not-connected--cluster-actions-fail).
+
+## Values and secrets reference
+
+The chart accepts secret material in one of two modes. The full list lives
+in the
+[chart README](https://github.com/kubestellar/console/tree/main/deploy/helm/kubestellar-console#secrets-and-configuration);
+the common keys are:
+
+| Value | Default | `existingSecret` alternative | Auto-generated? |
+|---|---|---|---|
+| `github.clientId` / `github.clientSecret` | *(empty)* | `github.existingSecret` + `github.existingSecretKeys.clientId` / `.clientSecret` | No — OAuth disabled if unset |
+| `jwt.secret` | *(empty)* | `jwt.existingSecret` + `jwt.existingSecretKey` (default `jwt-secret`) | **Yes** — chart generates a 64-char random value on first install |
+| `googleDrive.apiKey` | *(empty)* | `googleDrive.existingSecret` + `googleDrive.existingSecretKey` | No — benchmark cards fall back to demo data |
+| `claude.apiKey` | *(empty)* | `claude.existingSecret` + `claude.existingSecretKey` | No — AI features disabled |
+| `feedbackGithubToken.token` | *(empty)* | `feedbackGithubToken.existingSecret` + `feedbackGithubToken.existingSecretKey` | No — in-app feedback disabled |
+
+### Secret creation — mode 1: chart-managed
+
+The chart renders a Secret named `{release-name}-kubestellar-console` for
+you. Pass values inline:
+
+```bash
+helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
+  -n kubestellar-console --create-namespace \
+  --set github.clientId=YOUR_CLIENT_ID \
+  --set github.clientSecret=YOUR_CLIENT_SECRET
+```
+
+The JWT secret is auto-generated; you don't need to set anything.
+
+### Secret creation — mode 2: bring-your-own
+
+Create the Secret **before** `helm install` — if you pass
+`*.existingSecret` for a Secret that doesn't exist, the pod fails with
+`CreateContainerConfigError`. The chart does **not** create it for you.
+
+```bash
+kubectl create namespace kubestellar-console
+
+kubectl -n kubestellar-console create secret generic kc-oauth-secret \
+  --from-literal=github-client-id="YOUR_CLIENT_ID" \
+  --from-literal=github-client-secret="YOUR_CLIENT_SECRET" \
+  --from-literal=jwt-secret="$(openssl rand -hex 32)"
+
+helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
+  -n kubestellar-console \
+  --set github.existingSecret=kc-oauth-secret \
+  --set jwt.existingSecret=kc-oauth-secret
+```
+
+The default key names the chart expects are `github-client-id`,
+`github-client-secret`, and `jwt-secret`. If your Secret uses different
+keys, override `github.existingSecretKeys.clientId`,
+`github.existingSecretKeys.clientSecret`, and `jwt.existingSecretKey`
+accordingly.
+
+### JWT secret behavior (by mode)
+
+| Scenario | What happens |
+|---|---|
+| Neither `jwt.secret` nor `jwt.existingSecret` set (default) | Chart generates a 64-char random JWT secret on first install and reuses it on upgrades. |
+| `jwt.secret` set inline | Chart uses that value. Changing it rotates the key and invalidates active sessions. |
+| `jwt.existingSecret` set | Chart reads key `jwt-secret` (or `jwt.existingSecretKey`) from the named Secret. The Secret must exist first. |
+
+### `FEEDBACK_GITHUB_TOKEN` — enables in-app feedback
+
+The in-app feedback / `/issue` flow posts to GitHub on the user's behalf.
+It requires a GitHub Personal Access Token with `public_repo` scope. In
+the Helm chart it's `feedbackGithubToken.token` (or
+`feedbackGithubToken.existingSecret`). In local dev it's the
+`FEEDBACK_GITHUB_TOKEN` environment variable or `.env` entry. Without it,
+the feedback buttons in the UI are disabled.
+
+## Data persistence and storage behavior
+
+By default the chart sets:
+
+- `persistence.enabled: true` — a PVC is created for the SQLite database
+  that holds sessions, user preferences, and the feedback queue.
+- `backup.enabled: true` — a CronJob periodically snapshots the SQLite
+  database into a `backup` volume, and an init container restores the
+  latest snapshot on pod startup.
+
+**This means:**
+
+- On clusters **without** a default StorageClass, the pod will stay `Pending`
+  until the PVC is bound. Set `persistence.enabled=false` and
+  `backup.enabled=false` for a stateless evaluation install.
+- `helm uninstall` **does not** delete PVCs by default. Run
+  `kubectl -n kubestellar-console delete pvc -l app.kubernetes.io/instance=kc`
+  if you want a fresh install.
+- On local clusters (Kind, Minikube) the default StorageClass uses
+  `volumeBindingMode: WaitForFirstConsumer`, which means the PV is not
+  provisioned until a pod requests it. This is **expected** and not a
+  failure — only act if the PVC is still `Pending` after the pod exists.
+
+See [Persistence](persistence.md) for the data model and backup CronJob
+details.
+
+## `deploy.sh` vs direct Helm
+
+The `deploy.sh` convenience script wraps Helm plus a few extras. It is **not
+a superset of Helm** — behavior differs in ways users have hit:
+
+| Behavior | `deploy.sh` | Direct `helm install` |
+|---|---|---|
+| Installs the chart | Yes — wraps `helm install`/`upgrade` | Yes |
+| Helm `--wait` | **Hardcoded `--timeout 120s`** | You control it |
+| Creates namespace | Yes | Only with `--create-namespace` |
+| Creates GitHub OAuth Secret | With `--github-oauth` | You create it yourself |
+| Configures Ingress | With `--ingress <host>` | Via `--set ingress.*` |
+| Configures OpenShift Route | With `--openshift` | Via `--set route.*` |
+| Uses `--context` | Yes, respects it | Respects current kube context |
+| Loads image into Kind | **No** | No |
+
+**Practical rule of thumb:**
+
+- On Kind / Minikube / anywhere image pull might exceed 120 s, **skip
+  `deploy.sh`** and use direct Helm with `--wait --timeout 10m` (see the
+  [Kind quickstart](#kind-quickstart-zero-to-browser)).
+- On real clusters where the image is already cached on the node, the
+  `deploy.sh --github-oauth --ingress` one-liner is genuinely the fastest
+  path.
+- In either case, `deploy.sh` abstracts **which** values it sets; read the
+  script or pass the equivalent `--set` flags directly if you want the
+  change visible in your shell history or GitOps diff.
 
 ## Upgrading
 

--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -406,7 +406,7 @@ helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
 
 # 4. Verify (see "Verification commands" below for full checks)
 kubectl -n kubestellar-console rollout status deploy \
-  -l app.kubernetes.io/name=kubestellar-console
+  -l app.kubernetes.io/name=kubestellar-console --timeout=300s
 
 # 5. Port-forward — service port is 8080, NOT 80
 kubectl -n kubestellar-console port-forward svc/kc-kubestellar-console 8080:8080
@@ -447,7 +447,7 @@ helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
 
 # 4. Verify
 kubectl -n kubestellar-console rollout status deploy \
-  -l app.kubernetes.io/name=kubestellar-console
+  -l app.kubernetes.io/name=kubestellar-console --timeout=300s
 
 # 5. Port-forward
 kubectl -n kubestellar-console port-forward svc/kc-kubestellar-console 8080:8080

--- a/docs/content/console/troubleshooting.md
+++ b/docs/content/console/troubleshooting.md
@@ -1,0 +1,342 @@
+---
+title: "Troubleshooting — KubeStellar Console install, port-forward, and agent problems"
+linkTitle: "Troubleshooting"
+weight: 5
+description: >
+  Diagnose and fix common KubeStellar Console installation problems — PodSecurity
+  restricted rejections, stuck PersistentVolumeClaims, dropped port-forwards,
+  deploy.sh timeouts, and "Agent Not Connected" states across hosted demo,
+  in-cluster Helm, and local kc-agent modes.
+keywords:
+  - kubestellar console troubleshooting
+  - helm chart pod security
+  - kubectl port-forward drops
+  - kc-agent not connected
+  - persistentvolumeclaim pending kind
+---
+
+# Troubleshooting the KubeStellar Console install
+
+This page covers the failure modes users hit most often when installing the
+console. Each section gives you the exact symptom, the root cause, and a
+reproducible remediation. For the canonical Helm chart reference, see the
+[chart README](https://github.com/kubestellar/console/tree/main/deploy/helm/kubestellar-console#troubleshooting)
+in the `kubestellar/console` repo.
+
+> If you only need to diagnose a "live" symptom, skip to
+> [Pre-port-forward diagnostics](#pre-port-forward-diagnostics) — those are
+> the same commands the rest of this page assumes you've already run.
+
+## Pre-port-forward diagnostics
+
+Run these **before** starting `kubectl port-forward`. They are the diagnostic
+baseline every other section on this page refers to.
+
+```bash
+NS=kubestellar-console
+
+# 1. Is the deployment rolled out?
+kubectl -n "$NS" rollout status deploy -l app.kubernetes.io/name=kubestellar-console --timeout=180s
+
+# 2. Are the pods actually Ready?
+kubectl -n "$NS" get pods -l app.kubernetes.io/name=kubestellar-console -o wide
+
+# 3. Full pod status (Events at the bottom are usually the smoking gun)
+kubectl -n "$NS" describe pod -l app.kubernetes.io/name=kubestellar-console
+
+# 4. Last 200 log lines from every container
+kubectl -n "$NS" logs -l app.kubernetes.io/name=kubestellar-console --tail=200 --all-containers
+
+# 5. Service exists and targets the pod
+kubectl -n "$NS" get svc
+kubectl -n "$NS" get endpoints
+
+# 6. PVC is Bound (if persistence is enabled — it is by default)
+kubectl -n "$NS" get pvc
+```
+
+The console pod needs to reach `Ready: 1/1` before port-forwarding will work.
+The startup probe takes roughly 30 seconds on a cold start.
+
+## `kubectl port-forward` hangs, drops, or is refused
+
+**Symptom:** `kubectl port-forward svc/...` prints `Forwarding from ...` but
+connections to `localhost:8080` time out, close immediately, or fail with
+`connection refused`.
+
+**Cause — in order of likelihood:**
+
+1. Pod is not yet `Ready`. Port-forward opens against the service but the
+   selector matches no ready endpoints. Confirm with
+   `kubectl -n kubestellar-console get endpoints` — if the endpoint address
+   list is empty, the pod is not ready.
+2. You port-forwarded to the wrong port. The service listens on
+   **port 8080, not 80**. Use `8080:8080`:
+   ```bash
+   kubectl -n kubestellar-console port-forward svc/kc-kubestellar-console 8080:8080
+   ```
+3. The pod was killed and replaced after the port-forward was opened (an
+   `OOMKilled`, a node eviction, or a `helm upgrade`). Re-run the command —
+   `kubectl port-forward` does not automatically reconnect.
+4. A local process is already bound to `:8080`. Check with
+   `lsof -nP -iTCP:8080 -sTCP:LISTEN` and either stop it or forward to a
+   different local port: `kubectl ... port-forward ... 18080:8080`.
+
+**Remediation:** run the [pre-port-forward diagnostics](#pre-port-forward-diagnostics)
+first; if the pod is Ready and endpoints are populated, simply re-run the
+port-forward. If you need a long-lived external URL instead, switch to
+`ingress.enabled=true` (or `route.enabled=true` on OpenShift) — see
+[Installation](installation.md#helm-installation).
+
+## PodSecurity `restricted` rejects the pod
+
+**Symptom:** `helm install` succeeds but the pod never starts. `kubectl
+describe` shows one of:
+
+- `container has runAsNonRoot and image has non-numeric user (appuser),
+  cannot verify user is non-root`
+- `violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false`
+- `violates PodSecurity "restricted:latest": seccompProfile (pod or container
+  must set seccompProfile.type to "RuntimeDefault" or "Localhost")`
+
+**Cause:** the namespace enforces the `restricted` Pod Security Standard.
+The chart ships settings that satisfy the profile out of the box:
+
+| Chart value | Default | Why |
+|---|---|---|
+| `securityContext.runAsUser` | `1001` | Must be numeric — the Dockerfile's `USER appuser` is opaque to the restricted admission plugin. |
+| `securityContext.runAsNonRoot` | `true` | |
+| `securityContext.allowPrivilegeEscalation` | `false` | |
+| `securityContext.capabilities.drop` | `["ALL"]` | |
+| `podSecurityContext.seccompProfile.type` | `RuntimeDefault` | |
+
+If you've overridden `securityContext` or `podSecurityContext` in a values
+file and dropped any of these keys, the pod will be rejected. Put them back,
+or let the chart defaults win by not overriding those blocks.
+
+See `kubestellar/console` issues
+[#6323](https://github.com/kubestellar/console/issues/6323) and
+[#6334](https://github.com/kubestellar/console/issues/6334) for the history.
+
+## Pod stuck `Pending` on a PersistentVolumeClaim
+
+**Symptom:** `kubectl get pods` shows `Pending`; `kubectl describe pod` shows
+`pod has unbound immediate PersistentVolumeClaims` or
+`waiting for a volume to be created, either by external provisioner
+"..." or manually`.
+
+**Cause:** The chart sets `persistence.enabled: true` and `backup.enabled:
+true` by default. On local clusters (Kind, Minikube, k3d) the default
+StorageClass uses `volumeBindingMode: WaitForFirstConsumer`, which means the
+PV isn't provisioned until a pod is actually scheduled — but if the cluster
+has **no** default StorageClass at all, the PVC stays `Pending` forever.
+
+**Remediation — pick one:**
+
+- **Disable persistence for throwaway local evaluation** (simplest):
+  ```bash
+  helm upgrade --install kc ./deploy/helm/kubestellar-console \
+    -n kubestellar-console \
+    --set persistence.enabled=false \
+    --set backup.enabled=false
+  ```
+  You lose session/database state across restarts, which is fine for demos.
+
+- **Install a provisioner on Kind** — Kind ships with `rancher.io/local-path`
+  by default; if your cluster was built without it, install
+  [local-path-provisioner](https://github.com/rancher/local-path-provisioner)
+  and mark it the default StorageClass:
+  ```bash
+  kubectl patch storageclass local-path \
+    -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+  ```
+
+- **Point the chart at an existing StorageClass:**
+  ```bash
+  helm upgrade --install kc ./deploy/helm/kubestellar-console \
+    -n kubestellar-console \
+    --set persistence.storageClass=my-storage-class
+  ```
+
+The `WaitForFirstConsumer` delay is **normal** — the PVC will stay unbound
+until the pod is scheduled. You only need to act if the PVC is still
+unbound *after* the pod has been created.
+
+## `deploy.sh` fails with `context deadline exceeded`
+
+**Symptom:** running the one-liner deploy script —
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/deploy.sh | bash
+```
+
+— fails with `Error: context deadline exceeded` or `timed out waiting for
+the condition` roughly two minutes in.
+
+**Cause:** `deploy.sh` hardcodes `--wait --timeout 120s` on `helm install`.
+On Kind, Minikube, and fresh clusters the image pull alone frequently
+exceeds two minutes, so the helm call fails before the pod is Ready even
+though the install will eventually succeed.
+
+**Remediation:**
+
+1. **Pre-pull the image** before running the script:
+   ```bash
+   docker pull ghcr.io/kubestellar/console:latest
+   kind load docker-image ghcr.io/kubestellar/console:latest --name <your-kind-cluster>
+   ```
+   Then re-run `deploy.sh`.
+2. **Or skip `deploy.sh` entirely** and call Helm directly with a longer
+   timeout:
+   ```bash
+   helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console \
+     -n kubestellar-console --create-namespace \
+     --wait --timeout 10m
+   ```
+
+See `deploy.sh` vs direct Helm comparison in
+[Installation → deploy.sh vs direct Helm](installation.md#deploysh-vs-direct-helm).
+
+## "Agent Not Connected" / cluster actions fail
+
+The console shows an orange **Agent Not Connected** banner, terminal
+commands hang, and AI Missions that need `kubectl` fail. The remediation
+depends on **which mode** your console is running in.
+
+| Mode | How you installed | Where kc-agent runs | Fix |
+|---|---|---|---|
+| **Hosted demo** | You're on `https://console.kubestellar.io` | There is no agent — hosted demo is read-only | Nothing to fix; see [Hosted demo limitations](#hosted-demo-limitations) below |
+| **Local (from source / curl)** | `start.sh`, `start-dev.sh`, or `startup-oauth.sh` | Same process, port **8585** | Restart the console process; it spawns kc-agent as a child |
+| **Helm / in-cluster** | `helm install` | On your **workstation**, not in the cluster | Run `kc-agent` locally (see below) |
+
+### In-cluster (Helm) mode — start kc-agent on your workstation
+
+The Helm chart deploys the console backend inside the cluster but **not**
+kc-agent — kc-agent needs direct access to your local kubeconfig and runs
+on *your* laptop.
+
+```bash
+# Install
+brew tap kubestellar/tap
+brew install kc-agent
+
+# Run (listens on 127.0.0.1:8585 by default)
+kc-agent
+```
+
+Then reload the console tab. The "Agent Not Connected" banner should clear
+within a few seconds as the browser's WebSocket finds the local agent.
+
+Without kc-agent the in-cluster console will fall back to **demo mode** if
+it was deployed without GitHub OAuth, or will simply refuse to execute
+`kubectl` commands if OAuth is configured.
+
+### Hosted demo limitations
+
+`https://console.kubestellar.io` is a **strict capability boundary**, not a
+degraded version of the real product:
+
+- Every cluster you see is a fixture. No real workloads are affected by
+  anything you click.
+- AI Missions generate plans but cannot apply them.
+- You will be **signed out intermittently and intentionally** — the hosted
+  demo forces logout to reset state. This is not a bug. Install locally
+  (see [Quick Start](quickstart.md)) if you need a persistent session.
+- Any "install" / "deploy" / "upgrade" button in the hosted demo is a
+  no-op dry run.
+
+If the behavior you want isn't in the hosted demo, you need a local install.
+
+## Forced logout in demo mode
+
+**Symptom:** you're signed in to a local console with `DEMO_MODE=true` (or
+to `console.kubestellar.io`) and you get logged out unexpectedly.
+
+**Cause:** this is **intentional**. Demo mode periodically forces a logout
+to reset session state so the next user sees a clean demo. It is not a
+token expiry bug and not something to report as broken auth.
+
+If you need a persistent session, disable demo mode or configure real
+GitHub OAuth — see [Authentication](authentication.md).
+
+## JWT secret surprises
+
+The chart behavior differs depending on how you supplied the JWT secret:
+
+| Scenario | Behavior |
+|---|---|
+| `jwt.secret` empty and `jwt.existingSecret` empty (**default**) | Chart auto-generates a 64-character random JWT secret on first install and stores it in the release-fullname Secret. Subsequent `helm upgrade` calls reuse the existing value. |
+| `jwt.secret` set inline | Chart uses that exact value. Changing it rotates the key and **invalidates all active sessions**. |
+| `jwt.existingSecret` set | Chart reads the key from the named Secret (key defaults to `jwt-secret`). The **Secret must exist before `helm install`** or the pod will fail with `CreateContainerConfigError`. |
+
+**If users see `JWT signature verification failed` after an upgrade:**
+somebody rotated the key. Have users sign out and back in, and restart the
+pods so they pick up the latest Secret:
+
+```bash
+kubectl -n kubestellar-console delete pod \
+  -l app.kubernetes.io/name=kubestellar-console
+```
+
+## `CreateContainerConfigError: secret "..." not found`
+
+**Symptom:** pod is stuck in `CreateContainerConfigError`;
+`kubectl describe pod` says `secret "kc-oauth-secret" not found` (or
+similar).
+
+**Cause:** you passed `github.existingSecret=<name>` or
+`jwt.existingSecret=<name>` to Helm, but that Secret **does not exist in
+the release namespace**. Helm does not create it for you — that's the whole
+point of the "bring your own secret" mode.
+
+**Remediation:** create the Secret first, then force the pod to restart:
+
+```bash
+kubectl -n kubestellar-console create secret generic kc-oauth-secret \
+  --from-literal=github-client-id="YOUR_CLIENT_ID" \
+  --from-literal=github-client-secret="YOUR_CLIENT_SECRET"
+
+kubectl -n kubestellar-console delete pod \
+  -l app.kubernetes.io/name=kubestellar-console
+```
+
+The chart's default `existingSecretKeys` are `github-client-id` and
+`github-client-secret` — if your Secret uses different keys, set
+`github.existingSecretKeys.clientId` and
+`github.existingSecretKeys.clientSecret` accordingly.
+
+## Retrying a failed install
+
+If Helm left the release in a broken state (stuck `pending-install`,
+`pending-upgrade`, or half-created resources), **do not** re-run the exact
+same `helm install` command — you'll get `cannot re-use a name that is
+still in use`.
+
+**Clean retry:**
+
+```bash
+NS=kubestellar-console
+REL=kc
+
+# 1. Uninstall the broken release (safe even if resources are half-created)
+helm uninstall "$REL" -n "$NS" || true
+
+# 2. Delete any leftover PVC if you want a truly fresh start
+kubectl -n "$NS" delete pvc -l app.kubernetes.io/instance="$REL" --ignore-not-found
+
+# 3. Re-run with a longer timeout so image pull doesn't kill the install
+helm install "$REL" oci://ghcr.io/kubestellar/charts/kubestellar-console \
+  -n "$NS" --create-namespace \
+  --wait --timeout 10m
+```
+
+If `helm uninstall` itself hangs, add `--no-hooks` and finish cleaning up
+resources manually with `kubectl delete`.
+
+## Related pages
+
+- [Installation](installation.md) — all deployment paths
+- [Quick Start](quickstart.md) — 5-minute path
+- [Architecture](architecture.md) — how the pieces fit together
+- [Authentication](authentication.md) — GitHub OAuth setup
+- [Persistence](persistence.md) — PVC and backup behavior

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - Overview: console/readme.md
       - Quick Start: console/quickstart.md
       - Installation: console/installation.md
+      - Troubleshooting: console/troubleshooting.md
       - Dashboards: console/dashboards.md
       - Cards: console/all-cards.md
       - Stats Blocks: console/stats-blocks.md


### PR DESCRIPTION
## Summary

Addresses 28 install/troubleshooting/architecture documentation gaps filed by @rishi-jat (#1384-#1411). Sourced from the authoritative Helm chart README in kubestellar/console so the values, defaults, and behavior match the real chart.

## What changed

**New page — `docs/content/console/troubleshooting.md`:**
- Pre-port-forward diagnostic commands (the baseline every other section refers to)
- `kubectl port-forward` hangs / drops / refuses — including the \"service port is 8080, not 80\" gotcha
- PodSecurity `restricted` rejections (`runAsNonRoot`, `allowPrivilegeEscalation`, `seccompProfile`)
- PVC stuck `Pending` + `WaitForFirstConsumer` explanation for local clusters
- `deploy.sh` `context deadline exceeded` (the hardcoded 120s timeout)
- \"Agent Not Connected\" remediation split by mode (hosted / local / in-cluster)
- Hosted demo strict capability boundary + forced-logout-is-intentional explainer
- JWT secret behavior across chart-managed / inline / existingSecret modes
- `CreateContainerConfigError: secret \"...\" not found` recipe
- Retrying a failed Helm install (clean-up + re-run)

**`installation.md` additions:**
- **Prerequisites table**: Kubernetes 1.28+, CPU/memory/storage requirements, service port 8080
- **Kind quickstart** (zero to browser) with image pre-pull to avoid deploy.sh timeouts
- **Minikube quickstart** (zero to browser)
- **Verification commands** for the console *and* kc-agent
- **Values and secrets reference**: chart-managed vs BYO secret, JWT auto-generation, `existingSecret` key contract, `FEEDBACK_GITHUB_TOKEN` explainer
- **Data persistence and storage behavior**: PVC on by default, not deleted on uninstall, `WaitForFirstConsumer` normal
- **`deploy.sh` vs direct Helm** comparison table

**`architecture.md` additions:**
- Multi-cluster data flow short version with control plane vs data plane split
- Demo data vs real cluster data section with explicit UI indicators (Demo badge, yellow outline)
- Hosted demo strict capability boundary table

**`mkdocs.yml`**: new Troubleshooting entry in Console nav.

## Out of scope for this repo

- **#1396** (`.env.example` points to GitHub Apps URL) and **#1397** (CONTRIBUTING.md broken anchor) both live in the `kubestellar/console` repo, not this one. They need a separate PR on the console repo and are **not** closed by this PR.

## Issues closed

Closes #1384
Closes #1385
Closes #1386
Closes #1387
Closes #1388
Closes #1389
Closes #1390
Closes #1391
Closes #1392
Closes #1393
Closes #1394
Closes #1395
Closes #1398
Closes #1399
Closes #1400
Closes #1401
Closes #1402
Closes #1403
Closes #1404
Closes #1405
Closes #1406
Closes #1407
Closes #1408
Closes #1409
Closes #1410
Closes #1411

## Test plan

- [ ] MkDocs/Next.js build passes in CI
- [ ] Markdown lint passes
- [ ] Nav entry for Troubleshooting renders under Console
- [ ] Cross-links (`installation.md` ↔ `troubleshooting.md` ↔ `architecture.md`) resolve