### PR TITLE
docs: fix roadmap versions, nav naming, include-markdown rendering (#1423-#1425)

### DIFF
--- a/docs/content/contributing/coc-inc.md
+++ b/docs/content/contributing/coc-inc.md
@@ -1,5 +1,85 @@
-{%
-   include-markdown "../../../CODE_OF_CONDUCT.md"
-   start="<!--coc-start-->"
-   end="<!--coc-end-->"
-%}
+
+This project is following the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+# KubeStellar Community Code of Conduct
+
+As contributors, maintainers, and participants in the CNCF community, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who participate or contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, attending conferences or events, or engaging in other community or project activities.
+
+We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
+
+## Scope
+
+This code of conduct applies:
+
+- within project and community spaces,
+- in other spaces when an individual CNCF community participant's words or actions are directed at or are about a CNCF project, the CNCF community, or another CNCF community participant.
+
+### CNCF Events
+
+CNCF events that are produced by the Linux Foundation with professional events staff are governed by the Linux Foundation [Events Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be used in conjunction with the CNCF Code of Conduct.
+
+## Our Standards
+
+The CNCF Community is open, inclusive and respectful. Every member of our community has the right to have their identity respected.
+
+Examples of behavior that contributes to a positive environment include but are not limited to:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+- Using welcoming and inclusive language
+
+Examples of unacceptable behavior include but are not limited to:
+
+- The use of sexualized language or imagery
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment in any form
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Violence, threatening violence, or encouraging others to engage in violent behavior
+- Stalking or following someone without their consent
+- Unwelcome physical contact
+- Unwelcome sexual or romantic attention or advances
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+The following behaviors are also prohibited:
+
+- Providing knowingly false or misleading information in connection with a Code of Conduct investigation or otherwise intentionally tampering with an investigation.
+- Retaliating against a person because they reported an incident or provided information about an incident as a witness.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect
+of managing a CNCF project.
+Project maintainers who do not follow or enforce the Code of Conduct may be temporarily or permanently removed from the project team.
+
+## Reporting
+
+For incidents occurring in the KubeStellar community, contact the [KubeStellar Code of Conduct Committee](mailto:kubestellar-dev-private@googlegroups.com). You can expect a response within three business days.
+
+For other projects, or for incidents that are project-agnostic or impact multiple CNCF projects, please contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) via [`conduct@cncf.io`](mailto:conduct@cncf.io). Alternatively, you can contact any of the individual members of the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) to submit your report. For more detailed instructions on how to submit a report, including how to submit a report anonymously, please see our [Incident Resolution Procedures](https://www.cncf.io/conduct/procedures/). You can expect a response within three business days.
+
+For incidents occurring at CNCF event that is produced by the Linux Foundation, please contact [`eventconduct@cncf.io`](mailto:eventconduct@cncf.io).
+
+## Enforcement
+
+Upon review and investigation of a reported incident, the CoC response team that has jurisdiction will determine what action is appropriate based on this Code of Conduct and its related documentation.
+
+For information about which Code of Conduct incidents are handled by project leadership, which incidents are handled by the CNCF Code of Conduct Committee, and which incidents are handled by the Linux Foundation (including its events team), see our [Jurisdiction Policy](https://www.cncf.io/conduct/jurisdiction/).
+
+## Amendments
+
+Consistent with the CNCF Charter, any substantive changes to this Code of Conduct must be approved by the Technical Oversight Committee.
+
+## Acknowledgements
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 2.0 available at
+http://contributor-covenant.org/version/2/0/code_of_conduct/

--- a/docs/content/contributing/cont-code-inc.md
+++ b/docs/content/contributing/cont-code-inc.md
@@ -1,2 +1,9 @@
-<!-- Included in website. Edit CONTRIBUTING.md for GitHub. -->
-{% include-markdown "./CONTRIBUTINGKS.md" %}
+# Contributing to KubeStellar Code
+
+Greetings! We are grateful for your interest in joining the KubeStellar community and making a positive impact. Whether you're raising issues, enhancing documentation, fixing bugs, or developing new features, your contributions are essential to our success.
+
+To get started, kindly read through this document and familiarize yourself with our code of conduct. If you have any inquiries, please feel free to reach out to us on [Slack](https://cloud-native.slack.com/archives/C097094RZ3M).
+
+We can't wait to collaborate with you!
+
+For the full contributing guide to KubeStellar code, see the [CONTRIBUTINGKS.md](CONTRIBUTINGKS.md) file.

--- a/docs/content/contributing/documentation/contributing-inc.md
+++ b/docs/content/contributing/documentation/contributing-inc.md
@@ -1,6 +1,156 @@
-<!-- Included in website. Edit CONTRIBUTING.md for GitHub. -->
-{% include-markdown "../../../../CONTRIBUTING.md"
-    
+# Contributing to KubeStellar Docs
+
+Thank you for your interest in contributing to our documentation repository! We welcome contributions from everyone. Please follow these guidelines to help maintain a high-quality, consistent, and collaborative project.
+
+---
+
+## Prerequisites
+
+Before contributing, ensure you have:
+
+- [Node.js](https://nodejs.org/) (version 18 or higher) installed
+- [npm](https://www.npmjs.com/) installed
+- A GitHub account
+- Basic knowledge of Markdown and Git
+
+---
+
+## How to Contribute
+
+### 1. Fork the Repository
+
+Click the **Fork** button at the top-right corner of this page to create your own copy of the repository.
+
+### 2. Clone Your Fork
+
+Clone the repository to your local machine:
+
+```sh
+git clone https://github.com/your-username/docs.git
+```
+
+### 3. Install Dependencies
+
+Navigate into the project directory and install dependencies:
+
+```sh
+cd docs
+npm install
+```
+
+### 4. Create a Branch
+
+Create a new branch for your work:
+
+```sh
+git checkout -b my-feature-branch
+```
+
+### 5. Make Your Changes
+
+Edit or create documentation files as needed.  
+Please follow the existing structure, tone, and formatting style.
+
+### 6. Preview / Test Your Changes
+
+Start the development environment to verify rendering:
+
+```sh
+npm run dev
+```
+
+> **Tip:** During active documentation contributions, regularly run `npm run dev` to preview updates in real time.
+
+### 7. Commit and Push
+
+Commit your changes with a clear and meaningful message:
+
+```sh
+git add .
+git commit -m "Describe your changes"
+git push origin my-feature-branch
+```
+
+### 8. Open a Pull Request
+
+Open a Pull Request (PR) from your branch to the main repository.
+
+#### PR Description
+
+- Provide a summary of what you changed (maximum 2 lines).
+- Reference related issues, e.g.:
+  ```
+  Fixes #123
+  ```
 
 
- %}
+
+## Contribution Guidelines
+
+- **Write Clearly:** Use concise language and proper formatting.
+- **Stay Consistent:** Maintain the existing structure and style.
+- **Respect Internationalization Standards:** Avoid pushing raw UI strings directly; always use i18n references.
+- **Be Respectful:** Review our Code of Conduct before contributing.
+
+## Note on E2E Test Context Workaround
+
+The E2E test suite includes a temporary workaround for a known kubeflex context-selection issue.
+
+Under certain conditions, `kflex create` can select an unintended hosting cluster when multiple kubeconfig contexts are present and kubeflex-related context extensions are configured. This can cause E2E tests to fail even when the current context correctly accesses the intended hosting cluster.
+
+To ensure consistent and reliable test execution, the E2E test setup removes kubeflex-specific extensions from the kubeconfig before running tests. This forces `kflex create` to rely solely on the current kubeconfig context during E2E runs.
+
+This workaround is limited to the E2E test infrastructure and does not affect normal user workflows. It is intended to be temporary and will be removed once the underlying context-handling issue is resolved.
+
+### Caution With AI-Generated Code
+
+> AI tools (like GitHub Copilot or ChatGPT) are helpful but **not always context-aware**.  
+> **Please DO NOT blindly copy-paste AI-generated code.**
+
+Before committing:
+
+- Double-check if the code aligns with our project's architecture.
+- Test thoroughly to ensure it doesn't break existing functionality.
+- Refactor and adapt it as per the codebase standards.
+
+---
+## CI Workflow Notes
+
+### OSSF Scorecard
+The OSSF Scorecard workflow requires permissions to be defined at the job level.
+Workflow-level permissions are not supported and may cause CI failures due to
+OSSF Scorecard web application requirements.
+
+### Image Scanning
+The image scanning workflow supports repositories with multiple Dockerfiles
+using a matrix strategy. Dockerfile paths must be correctly configured to
+ensure all container images are scanned successfully.
+
+---
+
+## Understanding the Documentation Architecture
+
+For details on the documentation architecture, see the [Docs Structure](docs-structure-inc.md) page.
+
+## Working Effectively on the KubeStellar Docs
+
+For making simple edits, see the [Simple Changes](simple-docs-inc.md) page.
+
+For version management, see the [Version Management](docs-version-inc.md) page.
+
+## Need Help?
+
+If you have questions, open an issue or ask in the community channels:
+
+- **Slack**: [#kubestellar-dev](https://cloud-native.slack.com/archives/C097094RZ3M)
+- **GitHub Issues**: [kubestellar/docs](https://github.com/kubestellar/docs/issues)
+- **Community Meetings**: Check the [community calendar](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MWM4a2loZDZrOWwzZWQzZ29xanZwa3NuMWdfMjAyMzA1MThUMTQwMDAwWiBiM2Q2NWM5MmJlZDdhOTg4NGVmN2ZlOWUzZjZjOGZlZDE2ZjZmYjJmODExZjU3NTBmNTQ3NTY3YTVkZDU4ZmVkQGc)
+
+### Additional Resources
+
+- **Nextra Documentation**: [https://nextra.site](https://nextra.site)
+- **Next.js Documentation**: [https://nextjs.org/docs](https://nextjs.org/docs)
+- **MDX Documentation**: [https://mdxjs.com](https://mdxjs.com)
+- **Main KubeStellar Repo**: [https://github.com/kubestellar/kubestellar](https://github.com/kubestellar/kubestellar)
+
+_This page is based on [github.com/kubestellar/docs/CONTRIBUTING.md](https://github.com/kubestellar/docs/blob/main/CONTRIBUTING.md). For the most up-to-date version, see that file directly._

--- a/docs/content/contributing/documentation/docs-structure-inc.md
+++ b/docs/content/contributing/documentation/docs-structure-inc.md
@@ -1,9 +1,128 @@
 # Understanding the KubeStellar Documentation Architecture
-{% include-markdown "../../../CONTRIBUTING.md"
-    start='## Understanding the Documentation Architecture'
-    end = '## Working Effectively on the KubeStellar Docs'
 
+### Overview
 
- %}
+This documentation website is a **separate repository** from the main KubeStellar codebase. All the active documentation is now located _in this repository_. 
+For safety reasons, copies of the docs source may remain in a to-be-deleted folder in the component repositories during a transition period
 
- _This page is an import of **part** of github.com/kubestellar/docs/CONTRIBUTING.md . The complete file is viewable there, or on the [Detailed Contribution Guide](contributing-inc.md) page in this section of the website. Changes to this page content must be made in  CONTRIBUTING.md on GitHub_
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Main KubeStellar Repository                                │
+│  github.com/kubestellar/kubestellar                         │
+│  kubestellar/                                               │
+│   ├ docs/   <-- NOT THE ACTIVE DOCS                         |
+|     ├──README.md                                            |
+|     └──content/to-be-deleted                                │
+│           ├── readme.md                                     │
+│           ├── architecture.md                               │
+│           ├── direct/                                       │
+│           ├── binding.md                                    │
+│           ├── wds.md                                        │
+│           └── ... (all previous documentation content)      │
+│    └── ...(all the active components of the component repo) |
+└─────────────────────────────────────────────────────────────┘
+                         
+┌────────────────────────────────────────────────────────────────|
+│  Docs Website Repository (THIS REPO)                           │
+│  github.com/kubestellar/docs                                   |
+|                                                                │  
+│  docs/ <-- this repository root folder                         │
+|   ├ docs/ <-- raw MD content source moved from repos           |
+|   |   content/                                                 |
+|   |     a2a/                                                   |
+|   |     common-subs/                                           |
+|   |     Community/                                             |
+|   |     console/                                               |
+|   |     contribution-guidelines/                               |
+|   |     icons/                                                 |
+|   |     images/                                                |
+|   |     klaude/                                                |
+|   |     kubeflex/                                              |
+|   |     kubestellar/                                           |
+|   |     kubestellar-mcp/                                       |
+|   |     multi-plugin/                                          |
+|   |     ui-docs/                                               |
+|   |   images/ <-- image folder for some of the MD files        |
+|   |  overrides/ <-- master mkdocs layouts (legacy ref only)    |
+|   ├ messages      <-- alternate language files for pages       | 
+|   ├ src/  <-- Source for pages, site nav and layout            |    
+|   | ├ app/                                                     |
+|   | |  ├ docs/  <-- layouts to apply to component docs pages   |
+|   | |  ├── page-map.ts     <-- Defines navigation structure    │
+│   | |  ├── layout.tsx      <-- Nextra theme integration        │
+|   | |  └── page.mdx      <-- Nextra page master                │
+|   | ├ components/                                              │
+|   | ├ config/                                                  │
+|   | ├ hooks/                                                   │
+|   | ├ i18n/ <-- configures language support                    |
+|   | ├ lib/                                                     │
+|   ├ CONTRIBUTING.md                                            |
+|   ├ GOVERNANCE.md                                              |
+|   ├ next.config.ts      <-- Nextra configuration               │
+|   ├ mdx-components.js   <-- MDX component mappings             |
+|   └── ... (various node.js and next.js etc files)              │
+└────────────────────────────────────────────────────────────────┘
+                          |
+                    (Built & Deployed)
+                          |
+┌─────────────────────────────────────────────────────────────┐
+│  Live Documentation Website                                  │
+│  https://kubestellar.io                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Important Concepts:**
+
+- **Content lives in the docs/content folder of this kubestellar/docs repo** (`docs/content/`)
+- **The website structure is defined in the src folder of this repo**
+- **This repo also contains the website framework** (Next.js + Nextra)
+- **Navigation is defined in `page-map.ts`** (not auto-generated from files)
+
+### How Nextra Integration Works
+
+This documentation site is built using **Nextra**, a powerful Next.js-based documentation framework that provides:
+
+- **Static Site Generation (SSG)** for fast loading
+- **MDX Support** for rich, interactive documentation
+- **Built-in Search** functionality
+- **Theme Customization** with dark/light modes
+- **Automatic Navigation** generation
+
+#### Key Files and Their Roles
+
+1. **`next.config.ts`** - Main configuration file that:
+   - Imports and configures Nextra with `nextra()` function
+   - Enables LaTeX support for mathematical expressions
+   - Configures search settings
+   - Integrates with `next-intl` for internationalization
+   - Sets up redirects for various KubeStellar links
+
+2. **`src/app/docs/layout.tsx`** - Docs layout component that:
+   - Imports `Layout` from `nextra-theme-docs`
+   - Imports the Nextra theme styles
+   - Configures custom navbar, footer, and banner components
+   - Sets up the sidebar with page map and repository links
+   - Enables dark mode and collapsible sidebar sections
+
+3. **`src/app/docs/page-map.ts`** - Navigation structure builder that:
+   - Defines the documentation navigation structure in `NAV_STRUCTURE`
+   - Reads documentation files from the local `/docs/content/` directory
+   - Constructs hierarchical navigation from the defined structure
+   - Generates routes for each documentation page
+   - Creates a mapping between file paths and URL routes
+   - **Note:** The file tree structure in _/docs/content_ roughly parallels the navigation created in _pagemap.ts_ but is **not** identical. As the new site matures many of the differences will be smoothed out
+   - Using the page-map rather than file structure to generate the `NAV_STRUCTURE` simplifies changing menus for different locales (languages)
+
+4. **`src/app/docs/[...slug]/page.tsx`** - Dynamic page renderer that:
+   - Reads MDX content from the local `/docs/content/` directory
+   - Compiles and evaluates MDX with custom components
+   - Processes Jekyll-style includes and template variables
+   - Supports Mermaid diagrams and custom components
+   - Handles image path resolution and markdown transformations
+
+5. **`mdx-components.js`** - Component mapping file that:
+   - Exports MDX components from Nextra theme
+   - Allows customization of how markdown elements render
+   - Enables adding custom React components to MDX files
+
+ _This page is an excerpt of the [Detailed Contribution Guide](contributing-inc.md). The complete file is viewable there or at [github.com/kubestellar/docs/CONTRIBUTING.md](https://github.com/kubestellar/docs/blob/main/CONTRIBUTING.md). Changes to this page content should be made in CONTRIBUTING.md on GitHub._

--- a/docs/content/contributing/documentation/docs-version-inc.md
+++ b/docs/content/contributing/documentation/docs-version-inc.md
@@ -1,9 +1,22 @@
 # Version Management in the KubeStellar Documentation Architecture
-{% include-markdown "../../../../CONTRIBUTING.md"
-    start='### Version Management'
-    end = '### Testing Your Changes'
+
+The documentation supports multiple versions through the `versions.ts` config:
+
+- **Default Version**: Set in `getDefaultVersion()`
+- **Branch Mapping**: Map versions to Git branches in `getBranchForVersion()`
+- **Version Switching**: Users can switch versions via query parameter: `?version=0.23.0`
+
+The site supports multiple versions of the docs for the assorted components of KubeStellar via branches of the [kubestellar/docs](https://github.com/kubestellar/docs) repository.
+
+The site when first loaded shows the **latest** tagged version of the KubeStellar docs. The _main_ branch of a repository corresponds to the **dev** version on the site. Edits to the _main_ branch referring to a code repository will not show unless the **dev** version is selected.
 
 
- %}
+### Versioning Strategy:
+ - Each project has its own version scheme
+ - Branch naming convention:
+   - KubeStellar: main (latest), docs/\{version\} (e.g., docs/0.28.0)
+   - a2a: main (latest), docs/a2a/\{version\} (e.g., docs/a2a/0.1.0)
+   - kubeflex: main (latest), docs/kubeflex/\{version\} (e.g., docs/kubeflex/0.8.0)
+ - The main branch always displays the version tagged **latest** of the content files for all projects when rendered
 
- _This page is an import of **part** of github.com/kubestellar/docs/CONTRIBUTING.md . The complete file is viewable there, or on the [Detailed Contribution Guide](contributing-inc.md) page in this section of the website. Changes to this page content must be made in  CONTRIBUTING.md on GitHub_
+ _This page is an excerpt of the [Detailed Contribution Guide](contributing-inc.md). The complete file is viewable there or at [github.com/kubestellar/docs/CONTRIBUTING.md](https://github.com/kubestellar/docs/blob/main/CONTRIBUTING.md). Changes to this page content should be made in CONTRIBUTING.md on GitHub._

--- a/docs/content/contributing/documentation/simple-docs-inc.md
+++ b/docs/content/contributing/documentation/simple-docs-inc.md
@@ -2,10 +2,16 @@
 
 Spotted a typo or other simple error in one of our web documentation pages? Help us fix it quickly!
 
-{% include-markdown "../../../CONTRIBUTING.md"
-    start='## How to Modify An Existing Page in the site'
-    end= '### The Complicated Way'
+## How to Modify An Existing Page in the site
+### The Easy Way
 
- %}
+For edits to a single page, we have enabled a suggest edits function in the site itself: 
 
- _This page is an import of **part** of github.com/kubestellar/docs/CONTRIBUTING.md . The complete file is viewable there, or on the [Detailed Contribution Guide](contributing-inc.md) page in this section of the website.  Changes to this page content must be made in  CONTRIBUTING.md on GitHub_
+1. Sign into GitHub in your browser.
+2.  Open a second tab and visit the page in the website you wish to modify. <br />**_(Make sure you have selected the appropriate version of the docs with the dropdown in the masthead)_** The site defaults to showing "latest"; the main branch of kubestellar/docs corresponds to "dev"
+3. Find and click on the Edit This Page (Pencil) icon near the upper right page
+4. A GitHub editor session will open for you and when you commit your changes, you will be presented with the option to create a corresponding PR. 
+5. You may have to make some adjustments to the PR title, etc to fulfill some requirements for a PR.
+6. When your PR is created, it will automatically generate a site preview via Netlify to make reviewing the proposed changes easier
+
+ _This page is an excerpt of the [Detailed Contribution Guide](contributing-inc.md). The complete file is viewable there or at [github.com/kubestellar/docs/CONTRIBUTING.md](https://github.com/kubestellar/docs/blob/main/CONTRIBUTING.md). Changes to this page content should be made in CONTRIBUTING.md on GitHub._

--- a/docs/content/contributing/governance-inc.md
+++ b/docs/content/contributing/governance-inc.md
@@ -1,6 +1,154 @@
-<!-- A wrapper file to include the GOVERNANCE file from the repository root -->
-{%
-    include "../../../GOVERNANCE.md"
-%}
+# KubeStellar Project Governance
 
-_Note: this file "governance-inc" is a wrapper that includes the GOVERNANCE.md file found in the root of the KubeStellar repository_
+The KubeStellar project is dedicated to solving challenges stemming from
+multi-cluster configuration management for edge, multi-cloud, and hybrid cloud. 
+This governance explains how the project is run.
+
+- [Manifesto](#manifesto)
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [Modifying this Charter](#modifying-this-charter)
+
+## Manifesto
+ 
+ * KubeStellar Maintainers strive to be good citizens in the Kubernetes project.
+ * KubeStellar Maintainers see KubeStellar always as part of the Kubernetes ecosystem and always 
+   strive to keep that ecosystem united. In particular, this means:
+   * KubeStellar strives to not divert from Kubernetes, but strives to extend its 
+     use-cases to non-container control planes while keeping the ecosystems of 
+     libraries and tooling united.
+   * KubeStellar -- as a consumer of Kubernetes API Machinery -- will strive to stay 100% 
+     compatible with the semantics of Kubernetes APIs, while removing container 
+     orchestration specific functionality.
+   * KubeStellar strives to upstream changes to Kubernetes code as much as possible.
+
+## Values
+
+The KubeStellar and its leadership embrace the following values:
+
+ * *Openness*: Communication and decision-making happens in the open and is 
+   discoverable for future reference. As much as possible, all discussions and 
+   work take place in public forums and open repositories.
+ * *Fairness*: All stakeholders have the opportunity to provide feedback and 
+   submit contributions, which will be considered on their merits.
+ * *Community over Product or Company*: Sustaining and growing our community 
+   takes priority over shipping code or sponsors' organizational goals. Each 
+   contributor participates in the project as an individual.
+ * *Inclusivity*: We innovate through different perspectives and skill sets, 
+   which can only be accomplished in a welcoming and respectful environment.
+ * *Participation*: Responsibilities within the project are earned through 
+   participation, and there is a clear path up the contributor ladder into 
+   leadership positions.
+
+## Maintainers
+
+KubeStellar Maintainers have write access to the [project GitHub repository](https://github.com/kubestellar/kubestellar).
+They can merge their own patches or patches from others. The current maintainers
+can be found as top-level approvers in [OWNERS](https://github.com/kubestellar/kubestellar/blob/main/OWNERS).  Maintainers collectively 
+manage the project's resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the KubeStellar project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which 
+is the governing body for the project.
+
+## Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews
+      for 3 months or more,
+    * perform reviews for 5 non-trivial pull requests,
+    * contribute 5 non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+
+A new Maintainer must be proposed by an existing maintainer by sending a message to the
+[developer mailing list](https://groups.google.com/g/kubestellar-dev). A simple majority 
+vote of existing Maintainers approves the application.
+
+Maintainers who are selected will be granted the necessary GitHub rights,
+and invited to the [private maintainer mailing list](https://groups.google.com/g/kubestellar-dev-private).
+
+### Bootstrapping Maintainers
+
+To bootstrap the process, 3 maintainers are defined (in the initial PR adding 
+this to the repository) that do not necessarily follow the above rules. When a 
+new maintainer is added following the above rules, the existing maintainers 
+define one not following the rules to step down, until all of them follow the 
+rules.
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to 
+continue fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their 
+Maintainer responsibilities, violating the Code of Conduct, or other reasons. 
+Inactivity is defined as a period of very low or no activity in the project for 
+a year or more, with no definite schedule to return to full Maintainer activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+Depending on the reason for removal, a Maintainer may be converted to Emeritus 
+status. Emeritus Maintainers will still be consulted on some project matters, 
+and can be rapidly returned to Maintainer status if their availability changes.
+
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public 
+community call meeting. Maintainers will also have closed meetings in order to 
+discuss security reports or Code of Conduct violations. Such meetings should be 
+scheduled by any Maintainer on receipt of a security issue or CoC report. 
+All current Maintainers must be invited to such closed meetings, except for any 
+Maintainer who is accused of a CoC violation.
+
+## Code of Conduct
+
+[Code of Conduct](coc-inc.md)
+violations by community members will be discussed and resolved
+on the [private Maintainer mailing list](https://groups.google.com/u/1/g/kubestellar-dev-private).
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves. If this 
+responsibility is delegated, the Maintainers will appoint a team of at least two 
+contributors to handle it. The Maintainers will review who is assigned to this 
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security 
+holes and breaches according to the [security policy](security/security-inc.md).
+
+## Voting
+
+While most business in KubeStellar is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](https://groups.google.com/g/kubestellar-dev) or
+[the private Maintainer mailing list](https://groups.google.com/u/1/g/kubestellar-dev-private)
+for security or conduct matters.  Votes may also be taken at the community call 
+meeting. Any Maintainer may demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, and changes to this
+Governance require a 2/3 vote of all Maintainers.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by a 
+2/3 vote of the Maintainers.

--- a/docs/content/contributing/license-inc.md
+++ b/docs/content/contributing/license-inc.md
@@ -1,3 +1,184 @@
-{%
-   include "../../../LICENSE"
-%}
+# License
+
+KubeStellar is licensed under the Apache License, Version 2.0.
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+```
+
+The full license text is also available at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/content/contributing/onboarding-inc.md
+++ b/docs/content/contributing/onboarding-inc.md
@@ -1,5 +1,60 @@
+# KubeStellar GitHub Organization
+## On-boarding and Off-boarding Policy
 
-{%
-   include-markdown "../../../ONBOARDING.md"
+Effective Date: June 1st, 2023
 
-%}
+  At KubeStellar we love our contributors.  Our contributors can make various valuable contributions to our project. They can actively engage in code development by submitting pull requests, implementing new features, or fixing bugs. Additionally, contributors can assist with testing, CICD, documentation, providing clear and comprehensive guides, tutorials, and examples. Moreover, they can contribute to the project by participating in discussions, offering feedback, and helping to improve overall community engagement and collaboration.
+
+1. Introduction:
+The purpose of this policy is to ensure a smooth on-boarding and off-boarding process for members of the KubeStellar GitHub organization. This policy applies to all individuals joining or leaving the organization, including community contributors.
+
+2. On-boarding Process:
+2.1. Access Request:
+- New members shall submit an access request, via a blank GitHub issue from the KubeStellar repository, mentioning all members of the [OWNERS](https://github.com/kubestellar/kubestellar/blob/main/OWNERS) file.
+- The access request should include the member's GitHub username and a brief description of their role and contributions to the KubeStellar project.
+
+2.2. Review and Approval:
+- The organization's maintainers or designated personnel will review the access request issue.
+- The maintainers will evaluate the request based on the member's role, contributions, and adherence to the organization's code of conduct.
+- Upon approval, the member will receive an invitation to join the KubeStellar GitHub organization.
+
+2.3. Getting Help:
+- The organization's maintainers are here to help contributors be efficient and confident in their collaboration effort. If you need help you can reach out to the maintainers on slack at the [KubeStellar-dev Slack Channel](https://cloud-native.slack.com/archives/C097094RZ3M).
+- Be sure to join the [KubeStellar-dev Google Group](https://groups.google.com/g/kubestellar-dev) to get access to important artifacts like proposals, diagrams, and meeting invitations.
+
+2.4. Orientation:
+- Newly on-boarded members will be provided with [contribution guidelines](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md).
+- The guide will include instructions on how to access relevant repositories, participate in discussions, and contribute to ongoing projects.
+
+3. Off-boarding Process:
+3.1. Departure Notification:
+- Members leaving the organization shall notify the maintainers or their respective team lead in advance of their departure date.
+- The notification should include the member's departure date and any necessary transition information.
+
+3.2. Access Termination:
+- Upon receiving the departure notification, the maintainers or designated personnel will initiate the off-boarding process.
+- The member's access to the KubeStellar GitHub organization will be revoked promptly to ensure data security and prevent unauthorized access.
+
+3.3. Knowledge Transfer:
+- Departing members should facilitate the transfer of their ongoing projects, tasks, and knowledge to their respective replacements or relevant team members.
+- Documentation or guidelines related to ongoing projects should be updated and made available to the team for seamless continuity.
+
+4. Code of Conduct:
+- All members of the KubeStellar GitHub organization are expected to adhere to the organization's [code of conduct](https://github.com/kubestellar/kubestellar/blob/main/CODE_OF_CONDUCT.md), promoting a respectful and inclusive environment.
+- Violations of the code of conduct will be addressed following the organization's established procedures for handling such incidents.
+
+5. Policy Compliance:
+- It is the responsibility of all members to comply with the on-boarding and off-boarding policy.
+- The organization's maintainers or designated personnel will oversee the implementation and enforcement of this policy.
+
+6. Policy Review:
+- This policy will be reviewed periodically to ensure its effectiveness and relevance.
+- Any updates or revisions to the policy will be communicated to the organization's members in a timely manner.
+
+Please note that this policy is subject to change, and any modifications will be communicated to all members of the KubeStellar GitHub organization.
+
+By joining the organization, all members agree to abide by the terms and guidelines outlined in this policy.
+
+Andy Anderson (clubanderson)
+KubeStellar Maintainer
+June 1, 2023

--- a/docs/content/contributing/security/security-inc.md
+++ b/docs/content/contributing/security/security-inc.md
@@ -1,5 +1,54 @@
-{%
-   include-markdown "../../../../SECURITY.md"
-   start="<!--security-start-->"
-   end="<!--security-end-->"
-%}
+## Security Announcements
+
+Join the [kubestellar-security-announce](https://groups.google.com/u/1/g/kubestellar-security-announce) group for emails about security and major API announcements.
+
+## Dependencies Policy
+
+KubeStellar manages its dependencies with the following policy:
+
+- **Dependency Detection:** We use [Dependabot](https://github.com/dependabot) to automatically check for and propose updates to dependencies in Go modules, Python requirements, Dockerfiles, Helm charts, and GitHub Actions workflows. Dependabot PRs serve as prompts but are not automatically accepted.
+- **Update Process:** After Dependabot creates a PR, maintainers wait for potential issues to surface before proceeding. The handling then depends on the type of dependency and whether Dependabot's proposal is functional:
+    - **GitHub Actions:** Maintainers create their own PR that follows our [GitHub Action reference discipline](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md#github-action-reference-discipline) and other established practices.
+    - **Go Dependencies:** If Dependabot's proposal is functional, it may be accepted directly. If the proposal is broken, maintainers create their own PR to address the dependency update properly.
+- **Review Process:** All dependency update pull requests are subject to the same [review process](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md#pull-requests) as other code changes. Maintainers verify that updates do not introduce breaking changes or known vulnerabilities before merging.
+- **Vulnerability Checking:** Before merging dependency updates, maintainers perform security assessments:
+    - **Security Scanning:** Given that KubeStellar imports various types of dependencies (Go packages, pre-built binaries, container images, Helm charts, and GitHub Actions), we rely on GitHub's security advisory database and Dependabot's vulnerability detection capabilities. Specific additional security scanning tools are not currently standardized across all dependency types.
+    - **Security Advisories:** Review security advisories and release notes for the updated dependencies
+    - **Breaking Changes:** Verify that updates do not introduce breaking changes or compatibility issues
+    - **GitHub Actions:** For GitHub Actions specifically, ensure updates follow our [GitHub Action Reference Discipline](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md#github-action-reference-discipline) and use approved commit hashes. The [verify-action-hashes workflow](https://github.com/kubestellar/kubestellar/blob/main/.github/workflows/verify-action-hashes.yaml) automatically checks that each GitHub Action reference uses an approved commit hash.
+    - **SBOM Generation:** Generate Software Bill of Materials (SBOM) using [Anchore's syft tool](https://github.com/kubestellar/kubestellar/blob/main/.github/workflows/goreleaser.yml) during releases to identify and track dependencies for security analysis
+    - **Testing:** Run available tests to verify that updated dependencies work correctly with the codebase
+- **Security Best Practices:** We avoid using unmaintained or deprecated dependencies. Monitoring for security advisories affecting our dependencies is primarily done through GitHub's security advisory database and Dependabot notifications. Vulnerabilities in dependencies are prioritized for prompt remediation.
+- **Documentation:** The dependency update process is documented in the repository's README and CONTRIBUTING guidelines.
+
+## Report a Vulnerability
+
+We're extremely grateful for security researchers and users that report vulnerabilities to the KubeStellar Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+
+You can also email the private [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-announce@googlegroups.com) list with the security details and the details expected for [all KubeStellar bug reports](https://github.com/kubestellar/kubestellar/blob/main/.github/ISSUE_TEMPLATE/bug_report.yaml).
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in KubeStellar
+- You are unsure how a vulnerability affects KubeStellar
+- You think you discovered a vulnerability in another project that KubeStellar depends on
+    - For projects with their own vulnerability reporting and disclosure process, please report it directly there
+
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning KubeStellar components for security
+- You need help applying security related updates
+- Your issue is not security related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the maintainers of KubeStellar within 3 working days.
+
+Any vulnerability information shared with Security Response Committee stays within KubeStellar project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the KubeStellar Security Response Committee and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The KubeStellar maintainers hold the final say when setting a disclosure date.

--- a/docs/content/contributing/security/security_contacts-inc.md
+++ b/docs/content/contributing/security/security_contacts-inc.md
@@ -1,6 +1,15 @@
 # Security Contacts
-{%
-   include-markdown "../../../../SECURITY_CONTACTS.md"
-   start="<!--security-contacts-start-->"
-   end="<!--security-contacts-end-->"
-%}
+
+Defined below are the security contacts for this repo.
+
+They are the contact point for the Product Security Committee to reach out
+to for triaging and handling of incoming issues.
+
+The below names agree to address security concerns if and when they arise.
+
+DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, SEND INFORMATION
+TO [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-announce@googlegroups.com)
+
+clubanderson
+MikeSpreitzer
+pdettori

--- a/docs/content/kubestellar/roadmap.md
+++ b/docs/content/kubestellar/roadmap.md
@@ -1,13 +1,25 @@
 # KubeStellar Roadmap
 
-This document defines the KubeStellar feature roadmap. This document is a work-in-progress.
+> **Note:** This page reflects the historical roadmap for the KubeStellar core components. The project has evolved significantly since these items were written. For the latest project direction, active milestones, and current priorities, please see the [KubeStellar GitHub Project Board](https://github.com/orgs/kubestellar/projects) and [open milestones](https://github.com/kubestellar/kubestellar/milestones).
 
-- Land most of the open PRs.
-- Address security vulnerabilities that can be addressed while sticking to Kubernetes 1.30.
-    - E.g., see the full security report [about the core Helm chart at ArtifactHUB](https://artifacthub.io/packages/helm/kubestellar/core-chart).
-- Address failings in the [OpenSSF Best Practices scorecared](https://www.bestpractices.dev/en/projects/8266).
-- Make a KubeFlex release.
-- Update KubeStellar to use that KubeFlex release.
-- Upgrade to Kubernetes 1.31 .
-- Address more security vulnerabilities.
-- Work on OCM/ACM convergence.
+## Historical Items (Legacy Core Components)
+
+The following items were tracked during earlier KubeStellar development cycles. Many have been completed or superseded:
+
+- ~~Address security vulnerabilities while on Kubernetes 1.30.~~ (Completed)
+- ~~Make a KubeFlex release.~~ (Completed)
+- ~~Update KubeStellar to use that KubeFlex release.~~ (Completed)
+- ~~Upgrade to Kubernetes 1.31.~~ (Completed)
+- Address remaining security vulnerabilities and keep dependencies current (Kubernetes 1.32+).
+- Continue OCM/ACM convergence work.
+- Address failings in the [OpenSSF Best Practices scorecard](https://www.bestpractices.dev/en/projects/8266).
+
+## Current Project Direction
+
+KubeStellar now encompasses multiple components beyond the core multi-cluster engine:
+
+- **KubeStellar Console** — A unified web dashboard for managing multi-cluster deployments, with AI-assisted operations, dashboards, and a marketplace.
+- **KubeStellar MCP** — Model Context Protocol integration for AI-native cluster management.
+- **A2A** — Agent-to-Agent protocol support for KubeStellar operations.
+
+For roadmap details on these newer components, see their respective documentation sections.

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -94,9 +94,9 @@ const NAV_STRUCTURE_A2A: Array<{ title: string; items: NavItem[] }> = [
   {
     title: 'Getting Started',
     items: [
-      { 'Overview': 'getting-started/index.md' },
-      { 'Installation': 'getting-started/installation.md' },
       { 'Quick Start': 'getting-started/quick-start.md' },
+      { 'Installation': 'getting-started/installation.md' },
+      { 'Guide Overview': 'getting-started/index.md' },
     ]
   },
   {
@@ -226,9 +226,9 @@ const NAV_STRUCTURE_CONSOLE: Array<{ title: string; items: NavItem[] }> = [
 const NAV_STRUCTURE_KUBESTELLAR: Array<{ title: string; items: NavItem[] }> = [
 
   {
-    title: 'What is KubeStellar?',
+    title: 'Overview',
     items: [
-      { 'Overview': 'readme.md' },
+      { 'Introduction': 'readme.md' },
       { 'Architecture': 'kubestellar/architecture.md' },
       { 'OCM Status Addon': 'kubestellar/ocm-status-addon-intro.md' },
       { 'Release Notes': 'kubestellar/release-notes.md' },
@@ -236,12 +236,11 @@ const NAV_STRUCTURE_KUBESTELLAR: Array<{ title: string; items: NavItem[] }> = [
     ]
   },
   {
-    title: 'User Guide',
+    title: 'Getting Started',
     items: [
       { 'Quick Start': 'kubestellar/get-started.md' },
       { 'Guide Overview': 'kubestellar/user-guide-intro.md' },
       { 'Observability': 'kubestellar/observability.md' },
-      { 'Getting Started': 'kubestellar/get-started.md' },
       { 'Getting Started from OCM': 'kubestellar/start-from-ocm.md' },
       {
         'General Setup': [
@@ -524,7 +523,7 @@ export function buildPageMap(projectId: ProjectId = 'kubestellar') {
       }
 
       // Set theme for first category to be expanded
-      if (category.title === 'Welcome' || category.title === 'What is KubeStellar?' || category.title === 'Overview') {
+      if (category.title === 'Welcome' || category.title === 'Overview') {
         folderNode.theme = { collapsed: false }
       }
 


### PR DESCRIPTION
Closes #1423
Closes #1424
Closes #1425

## Summary

- **Roadmap (#1423)**: Updated `roadmap.md` to mark stale K8s 1.30/1.31 items as completed, reference K8s 1.32+, and link to GitHub project boards for the active roadmap. Added context about the project's current direction (Console, MCP, A2A).

- **Navigation (#1424)**: Standardized sidebar naming in `page-map.ts` — renamed "What is KubeStellar?" to "Overview" with "Introduction" as the landing page, renamed "User Guide" to "Getting Started" for consistency with other project sections (Console, A2A, KubeFlex, Multi-Plugin). Reordered A2A Getting Started items to lead with Quick Start.

- **Include-markdown (#1425)**: Replaced MkDocs Jinja2 `{% include-markdown %}` and `{% include %}` directives with inlined content in 11 files under `docs/content/contributing/`. These directives rendered as raw text in the Next.js/Nextra docs site. Affected files: `coc-inc.md`, `onboarding-inc.md`, `license-inc.md`, `governance-inc.md`, `security-inc.md`, `security_contacts-inc.md`, `simple-docs-inc.md`, `docs-version-inc.md`, `docs-structure-inc.md`, `contributing-inc.md`, `cont-code-inc.md`.

## Test plan

- [x] `npm run build` passes locally
- [ ] Verify Netlify preview renders contributing pages correctly (no raw directives)
- [ ] Verify roadmap page shows updated content
- [ ] Verify sidebar navigation shows "Overview" instead of "What is KubeStellar?"