### PR TITLE
docs: fix scenario variable, WEC link, marketplace page (#1430, #1432, #1433)

### DIFF
--- a/docs/content/kubestellar/example-scenarios.md
+++ b/docs/content/kubestellar/example-scenarios.md
@@ -343,7 +343,7 @@ metadata:
   name: nginx-singleton-bpolicy
 spec:
   clusterSelectors:
-  - matchLabels: {"name":"cluster1"}
+  - matchLabels: {$(echo "$label_query_one" | tr , $'\n' | while IFS="=" read key val; do echo -n ", \"$key\": \"$val\""; done | tail -c +3)}
   downsync:
   - objectSelectors:
     - matchLabels: {"app.kubernetes.io/name":"nginx-singleton"}

--- a/docs/content/kubestellar/wec-registration.md
+++ b/docs/content/kubestellar/wec-registration.md
@@ -182,7 +182,7 @@ These properties can be used for rule-based transformations when workloads are d
 ### Local Development Clusters (Kind/K3d)
 
 For instructions on creating and registering local development clusters (Kind or K3d), refer to the  
-[Create and Register Two Workload Execution Clusters guide](https://docs.kubestellar.io/unreleased-development/kubestellar/get-started/#create-and-register-two-workload-execution-clusters).
+[Create and Register Two Workload Execution Clusters guide](../get-started/#create-and-register-two-workload-execution-clusters).
 
 ### OpenShift Clusters
 

--- a/src/app/[locale]/marketplace/page.tsx
+++ b/src/app/[locale]/marketplace/page.tsx
@@ -339,7 +339,11 @@ export default function MarketplacePage() {
   const tagRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    fetch(REGISTRY_URL)
+    const FETCH_TIMEOUT_MS = 10000;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    fetch(REGISTRY_URL, { signal: controller.signal })
       .then((res) => {
         if (!res.ok) throw new Error("Failed to fetch marketplace data");
         return res.json();
@@ -350,9 +354,13 @@ export default function MarketplacePage() {
         setLoading(false);
       })
       .catch((e) => {
-        setError(e.message);
+        const message = e.name === "AbortError"
+          ? "Request timed out. The marketplace registry may be temporarily unavailable."
+          : e.message;
+        setError(message);
         setLoading(false);
-      });
+      })
+      .finally(() => clearTimeout(timer));
   }, []);
 
   // Close tag dropdown on outside click
@@ -530,8 +538,43 @@ export default function MarketplacePage() {
 
           {error && (
             <div className="text-center py-20">
+              <Package size={48} className="mx-auto text-gray-600 mb-4" />
               <p className="text-red-400 mb-2">Failed to load marketplace</p>
-              <p className="text-gray-500 text-sm">{error}</p>
+              <p className="text-gray-500 text-sm mb-6">{error}</p>
+              <div className="flex items-center justify-center gap-4">
+                <button
+                  onClick={() => {
+                    setError(null);
+                    setLoading(true);
+                    fetch(REGISTRY_URL)
+                      .then((res) => {
+                        if (!res.ok) throw new Error("Failed to fetch marketplace data");
+                        return res.json();
+                      })
+                      .then((d: RegistryData) => {
+                        const allItems = [...(d.items || []), ...(d.presets || [])];
+                        setData({ ...d, items: allItems });
+                        setLoading(false);
+                      })
+                      .catch((e) => {
+                        setError(e.message);
+                        setLoading(false);
+                      });
+                  }}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-600/30 text-gray-400 hover:text-white hover:border-gray-500 transition-colors text-sm"
+                >
+                  Retry
+                </button>
+                <a
+                  href="https://github.com/kubestellar/console-marketplace"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-600/30 text-gray-400 hover:text-white hover:border-gray-500 transition-colors text-sm"
+                >
+                  <ExternalLink size={14} />
+                  Browse on GitHub
+                </a>
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
Closes #1430
Closes #1432
Closes #1433

## Changes

- **Scenario 4 hardcoded cluster name (#1430)**: Replaced `{"name":"cluster1"}` in the Scenario 4 BindingPolicy `matchLabels` with the `$label_query_one` shell variable expansion, matching the convention used by all other scenarios.

- **WEC registration unreleased link (#1432)**: Changed the absolute URL pointing to `/unreleased-development/kubestellar/get-started/` to a relative link (`../get-started/`) so it resolves to the current released docs version.

- **Marketplace permanent loading (#1433)**: Added a 10-second fetch timeout with `AbortController`, a retry button in the error state, and a "Browse on GitHub" fallback link so users are never stuck on an infinite spinner.

## Files changed

- `docs/content/kubestellar/example-scenarios.md`
- `docs/content/kubestellar/wec-registration.md`
- `src/app/[locale]/marketplace/page.tsx`

## Test plan

- Build passes locally (`npm run build`)
- Verify Scenario 4 works with non-"cluster1" WEC names
- Verify WEC registration link resolves to current release docs
- Verify marketplace page shows error/retry after timeout instead of spinning forever