### PR TITLE
docs: fix typo, deprecated ref, quickstart prerequisites (#1435, #1436, #1438)

### DIFF
--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -18,6 +18,20 @@ Get KubeStellar Console running locally for development or evaluation.
 
 > **Try it first!** See a live preview at [kubestellarconsole.netlify.app](https://kubestellarconsole.netlify.app) - no installation needed.
 
+!!! important "Claude Code is required for AI features"
+    This Quick Start uses **[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)**, Anthropic's CLI tool, to install and manage the kubestellar-mcp plugins that connect the console to your clusters. Claude Code requires an Anthropic API subscription.
+
+    **What requires Claude Code:**
+
+    - Installing kubestellar-mcp plugins via the Claude Code Marketplace (Option A in Step 1)
+    - AI Missions (automated issue detection and remediation)
+
+    **What works without Claude Code:**
+
+    - The console dashboard, cards, and multi-cluster views all work without Claude Code
+    - You can install kubestellar-mcp plugins via **Homebrew** instead (Option B in Step 1)
+    - The `curl` quickstart and source builds do not require Claude Code themselves
+
 ## Fastest Path (curl)
 
 > **Prerequisites**: You must install the kubestellar-mcp plugins **before** running this command — they are not installed by `start.sh`. See [Step 1](#step-1-install-kubestellar-mcp-tools) below.

--- a/docs/content/kubestellar/example-scenarios.md
+++ b/docs/content/kubestellar/example-scenarios.md
@@ -244,7 +244,7 @@ clusters=("$wds_context" "$wec1_context" "$wec2_context");
 done
 ```
 
-## Scenario 3: Multi-Custer Workload Deployment with Helm
+## Scenario 3: Multi-Cluster Workload Deployment with Helm
 
 Create a BindingPolicy for the helm chart app:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,7 +80,7 @@ nav:
               - Missing results in a CombinedStatus object: kubestellar/knownissue-collector-miss.md
               - Kind host not configured for more than two clusters: kubestellar/installation-errors.md
               - Insufficient CPU for your clusters: kubestellar/knownissue-cpu-insufficient-for-its1.md
-      - UI (User Interface): ui-docs/ui-overview.md
+      - UI (Deprecated → Console): ui-docs/ui-overview.md
       - Teardown: kubestellar/teardown.md
   - Contributing:
       - Overview (How to join in): kubestellar/contribute.md

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -305,7 +305,7 @@ const NAV_STRUCTURE_KUBESTELLAR: Array<{ title: string; items: NavItem[] }> = [
         ]
       },
       {
-        'UI (User Interface)': [
+        'UI (Deprecated → Console)': [
           { 'Overview': 'ui-docs/ui-overview.md' },
           { 'WECS Remote Monitoring': 'ui-docs/wecs-remote-monitoring.md' },
           { 'ITS cluster management': 'ui-docs/its-cluster-management.md' }


### PR DESCRIPTION
Closes #1435
Closes #1436
Closes #1438

## Changes

- **#1435 — UI sidebar deprecation**: Renamed sidebar entry from "UI (User Interface)" to "UI (Deprecated → Console)" in both `mkdocs.yml` and `page-map.ts` so users see the deprecation before clicking
- **#1436 — Typo fix**: Fixed "Multi-Custer" → "Multi-Cluster" in Scenario 3 heading of `example-scenarios.md`
- **#1438 — Claude Code prerequisite callout**: Added a prominent `!!! important` callout box at the top of `console/quickstart.md` explaining what requires Claude Code vs. what works without it

## Files Changed

- `docs/mkdocs.yml` — sidebar label
- `src/app/docs/page-map.ts` — sidebar label
- `docs/content/kubestellar/example-scenarios.md` — typo fix
- `docs/content/console/quickstart.md` — prerequisites callout