### PR TITLE
docs: fix 13 issues — typos, stubs, nav, broken links, rendering (#1416-#1444)

### DIFF
--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -25,14 +25,14 @@ Most users will wish to explore the demo and documentation for KubeStellar Conso
 - [KubeStellar-MCP Documentation](/docs/kubestellar-mcp/overview/introduction): More details about the Claude Code-enabled plugin for app-centric deployment management
 - [KubeStellar Console Demo](https://console.kubestellar.io): Live online demo of the KubeStellar Console UI/UX
 
-### Legacy KubeStellar Components
+### Core KubeStellar Components
 
-Deeper Documentation on the components which preceded the new standalone KubeStellar Console
+In-depth documentation for the foundational components that power KubeStellar's multi-cluster capabilities.
 
-- [KubeStellar](/docs/kubestellar/overview): the foundation that began the KubeStellar project
-- [KubeFlex](/docs/kubeflex/overview/introduction): A flexible and scalable platform for running Kubernetes control plane APIs with multi-tenancy support.
-- [KubeStellar A2A](/docs/a2a/overview/introduction): The first iteration of the KubeStellar agentic management tools embodied in KubeStellar Console
-- [kubectl-multi](/docs/multi-plugin/overview/introduction): A comprehensive kubectl plugin for multi-cluster operations with KubeStellar. The predecessor to the KubeStellar-MCP plugin which KubeStellar Console uses.
+- [KubeStellar](/docs/kubestellar/overview): The multi-cluster configuration management engine at the heart of the project
+- [KubeFlex](/docs/kubeflex/overview/introduction): A flexible and scalable platform for running Kubernetes control plane APIs with multi-tenancy support
+- [KubeStellar A2A](/docs/a2a/overview/introduction): Agent-to-agent orchestration for agentic multi-cluster management
+- [kubectl-multi](/docs/multi-plugin/overview/introduction): A kubectl plugin for multi-cluster operations with KubeStellar
 
 ### Community and Support Information
 

--- a/docs/content/kubestellar/acquire-hosting-cluster.md
+++ b/docs/content/kubestellar/acquire-hosting-cluster.md
@@ -16,9 +16,7 @@ The clients in KubeStellar comprise the following.
 - The OCM Agent and the OCM Status Add-On Agent in each WEC.
 - The KubeStellar controller-manager and the transport controller for each WDS, running in the KubeFlex hosting cluster.
 
-When everything runs on one machine, the defaults just work. When core and some WECs are on different machines, it gets more challenging. When the KubeFlex hosting cluster is an OpenShift cluster with a public domain name, the defaults just work.
-
-After the Getting Started setup, I looked at an OCM Agent (klusterlet-agent, to be specific) and did not find a clear passing of kubeconfig. I found adjacent Secrets holding kubeconfigs in which `cluster[0].cluster.server` was `https://kubeflex-control-plane:31048`. Note that `kubeflex-control-plane` is the name of the Docker container running `kind` cluster serving as KubeFlex hosting cluster. I could not find an explanation for the port number 31048; that Docker container maps port 443 inside to 9443 on the outside.
+When all components run on a single machine (e.g., a local `kind` cluster), the default networking configuration works without modification. When the KubeFlex hosting cluster and some WECs are on different machines, you need to ensure that WEC agents can reach the Ingress controller's HTTPS endpoint. When the KubeFlex hosting cluster is an OpenShift cluster with a public domain name, the defaults work.
 
 `kflex init` takes a command line flag `--domain string` described as `domain for FQDN (default "localtest.me")`.
 

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -42,17 +42,9 @@ Organizations adopt multi-cluster architectures for:
 
 ## Quick Start
 
-Get up and running with KubeStellar in minutes:
+Get up and running with KubeStellar by following the [Getting Started Guide](kubestellar/get-started.md), which walks you through the Helm-based installation and environment setup.
 
-```bash
-# Install KubeStellar CLI
-brew install kubestellar/kubestellar/kubestellar
-
-# Initialize your environment
-kubestellar init
-```
-
-For a complete walkthrough, see the [Quick Start Guide](kubestellar/get-started.md).
+For the KubeStellar Console UI experience, see the [Console Quick Start](console/quickstart.md).
 
 ## Documentation
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -138,16 +138,14 @@ nav:
   - KubeStellar MCP:
       - Overview: kubestellar-mcp/index.md
       - Getting Started: kubestellar-mcp/overview/intro.md
-  - News:
-      - Latest News: news/index.md
-      - "KubeStellar Console Announcement": news/kubestellar-console-announcement.md
+  # News is already listed under Community above; removed duplicate top-level entry
   # - 'Blog': https://medium.com/@kubestellar/list/predefined:e785a0675051:READING_LIST" target="_blank
   # # - Auto generated:
   #   - ... | auto-generated/*/*.md
 
 theme:
   font:
-    text: 'SapceMono'
+    text: 'Space Mono'
     code: 'Roboto Mono'
   name: material
   icon:

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -239,6 +239,12 @@ const NAV_STRUCTURE_KUBESTELLAR: Array<{ title: string; items: NavItem[] }> = [
     title: 'Getting Started',
     items: [
       { 'Quick Start': 'kubestellar/get-started.md' },
+      { 'Console Quick Start': 'console/quickstart.md' },
+    ]
+  },
+  {
+    title: 'User Guide',
+    items: [
       { 'Guide Overview': 'kubestellar/user-guide-intro.md' },
       { 'Observability': 'kubestellar/observability.md' },
       { 'Getting Started from OCM': 'kubestellar/start-from-ocm.md' },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -207,7 +207,7 @@ export default function Footer() {
                 </li>
                 <li>
                   <Link
-                    href="/ladder"
+                    href={getLocalizedUrl("https://kubestellar.io/docs/contributing/contributor-ladder")}
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >
                     {t("ladder")}
@@ -215,15 +215,7 @@ export default function Footer() {
                 </li>
                 <li>
                   <Link
-                    href="/products"
-                    className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
-                  >
-                    {t("products")}
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/contribute-handbook"
+                    href={getLocalizedUrl("https://kubestellar.io/docs/contributing/overview")}
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >
                     {t("contributeHandbook")}
@@ -249,16 +241,18 @@ export default function Footer() {
                   </a>
                 </li>
                 <li>
-                  <Link
-                    href="/programs"
+                  <a
+                    href="https://github.com/kubestellar"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >
-                    {t("programs")}
-                  </Link>
+                    GitHub
+                  </a>
                 </li>
                 <li>
                   <Link
-                    href="/partners"
+                    href={getLocalizedUrl("https://kubestellar.io/docs/community/get-involved")}
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >
                     {t("partners")}

--- a/src/components/docs/DocsFooter.tsx
+++ b/src/components/docs/DocsFooter.tsx
@@ -301,38 +301,26 @@ export default function Footer() {
                 </li>
                 <li>
                   <Link
-                    href="/ladder"
+                    href="/docs/contributing/contributor-ladder"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
-                    Ladder
+                    Contributor Ladder
                   </Link>
                 </li>
                 <li>
                   <Link
-                    href="/products"
+                    href="/docs/contributing/overview"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
-                    Products
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/contribute-handbook"
-                    className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
-                      isDark
-                        ? 'text-gray-400 hover:text-white'
-                        : 'text-gray-600 hover:text-gray-900'
-                    }`}
-                  >
-                    Contributor Handbook
+                    How to Contribute
                   </Link>
                 </li>
               </ul>
@@ -361,27 +349,29 @@ export default function Footer() {
                   </a>
                 </li>
                 <li>
-                  <Link
-                    href="/programs"
+                  <a
+                    href="https://github.com/kubestellar"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
-                    Programs
-                  </Link>
+                    GitHub
+                  </a>
                 </li>
                 <li>
                   <Link
-                    href="/partners"
+                    href="/docs/community/get-involved"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
-                    Partners
+                    Community
                   </Link>
                 </li>
                 <li>
@@ -480,34 +470,34 @@ export default function Footer() {
             {/* Right side - policy links */}
             <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 md:gap-6 lg:gap-8 order-1 md:order-2">
               <Link
-                href="/docs/contributing/license-inc"
+                href="/docs/contributing/license"
                 className={`text-xs sm:text-sm transition-colors duration-300 whitespace-nowrap ${
                   isDark
                     ? 'text-gray-400 hover:text-white'
                     : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
-                Privacy Policy
+                Apache 2.0 License
               </Link>
               <Link
-                href="/docs/contributing/security/security-inc"
+                href="/docs/contributing/security/policy"
                 className={`text-xs sm:text-sm transition-colors duration-300 whitespace-nowrap ${
                   isDark
                     ? 'text-gray-400 hover:text-white'
                     : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
-                Terms of Service
+                Security Policy
               </Link>
               <Link
-                href="/docs/contributing/security/security_contacts-inc"
+                href="/docs/contributing/security/contacts"
                 className={`text-xs sm:text-sm transition-colors duration-300 whitespace-nowrap ${
                   isDark
                     ? 'text-gray-400 hover:text-white'
                     : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
-                Cookie Policy
+                Security Contacts
               </Link>
             </div>
           </div>

--- a/src/components/docs/DocsProvider.tsx
+++ b/src/components/docs/DocsProvider.tsx
@@ -24,13 +24,23 @@ const DocsContext = createContext<DocsContextType | undefined>(undefined)
 export function DocsProvider({ children }: { children: ReactNode }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
-  const [bannerDismissed, setBannerDismissed] = useState(false)
+  const [bannerDismissed, setBannerDismissed] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('docs-banner-dismissed') === 'true'
+    }
+    return false
+  })
   const [navCollapsed, setNavCollapsed] = useState<Set<string>>(new Set())
   const navInitialized = useRef(false)
 
   const toggleMenu = () => setMenuOpen((prev) => !prev)
   const toggleSidebar = () => setSidebarCollapsed((prev) => !prev)
-  const dismissBanner = () => setBannerDismissed(true)
+  const dismissBanner = () => {
+    setBannerDismissed(true)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('docs-banner-dismissed', 'true')
+    }
+  }
   const toggleNavCollapsed = (key: string) => {
     setNavCollapsed(prev => {
       const next = new Set(prev)


### PR DESCRIPTION
Closes #1416
Closes #1417
Closes #1422
Closes #1428
Closes #1429
Closes #1434
Closes #1443
Closes #1444

## Summary

Batch fix for 13 documentation issues. 8 fixed directly, 4 already covered by open PR #1421, 1 investigated and found to be a non-issue in source.

### Fixed in this PR

- **#1429**: Font typo `SapceMono` -> `Space Mono` in mkdocs.yml
- **#1434**: Removed duplicate News section from mkdocs.yml navigation
- **#1416**: Replaced fabricated `brew install kubestellar` Quick Start with links to the real Getting Started guide
- **#1428**: Removed developer debug notes from acquire-hosting-cluster.md, replaced with proper connectivity docs
- **#1444**: Renamed "Legacy KubeStellar Components" to "Core KubeStellar Components" in intro.md
- **#1422**: Fixed 5+ broken footer links (404 destinations) in both Footer.tsx and DocsFooter.tsx; renamed misleading legal links to accurate labels
- **#1443**: Survey banner dismissal now persists in localStorage across page navigations
- **#1417**: Added top-level "Getting Started" section in KubeStellar sidebar so Quick Start is reachable in 1 click

### Already covered by PR #1421

- **#1426** (binding.md TODO): PR #1421 adds real Binding content
- **#1427** (control.md stub): PR #1421 replaces TODO with API reference link
- **#1441** (scenario 5 broken): PR #1421 replaces TODO with scenario description

### Investigated — no source-level fix needed

- **#1439** (architecture SVGs): Images exist on disk, API route serves them correctly, path resolution logic is correct. No source-level issue found.
- **#1442** (copyright year "026"): Both `Footer.tsx` and `DocsFooter.tsx` use `new Date().getFullYear()` which correctly returns `2026`. No truncation in source code.

## Files changed (8)

- `docs/mkdocs.yml` — font typo fix, duplicate nav removal
- `docs/content/readme.md` — replaced fake Quick Start commands
- `docs/content/intro.md` — renamed Legacy to Core components
- `docs/content/kubestellar/acquire-hosting-cluster.md` — removed debug notes
- `src/components/Footer.tsx` — fixed broken footer links
- `src/components/docs/DocsFooter.tsx` — fixed broken footer and legal links
- `src/components/docs/DocsProvider.tsx` — localStorage persistence for banner
- `src/app/docs/page-map.ts` — added top-level Getting Started nav section