### PR TITLE
docs: OCM version, Helm output, WDS wording, BindingPolicy typo, marketplace link (#1445-#1450)

### DIFF
--- a/docs/content/kubestellar/get-started.md
+++ b/docs/content/kubestellar/get-started.md
@@ -143,7 +143,30 @@ helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart 
     --set verbosity.default=5  # so we can debug your problem reports
 ```
 
-That command will print some notes about how to get kubeconfig "contexts" named "its1", "wds1", and "wds2" defined. Do that, because those contexts are used in the steps that follow.
+That command will print output similar to the following, indicating a successful installation:
+
+```console
+Release "ks-core" does not exist. Installing it now.
+NAME: ks-core
+LAST DEPLOYED: <timestamp>
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+For your convenience you will probably want to add contexts to your
+kubeconfig named after the non-host-type control planes (WDSes and
+ITSes) that you just created ...
+
+kubectl config use-context $the_one_where_you_installed_this_chart
+kflex ctx --set-current-for-hosting
+
+kflex ctx --overwrite-existing-context its1
+kflex ctx --overwrite-existing-context wds1
+kflex ctx --overwrite-existing-context wds2
+```
+
+Follow the instructions in the NOTES to create kubeconfig contexts named "its1", "wds1", and "wds2". These contexts are used in the steps that follow.
 
 ```shell
 kubectl config use-context kind-kubeflex # this is here only to remind you, it will already be the current context if you are following this recipe exactly

--- a/docs/content/kubestellar/pre-reqs.md
+++ b/docs/content/kubestellar/pre-reqs.md
@@ -25,8 +25,10 @@ Our documentation has remarks about using the following sorts of clusters:
     To install kubeflex go to [https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation). To upgrade from an existing installation,
 follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#upgrading-kubeflex). At the end of the install make sure that the kubeflex CLI, kflex, is in your `$PATH`.
 
-- **OCM CLI (clusteradm)** 0.10 <= version **< 0.11**.
-    To install the latest acceptable version of the OCM CLI use:
+- **OCM CLI (clusteradm)** version 0.10.x (i.e., 0.10 <= version **< 0.11**).
+    **Note:** KubeStellar specifically requires clusteradm **v0.10.x**. Versions 0.11 and later introduced an incompatible change in a ServiceAccount name that breaks KubeStellar's OCM integration. Although OCM has released newer versions (v0.11+, v1.x), you **must** use v0.10.1 with the current KubeStellar release.
+
+    To install the required version of the OCM CLI use:
 
     ```shell
     bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1

--- a/docs/content/kubestellar/troubleshooting.md
+++ b/docs/content/kubestellar/troubleshooting.md
@@ -61,7 +61,7 @@ Show the particulars of something going wrong.
 - Show a run of `scripts/check_pre_req.sh`.
 - Report timestamps of when salient changes happened. Make it clear which timezone is involved in each one. Particularly interesting times are when KubeStellar did the wrong thing or failed to do anything at all in response to something.
 - Show the relevant API objects. When the problem is behavior over time, show the objects contents from before and after the misbehavior.
-    - In the WDS: the workload objects involved; any `BidingPolicy` involved, and the corresponding `Binding` for each; any `CustomTransform`, `StatusCollector`, or `CombinedStatus` involved.
+    - In the WDS: the workload objects involved; any `BindingPolicy` involved, and the corresponding `Binding` for each; any `CustomTransform`, `StatusCollector`, or `CombinedStatus` involved.
     - Any involved objects in the WEC(s).
     - Implementation objects in the ITS: `ManifestWork`, `WorkStatus`.
     - Here is one way to show the evolution of a relevant set of objects over time. The following command displays the `ManifestWork` objects, after creation and after each update (modulo the gaps allowed by eventual consistency), in an ITS as addressed by the kubeconfig context named `its1` --- after first listing the existing objects. Each line is prefixed with the hour:minute:second at which it appears.

--- a/docs/content/kubestellar/wds.md
+++ b/docs/content/kubestellar/wds.md
@@ -21,9 +21,9 @@ A Workload Description Space (WDS) is a space in the [KubeStellar architecture](
 
 ## Creating a WDS
 
-Currently the only documented way to create a WDS is by using the [core Helm chart](core-chart.md). See [the step-by-step instructions for getting started](get-started.md#use-core-helm-chart-to-initialize-kubeflex-and-create-its-and-wds) for an example.
+The recommended way to create a WDS is by using the [core Helm chart](core-chart.md). See [the step-by-step instructions for getting started](get-started.md#use-core-helm-chart-to-initialize-kubeflex-and-create-its-and-wds) for an example.
 
-The adventurous user could --- after using the core Helm chart to get this `PostCreateHook` object created --- create a WDS directly using the KubeFlex CLI or API to create a suitable `ControlPlane` object that uses the same `PostCreateHook` as the core Helm chart does for creating WDSes.
+Alternatively, after using the core Helm chart to get the `PostCreateHook` object created, you can create a WDS directly using the KubeFlex CLI or API. This involves creating a suitable `ControlPlane` object that uses the same `PostCreateHook` as the core Helm chart does for creating WDSes. This approach gives advanced users more fine-grained control over the WDS configuration.
 
 ### Creating a kubeconfig context for accessing the WDS
 

--- a/src/components/docs/DocsFooter.tsx
+++ b/src/components/docs/DocsFooter.tsx
@@ -254,7 +254,7 @@ export default function Footer() {
                 </li>
                 <li>
                   <Link
-                    href="/docs/console/marketplace"
+                    href="/marketplace"
                     className={`text-xs sm:text-sm transition-colors duration-200 inline-block ${
                       isDark
                         ? 'text-gray-400 hover:text-white'


### PR DESCRIPTION
Closes #1445
Closes #1446
Closes #1447
Closes #1448
Closes #1450

## Summary

- **#1445** (OCM version): Clarified that the v0.10.x constraint is intentional — v0.11+ introduced an incompatible ServiceAccount name change. Added explanation so users understand why newer OCM versions cannot be used.
- **#1446** (Helm output): Added expected `helm upgrade --install` output inline in the Getting Started guide so users can verify success without cross-referencing core-chart.md.
- **#1447** (WDS wording): Changed "only documented way" to "recommended way" and reframed the KubeFlex CLI alternative as a supported approach for advanced users.
- **#1448** (typo): Fixed `BidingPolicy` → `BindingPolicy` in troubleshooting.md. Searched entire repo — only one instance found.
- **#1450** (marketplace link): Changed DocsFooter marketplace link from `/docs/console/marketplace` to `/marketplace` to match header/DocsNavbar links.

## Files changed (5)

- `docs/content/kubestellar/pre-reqs.md` — OCM version constraint clarification
- `docs/content/kubestellar/get-started.md` — added Helm expected output
- `docs/content/kubestellar/wds.md` — softened WDS creation wording
- `docs/content/kubestellar/troubleshooting.md` — BindingPolicy typo fix
- `src/components/docs/DocsFooter.tsx` — marketplace link consistency