### PR TITLE
fix(docs): correct typos in documentation

### DIFF
--- a/docs/content/kubestellar/example-scenarios.md
+++ b/docs/content/kubestellar/example-scenarios.md
@@ -244,7 +244,7 @@ clusters=("$wds_context" "$wec1_context" "$wec2_context");
 done
 ```
 
-## Scenario 3: Multi-Custer Workload Deployment with Helm
+## Scenario 3: Multi-Cluster Workload Deployment with Helm
 
 Create a BindingPolicy for the helm chart app:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -146,7 +146,7 @@ nav:
 
 theme:
   font:
-    text: 'SapceMono'
+    text: 'Space Mono'
     code: 'Roboto Mono'
   name: material
   icon:


### PR DESCRIPTION
## Summary

This PR fixes two typos in the documentation:

1. **Issue #1436**: Fixed 'Multi-Custer' → 'Multi-Cluster' in the Scenario 3 heading of `docs/content/kubestellar/example-scenarios.md` (line 247)
   - This typo affects the section heading anchor which could impact linking

2. **Issue #1429**: Fixed 'SapceMono' → 'Space Mono' in `docs/mkdocs.yml` (line 149)  
   - This caused MkDocs-rendered documentation to fall back to a default system font instead of the intended Space Mono font

## Changes Made
- `docs/content/kubestellar/example-scenarios.md`: Corrected section heading typo
- `docs/mkdocs.yml`: Corrected font name configuration

## Testing
- Verified the changes are purely textual corrections
- No functional changes to the documentation

Fixes #1436
Fixes #1429