### PR TITLE
🐛 fix: point top-nav KubeStellar entry to working architecture page (#1453)

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -226,7 +226,7 @@
     },
     {
       "title": "KubeStellar",
-      "href": "/docs/what-is-kubestellar/overview",
+      "href": "/docs/kubestellar/architecture",
       "description": "Multi-cluster configuration management",
       "secondary": true
     },


### PR DESCRIPTION
## Summary

The top-nav \"KubeStellar\" entry in \`public/config/shared.json\` pointed to \`/docs/what-is-kubestellar/overview\`, which 404s. The catch-all \`/docs/[...slug]\` route in \`src/app/docs/[...slug]/page.tsx\` only registers these project IDs via \`getProjectFromSlug\`: \`a2a\`, \`kubeflex\`, \`multi-plugin\`, \`kubestellar-mcp\`, \`console\`, and default fallback \`kubestellar\`. There is no \`what-is-kubestellar\` project and no \`what-is-kubestellar/overview.md\` file under \`docs/content/\`, so the link never resolved. Link-checker flagged hash \`7bd42cdc\` on \`/docs/multi-plugin\`.

## Fix

Repointed to \`/docs/kubestellar/architecture\`, which resolves to the existing \`docs/content/kubestellar/architecture.md\`. The architecture page opens with \"KubeStellar provides multi-cluster deployment of Kubernetes objects\" — matches shared.json description \"Multi-cluster configuration management\".

## Related (out of scope)

Other files still reference the broken \`what-is-kubestellar/*\` URL pattern (Footer.tsx, DocsSidebar.tsx, GetStartedSection.tsx, products/page.tsx). Left for a follow-up so this PR stays tight on the specific hash reported.

Fixes #1453

## Test plan

- [x] shared.json valid JSON
- [ ] Preview deploy renders the top-nav and clicking \"KubeStellar\" loads \`/docs/kubestellar/architecture\`