### PR TITLE
fix: replace window.closeLangSwitcher global with CustomEvent (#1456)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,6 +15,7 @@ export default function Navbar() {
   const [isCommunityOpen, setIsCommunityOpen] = useState(false);
   const [isGithubOpen, setIsGithubOpen] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const langSwitcherCloseHandlerRef = useRef<((e: Event) => void) | null>(null);
   // Fallback values shown until shields.io responds.
   const [githubStats, setGithubStats] = useState({
     stars: "30",
@@ -60,11 +61,7 @@ export default function Navbar() {
             });
 
             // Close language switcher when hovering other dropdowns
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            if (typeof (window as any).closeLangSwitcher === "function") {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (window as any).closeLangSwitcher();
-            }
+            window.dispatchEvent(new CustomEvent("close-lang-switcher"));
 
             // Ensure menu is visible
             menu.style.display = "block";
@@ -133,11 +130,7 @@ export default function Navbar() {
           });
 
           // Also close language switcher
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if (typeof (window as any).closeLangSwitcher === "function") {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (window as any).closeLangSwitcher();
-          }
+          window.dispatchEvent(new CustomEvent("close-lang-switcher"));
 
           setIsDropdownOpen(false);
         }
@@ -308,9 +301,10 @@ export default function Navbar() {
           }
         };
 
-        // Add method to global scope for other dropdowns to call
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).closeLangSwitcher = closeLangSwitcher;
+        // Listen for close-lang-switcher events from other dropdowns
+        const handleCloseLangSwitcher = () => closeLangSwitcher();
+        langSwitcherCloseHandlerRef.current = handleCloseLangSwitcher;
+        window.addEventListener("close-lang-switcher", handleCloseLangSwitcher);
 
         langSwitcher.addEventListener("mouseenter", handleMouseEnter);
         langSwitcher.addEventListener("mouseleave", handleMouseLeave);
@@ -370,7 +364,15 @@ export default function Navbar() {
     };
 
     // Small delay to ensure LanguageSwitcher is mounted
-    setTimeout(initLanguageSwitcher, 100);
+    const langTimer = setTimeout(initLanguageSwitcher, 100);
+
+    return () => {
+      clearTimeout(langTimer);
+      if (langSwitcherCloseHandlerRef.current) {
+        window.removeEventListener("close-lang-switcher", langSwitcherCloseHandlerRef.current);
+        langSwitcherCloseHandlerRef.current = null;
+      }
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Fixes #1456

## Problem

The  component uses  to coordinate closing the language switcher when other dropdowns are hovered or Escape is pressed. This:
- Pollutes the global namespace
- Is fragile (name collisions with other scripts)
- Has no cleanup when the component unmounts
- Requires `eslint-disable` comments for `@typescript-eslint/no-explicit-any`

## Solution

Replaced the global function with a **CustomEvent** pattern:

### Dispatchers (2 locations)
- **Dropdown hover** (line 64): `window.dispatchEvent(new CustomEvent('close-lang-switcher'))`
- **Escape key** (line 137): same dispatch

### Listener (LanguageSwitcher section)
- `window.addEventListener('close-lang-switcher', handleCloseLangSwitcher)`
- Handler stored in a ref for proper cleanup

### Cleanup
- `useEffect` return function removes the event listener on unmount
- Also cleans up the setTimeout timer

## Changes
- 1 file changed: `src/components/Navbar.tsx`
- 16 insertions(+), 14 deletions(-)
- Removed all `eslint-disable` comments related to `window.closeLangSwitcher`
- Zero functional changes — behavior is identical

## Testing
- Verify hovering Contribute/Community/GitHub dropdowns closes the language switcher
- Verify pressing Escape closes the language switcher
- Verify navigating away and back doesn't leak event listeners