### PR TITLE
🐛 Make aria-expanded state dynamic on Navbar dropdown buttons (#1458)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -511,7 +511,7 @@ export default function Navbar() {
                     className="text-sm font-medium text-gray-300 hover:text-emerald-400 transition-all duration-300 flex items-center space-x-1 px-3 py-2 rounded-lg hover:bg-emerald-500/10 hover:shadow-lg hover:shadow-emerald-500/20 hover:scale-100 transform nav-link-hover cursor-pointer"
                     data-dropdown-button
                     aria-haspopup="true"
-                    aria-expanded="false"
+                    aria-expanded={isContributeOpen}
                   >
                     <div className="relative">
                       <svg
@@ -681,7 +681,7 @@ export default function Navbar() {
                     className="text-sm font-medium text-gray-300 hover:text-cyan-400 transition-all duration-300 flex items-center space-x-1 px-3 py-2 rounded-lg hover:bg-cyan-500/10 hover:shadow-lg hover:shadow-cyan-500/20 hover:scale-100 transform nav-link-hover cursor-pointer"
                     data-dropdown-button
                     aria-haspopup="true"
-                    aria-expanded="false"
+                    aria-expanded={isCommunityOpen}
                   >
                     <div className="relative">
                       <svg

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -140,6 +140,9 @@ export default function Navbar() {
           }
 
           setIsDropdownOpen(false);
+          setIsContributeOpen(false);
+          setIsCommunityOpen(false);
+          setIsGithubOpen(false);
         }
       });
     };


### PR DESCRIPTION
### 📌 Fixes

Fixes #1455 

---

### 📝 Summary of Changes

- Made the `aria-expanded` attribute dynamic on the **Contribute** and **Community** dropdown navigation buttons so it properly synchronizes with standard WCAG 2.1 accessibility guidelines, replacing the hardcoded `"false"` string. 

---

### Changes Made

- [x] Updated the `aria-expanded` value on Navbar dropdown triggers (`src/components/Navbar.tsx`)
- [ ] Refactored 
- [x] Fixed accessibility violations (SC 4.1.2) where screen readers failed to recognize an open dropdown menu
- [ ] Added tests for 

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---

