### PR TITLE
🐛 Replace deprecated window.pageYOffset with window.scrollY

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
       if (!backToTopButton) return;
 
       const toggleButton = () => {
-        if (window.pageYOffset > 300) {
+        if (window.scrollY > 300) {
           backToTopButton.style.opacity = "1";
           backToTopButton.style.transform = "translateY(-30px)";
         } else {

--- a/src/components/docs/DocsFooter.tsx
+++ b/src/components/docs/DocsFooter.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
     if (!backToTopButton) return;
 
     const toggleButton = () => {
-      if (window.pageYOffset > 300) {
+      if (window.scrollY > 300) {
         backToTopButton.style.opacity = "1";
         backToTopButton.style.transform = "translateY(-30px)";
       } else {


### PR DESCRIPTION
### 📌 Fixes

Fixes #1459 

---

### 📝 Summary of Changes

- Replaced deprecated `window.pageYOffset` with the modern standard `window.scrollY` in both `Footer.tsx` and `DocsFooter.tsx` components.
- Resolves MDN and Chromium deprecation warnings while ensuring future-proof scroll position checking for the "Back to Top" button visibility toggles.

---

### Changes Made

- [x] Updated `src/components/Footer.tsx` logic to use modern scroll property
- [x] Updated `src/components/docs/DocsFooter.tsx` logic to use modern scroll property
- [x] Fixed deprecated code usage warning (`pageYOffset`)
- [ ] Added tests for 

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---