### PR TITLE
🐛 Remove non-functional placeholder policy links from footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -329,33 +329,11 @@ export default function Footer() {
 
         {/* Divider and bottom section */}
         <div className="border-t border-gray-800 pt-4 sm:pt-6 md:pt-8">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-3 sm:gap-4">
-            {/* Left side - copyright */}
-            <p className="text-gray-400 text-xs sm:text-sm text-center md:text-left order-2 md:order-1">
+          <div className="flex flex-col md:flex-row justify-center items-center gap-3 sm:gap-4">
+            {/* Copyright */}
+            <p className="text-gray-400 text-xs sm:text-sm text-center">
               {t("copyright", { year: new Date().getFullYear() })}
             </p>
-
-            {/* Right side - policy links */}
-            <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 md:gap-6 lg:gap-8 order-1 md:order-2">
-              <a
-                href="#"
-                className="text-gray-400 hover:text-white transition-colors duration-300 text-xs sm:text-sm whitespace-nowrap"
-              >
-                {t("privacyPolicy")}
-              </a>
-              <a
-                href="#"
-                className="text-gray-400 hover:text-white transition-colors duration-300 text-xs sm:text-sm whitespace-nowrap"
-              >
-                {t("termsOfService")}
-              </a>
-              <a
-                href="#"
-                className="text-gray-400 hover:text-white transition-colors duration-300 text-xs sm:text-sm whitespace-nowrap"
-              >
-                {t("cookiePolicy")}
-              </a>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### 📌 Fixes

Fixes #1461 

---

### 📝 Summary of Changes

- Removed non-functional placeholder links (`#`) for Privacy Policy, Terms of Service, and Cookie Policy from the main footer.
- Recentered the copyright attribution text to account for the removed layout items.

---

### Changes Made

- [x] Updated `src/components/Footer.tsx` to remove the dead links
- [ ] Refactored 
- [x] Fixed broken anchor links redirecting users to the top of the page
- [ ] Added tests for 

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---

### Screenshots or Logs (if applicable)

*N/A - Minor visual cleanup of footer elements.*

---

### 👀 Reviewer Notes

_The main footer contained links to 'Privacy Policy', 'Terms of Service', and 'Cookie Policy' which were all set to `href="#"`. Since no actual policy pages exist yet for this open source project, clicking these only confused users by jumping them to the top of the page. They have been removed entirely, and the layout styling was adjusted to properly center the remaining copyright text._
