### PR TITLE
🐛 fix: broken link in multi-plugin page (#1463)

### DIFF
--- a/docs/content/legacy-components.md
+++ b/docs/content/legacy-components.md
@@ -6,7 +6,7 @@ The KubeStellar project includes several legacy components that form the foundat
 
 | Component | Description |
 |-----------|-------------|
-| [**KubeStellar**](/docs/what-is-kubestellar/overview) | The core multi-cluster configuration management engine using OCM transport |
+| [**KubeStellar**](/docs/overview/introduction) | The core multi-cluster configuration management engine using OCM transport |
 | [**A2A**](/docs/a2a/overview/introduction) | Agent-to-Agent protocol support for KubeStellar |
 | [**KubeFlex**](/docs/kubeflex/overview/introduction) | Lightweight Kube API Server instances and control planes as a service |
 | [**Multi-Plugin**](/docs/multi-plugin/overview/introduction) | kubectl plugin for managing multiple KubeStellar control planes |

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -36,7 +36,7 @@ const PRIMARY_PROJECTS = [
 ] as const;
 
 const LEGACY_PROJECTS = [
-  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/what-is-kubestellar/overview' },
+  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/overview/introduction' },
   { id: 'a2a', label: 'A2A', href: '/docs/a2a/overview/introduction' },
   { id: 'kubeflex', label: 'KubeFlex', href: '/docs/kubeflex/overview/introduction' },
   { id: 'multi-plugin', label: 'Multi Plugin', href: '/docs/multi-plugin/overview/introduction' },


### PR DESCRIPTION
Fixes #1463

## Summary
The `/docs/multi-plugin` page (and every other multi-plugin doc page) contained a sidebar/table link to `/docs/what-is-kubestellar/overview` that returned 404. The broken URL was defined in two places:

- `docs/content/legacy-components.md` — table row for the KubeStellar legacy component
- `src/components/docs/DocsSidebar.tsx` — `LEGACY_PROJECTS` landing href for `id: 'kubestellar'` (rendered on every legacy-project doc page's sidebar, which is why the broken link surfaced on `/docs/multi-plugin`)

Updated both references from `/docs/what-is-kubestellar/overview` → `/docs/overview/introduction`.

## How the target URL was determined
The KubeStellar project uses the default base path `/docs` (not `/docs/kubestellar/`) — see `getBasePath()` in `src/app/docs/page-map.ts`. Its navigation structure (`NAV_STRUCTURE_KUBESTELLAR`) defines:

```ts
{
  title: 'Overview',
  items: [
    { 'Introduction': 'readme.md' },
    ...
  ]
}
```

Per the route-building logic in `buildPageMap()`, this generates the route `/docs/overview/introduction`, matching the convention used by the other legacy projects (`/docs/a2a/overview/introduction`, `/docs/kubeflex/overview/introduction`, `/docs/multi-plugin/overview/introduction`).

## Test plan
- [x] `grep -rn "what-is-kubestellar/overview"` returns only a historical entry in `public/data/contributors/clubanderson.json` (the issue title itself, not a live link) — no remaining live references
- [x] New URL `/docs/overview/introduction` is the route generated by `NAV_STRUCTURE_KUBESTELLAR` Overview > Introduction → `readme.md`
- [x] Matches the legacy-project convention already used for A2A, KubeFlex, and Multi-Plugin

## Out of scope
Other `what-is-kubestellar/*` references exist in `Footer.tsx` (`/release-notes`), `GetStartedSection.tsx` (`/architecture`), and `products/page.tsx` (`/related/kubeflex`). Those are separate URLs not flagged in #1463 and are left for follow-up if the link checker reports them.