### PR TITLE
Fix broken /docs/what-is-kubestellar/overview link

### DIFF
--- a/docs/content/legacy-components.md
+++ b/docs/content/legacy-components.md
@@ -6,7 +6,7 @@ The KubeStellar project includes several legacy components that form the foundat
 
 | Component | Description |
 |-----------|-------------|
-| [**KubeStellar**](/docs/what-is-kubestellar/overview) | The core multi-cluster configuration management engine using OCM transport |
+| [**KubeStellar**](/docs/kubestellar/architecture) | The core multi-cluster configuration management engine using OCM transport |
 | [**A2A**](/docs/a2a/overview/introduction) | Agent-to-Agent protocol support for KubeStellar |
 | [**KubeFlex**](/docs/kubeflex/overview/introduction) | Lightweight Kube API Server instances and control planes as a service |
 | [**Multi-Plugin**](/docs/multi-plugin/overview/introduction) | kubectl plugin for managing multiple KubeStellar control planes |

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -36,7 +36,7 @@ const PRIMARY_PROJECTS = [
 ] as const;
 
 const LEGACY_PROJECTS = [
-  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/what-is-kubestellar/overview' },
+  { id: 'kubestellar', label: 'KubeStellar', href: '/docs/kubestellar/architecture' },
   { id: 'a2a', label: 'A2A', href: '/docs/a2a/overview/introduction' },
   { id: 'kubeflex', label: 'KubeFlex', href: '/docs/kubeflex/overview/introduction' },
   { id: 'multi-plugin', label: 'Multi Plugin', href: '/docs/multi-plugin/overview/introduction' },


### PR DESCRIPTION
### 📌 Fixes

Fixes #1463

---

### 📝 Summary of Changes

- The `legacy-components.md` table and the `DocsSidebar` `LEGACY_PROJECTS` array both pointed at `/docs/what-is-kubestellar/overview`, which returns 404 on kubestellar.io.
- Repoint both to `/docs/kubestellar/architecture`, the canonical description of the core KubeStellar multi-cluster engine. That URL matches the surrounding text in `legacy-components.md` ("The core multi-cluster configuration management engine using OCM transport").

---

### Changes Made

- [x] Fixed broken link in `docs/content/legacy-components.md` — KubeStellar row of the Components table.
- [x] Fixed broken link in `src/components/docs/DocsSidebar.tsx` — `LEGACY_PROJECTS` array, `id: 'kubestellar'` entry.

Verified with:

```
$ curl -sL -o /dev/null -w "%{http_code}\n" https://kubestellar.io/docs/kubestellar/architecture
200
$ curl -sL -o /dev/null -w "%{http_code}\n" https://kubestellar.io/docs/what-is-kubestellar/overview
404
```

---

### Note on other `/docs/what-is-kubestellar/*` references

Grep also shows three other references to the legacy `what-is-kubestellar/*` path that return 404:

- `src/app/[locale]/products/page.tsx:61` → `.../related/kubeflex`
- `src/components/master-page/GetStartedSection.tsx:380` → `.../architecture`
- `src/components/Footer.tsx:184` → `.../release-notes`

I kept this PR scoped to the exact URL called out in #1463 to avoid scope creep. Happy to follow up with a separate PR for those if maintainers would like.

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable). — N/A, link-only change.
