### PR TITLE
🐛 Fix GitHub stats dropdown layout issue in navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -926,7 +926,7 @@ export default function Navbar() {
                 </div>
                 <div
                   data-dropdown-menu
-                  className="absolute hidden lg:flex right-0 mt-1 w-48 bg-gray-800/95 backdrop-blur-sm rounded-md shadow-lg border border-gray-700 before:content-[''] before:absolute before:bottom-full before:left-0 before:right-0 before:h-2 before:bg-transparent"
+                  className="absolute right-0 mt-1 w-48 bg-gray-800/95 backdrop-blur-sm rounded-md shadow-lg border border-gray-700 before:content-[''] before:absolute before:bottom-full before:left-0 before:right-0 before:h-2 before:bg-transparent"
                   style={{ display: "none" }}
                 >
                   <a

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -116,7 +116,9 @@ export default function Navbar() {
           );
           if (button) {
             button.addEventListener("mouseenter", clearHideTimeout);
-            cleanups.push(() => button.removeEventListener("mouseenter", clearHideTimeout));
+            cleanups.push(() => {
+              button.removeEventListener("mouseenter", clearHideTimeout);
+            });
           }
 
           menu.addEventListener("mouseenter", clearHideTimeout);
@@ -333,6 +335,11 @@ export default function Navbar() {
         cleanups.push(() => {
           langSwitcher.removeEventListener("mouseenter", handleMouseEnter);
           langSwitcher.removeEventListener("mouseleave", handleMouseLeave);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((window as any).closeLangSwitcher === closeLangSwitcher) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as any).closeLangSwitcher = undefined;
+          }
         });
 
         // Handle dropdown menu hover with improved detection


### PR DESCRIPTION
### 📌 Fixes

Fixes #1468

---

### 📝 Summary of Changes

- Fixed a layout discrepancy in `src/components/Navbar.tsx` where the GitHub Stats dropdown menu suffered from a specificity conflict.
- Removed the conflicting `hidden lg:flex` Tailwind classes on the dropdown menu container, allowing the imperative `style={{ display: "none" }}` (managed by the component's hover logic) to correctly govern the element's visibility and standard block-layout flow without interference.

---

### Changes Made

- [x] Updated `src/components/Navbar.tsx` to remove legacy layout classes conflicting with imperative JS styling behavior.
- [ ] Refactored 
- [x] Fixed broken desktop alignment for the Github stats dropdown
- [ ] Added tests for 

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---

### Screenshots or Logs (if applicable)

*N/A - Functional cascading stylesheet conflict resolved.*

---

### 👀 Reviewer Notes

_The component previously employed a dual-control mechanism for visiblity (`hidden` paired with `display: 'none'`). Because hover interactions set `menu.style.display = 'block'`, it inadvertently cancelled the `lg:flex` responsive layout intention, which breaks layout expectations when working with Tailwind classes. This has been normalized to align with how the other dropdown menus correctly operate._
