### PR TITLE
📖 docs: clarify Console is a standalone project, unrelated to legacy KubeStellar (#1472)

### DIFF
--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -1,5 +1,7 @@
 # KubeStellar Project Documentation 
 
+> **Looking for KubeFlex, BindingPolicy, WECs, ITSs, or the "Post Office" model?** Those are part of a separate project ([`kubestellar/kubestellar`](https://github.com/kubestellar/kubestellar)) and are **not** included in the KubeStellar Console. See [What is KubeStellar Console?](/docs/what-is-console) for details, or [Legacy Components](/docs/legacy-components) for pointers to the original project.
+
 Multi-cluster configuration management for edge, multi-cloud, and hybrid cloud environments.
 
 Enabled via  ***[KubeStellar Console](/docs/console/overview/introduction)***, a modern, AI-powered multi-cluster management interface that provides real-time monitoring, intelligent insights, and a customizable dashboard experience for managing Kubernetes clusters at scale.
@@ -19,8 +21,9 @@ Enabled via  ***[KubeStellar Console](/docs/console/overview/introduction)***, a
 
 ### KubeStellar Console
 
-Most users will wish to explore the demo and documentation for KubeStellar Console and the KubeStellar-MCP plugin for multicluster management and workload deployment. KubeStellar Console is a new, nimbler, from-the-ground-up AI-enabled control layer that does not use the legacy components.
+Most users will wish to explore the demo and documentation for KubeStellar Console and the KubeStellar-MCP plugin for multicluster management and workload deployment. KubeStellar Console is a standalone project — it is not related to and does not include any components from the original `kubestellar/kubestellar` repository (KubeFlex, WECs, ITSs, BindingPolicy, etc.).
 
+- [What is KubeStellar Console?](/docs/what-is-console): Short overview of what the Console is — and what it isn't
 - [KubeStellar Console Documentation](/docs/console/overview/introduction): Architecture, Features, Installation and Configuration
 - [KubeStellar-MCP Documentation](/docs/kubestellar-mcp/overview/introduction): More details about the Claude Code-enabled plugin for app-centric deployment management
 - [KubeStellar Console Demo](https://console.kubestellar.io): Live online demo of the KubeStellar Console UI/UX

--- a/docs/content/what-is-console.md
+++ b/docs/content/what-is-console.md
@@ -1,0 +1,37 @@
+---
+title: "What is KubeStellar Console?"
+linkTitle: "What is Console"
+description: >
+  KubeStellar Console is a standalone project for multi-cluster Kubernetes observability and AI-driven Mission Control. It is not related to the original kubestellar/kubestellar repository.
+---
+
+# What is KubeStellar Console?
+
+KubeStellar Console is a **standalone project** focused on multi-cluster Kubernetes observability, AI-driven Mission Control, and direct kubeconfig-based workflows. Its source lives at [github.com/kubestellar/console](https://github.com/kubestellar/console) and a live demo runs at [console.kubestellar.io](https://console.kubestellar.io).
+
+## It is a separate project
+
+KubeStellar Console is **not** related to the original [`kubestellar/kubestellar`](https://github.com/kubestellar/kubestellar) repository. It does **not** install, depend on, or interoperate with any of the following:
+
+- KubeFlex
+- Workload Execution Clusters (WECs)
+- Inventory and Transport Spaces (ITSs)
+- Workload Description Spaces (WDSs)
+- BindingPolicy / CombinedStatus
+- The original "Post Office" control model
+
+If you arrived here looking for those components, you are on a different project. See [Legacy Components](/docs/legacy-components) for pointers to the original `kubestellar/kubestellar` work.
+
+## What the Console does
+
+- **Multi-cluster dashboards** — 20+ dashboards and 110+ cards showing health, workloads, compute, storage, network, security, GitOps, alerts, and cost across every cluster you have access to.
+- **AI Mission Control** — Chat-driven troubleshooting, diagnose-and-repair flows, and AI-generated cards and dashboards.
+- **Drill-downs** — Click any card to open targeted views for pods, nodes, events, logs, and more.
+- **kc-agent kubeconfig bridge** — A local agent proxies the browser to your kubeconfig, so the Console only ever sees what you already have access to. There is no new control plane to install.
+
+## Get started
+
+- **Live demo**: [console.kubestellar.io](https://console.kubestellar.io) (starts in demo mode with sample data)
+- **Repository**: [github.com/kubestellar/console](https://github.com/kubestellar/console)
+- **Install**: [Installation guide](/docs/console/overview/installation)
+- **Quick Start**: [Console Quick Start](/docs/console/overview/quick-start)

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -548,6 +548,13 @@ export function buildPageMap(projectId: ProjectId = 'kubestellar') {
     routeMap['legacy-components'] = 'legacy-components.md'
   }
 
+  // Add "What is Console" disambiguation page (accessible at /docs/what-is-console)
+  // This is a standalone page that clarifies KubeStellar Console is a separate
+  // project from the original kubestellar/kubestellar repository. See issue #1472.
+  if (allDocFiles.includes('what-is-console.md')) {
+    routeMap['what-is-console'] = 'what-is-console.md'
+  }
+
   // Add top-level meta - only include our defined navigation structure
   const meta: Record<string, string> = {}
   for (const category of navStructure) {


### PR DESCRIPTION
Fixes #1472

## Summary

Adds a short "What is KubeStellar Console?" disambiguation page that makes it unambiguous that `kubestellar/console` is a **standalone, independent project** — not a migration target, successor, or evolution of the original `kubestellar/kubestellar` repository.

This replaces the closed PR #1473, which framed the Console as an "architecture evolution" from the legacy Post Office / KubeFlex / WEC / ITS / BindingPolicy model. That framing was incorrect: the Console has no connection to those components and does not install, depend on, or interoperate with them.

## Changes

- **New page** `docs/content/what-is-console.md` (~250 words): one paragraph on what the Console is, one paragraph explicitly stating it is not related to `kubestellar/kubestellar` and does not include KubeFlex/WECs/ITSs/WDSs/BindingPolicy/CombinedStatus/Post Office, a short "What the Console does" bulleted list, and links to the repo, live demo, and install docs.
- **Route registration** in `src/app/docs/page-map.ts`: new page is accessible at `/docs/what-is-console` (same registration pattern as the existing `legacy-components` entry).
- **Callout on `docs/content/intro.md`**: a prominent blockquote near the top pointing readers who arrived expecting the legacy components at the new page and at the existing `/docs/legacy-components` pointer page.
- **Small edit** to the Console section of `intro.md` to link the new page and to reword the existing sentence away from "nimbler, from-the-ground-up" (which could be read as evolution language) to a plain "standalone project" statement.

## Non-goals

- `docs/content/legacy-components.md` is left untouched.
- No migration table, no "v1 vs v2", no "evolution" narrative, no "from X to Y" storytelling.
- No changes to the original `kubestellar/kubestellar` docs pages.

## Test plan

- [ ] Next.js build succeeds in CI
- [ ] `/docs/what-is-console` renders on the preview deployment
- [ ] Callout renders at the top of `/docs/introduction`
- [ ] Link from intro.md "KubeStellar Console" section to `/docs/what-is-console` resolves