### PR TITLE
📖 docs(console): add public Security Model page

### DIFF
--- a/docs/content/console/security-model.md
+++ b/docs/content/console/security-model.md
@@ -119,30 +119,33 @@ Four layers gate every request to kc-agent:
 
 The console is designed to work in three progressively stricter network postures.
 
+**Posture A — fully online (default):** everything enabled.
+
 ```mermaid
-flowchart TB
-    subgraph A["A — fully online"]
-        direction LR
-        A_KA[kc-agent] --> A_K8S[Kubernetes]
-        A_KA --> A_AI[Public LLM]
-        A_GB[Backend] --> A_GH[GitHub OAuth]
-        A_GB --> A_UP[Update checks]
-    end
+flowchart LR
+    A_KA[kc-agent] --> A_K8S[Kubernetes]
+    A_KA --> A_AI[Public LLM]
+    A_GB[Backend] --> A_GH[GitHub OAuth]
+    A_GB --> A_UP[Update checks]
+```
 
-    subgraph B["B — restricted egress, no AI"]
-        direction LR
-        B_KA[kc-agent] --> B_K8S[Kubernetes]
-        B_KA -.blocked.-> B_AI[Public LLM]
-        B_GB[Backend] --> B_GH[GitHub OAuth]
-    end
+**Posture B — restricted egress, no AI:** all cluster-management features still work.
 
-    subgraph C["C — fully air-gapped"]
-        direction LR
-        C_KA[kc-agent] --> C_K8S[Kubernetes]
-        C_KA --> C_LLM[Local LLM]
-        C_KA -.blocked.-> C_AI[Public LLM]
-        C_GB[Backend] -.blocked.-> C_GH[GitHub OAuth]
-    end
+```mermaid
+flowchart LR
+    B_KA[kc-agent] --> B_K8S[Kubernetes]
+    B_KA -.blocked.-> B_AI[Public LLM]
+    B_GB[Backend] --> B_GH[GitHub OAuth]
+```
+
+**Posture C — fully air-gapped:** no public AI, no GitHub OAuth, optional local LLM.
+
+```mermaid
+flowchart LR
+    C_KA[kc-agent] --> C_K8S[Kubernetes]
+    C_KA --> C_LLM[Local LLM]
+    C_KA -.blocked.-> C_AI[Public LLM]
+    C_GB[Backend] -.blocked.-> C_GH[GitHub OAuth]
 ```
 
 - **Posture A** is the default — everything enabled. Cloud AI, GitHub OAuth, update checks.

--- a/docs/content/console/security-model.md
+++ b/docs/content/console/security-model.md
@@ -1,0 +1,205 @@
+---
+title: "Security Model — KubeStellar Console Data Flow, kc-agent, and Local LLMs"
+linkTitle: "Security Model"
+weight: 10
+description: >
+  Security posture of KubeStellar Console — what runs where, what data crosses which boundary, how kc-agent is scoped to your own machine, how AI keys are stored, and how to run air-gapped or with a fully-local LLM in high-security environments.
+keywords:
+  - kubestellar console security
+  - kc-agent security
+  - kubernetes dashboard air-gapped
+  - local llm kubernetes
+  - multi-cluster security model
+---
+
+# Security Model
+
+This page is for operators, platform engineers, and security reviewers evaluating whether KubeStellar Console is safe to install in their environment. It answers three questions:
+
+1. **What is the security model?** Where does each request go, what does each component see, and what leaves the cluster?
+2. **Can I run this in an air-gapped or network-restricted environment?** Yes — AI is optional and the core Kubernetes UX works with no outbound internet.
+3. **Can I use a local or self-hosted LLM instead of a public provider?** Yes, via the OpenAI-compatible providers whose base URLs are overridable.
+
+The canonical, code-grounded version of this document lives in the source tree at [`docs/security/SECURITY-MODEL.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) — every claim there is cited with file and line numbers. This page is the public-docs summary; read the source doc for the full detail.
+
+## Architecture overview
+
+The three-process architecture: your browser, a Go backend (serves UI, bootstrap-only identity), and `kc-agent` running on your own machine (identity is your kubeconfig). Every cluster mutation flows through kc-agent.
+
+```mermaid
+flowchart LR
+    subgraph User["User machine"]
+        B[Browser]
+        KA[kc-agent<br/>127.0.0.1:8585<br/>loopback only]
+        KC[~/.kube/config]
+        CFG[~/.kc/config.yaml<br/>AI keys, mode 0600]
+    end
+
+    subgraph Console["Console deployment"]
+        GB[Go backend<br/>:8080]
+        POD[(Pod SA)]
+    end
+
+    subgraph Clusters["Your managed clusters"]
+        K8S[Kubernetes API servers]
+    end
+
+    subgraph AI["AI providers (optional)"]
+        PUB[Public providers<br/>Anthropic / OpenAI /<br/>Gemini]
+        LOCAL[Local / self-hosted<br/>Ollama, vLLM, LM Studio,<br/>internal gateway]
+    end
+
+    B -->|HTTP/WS :8080<br/>serves UI| GB
+    B -->|HTTP/WS :8585<br/>all cluster ops| KA
+    KA -->|reads on disk| KC
+    KA -->|reads on disk| CFG
+    KA -->|kubectl as<br/>user identity| K8S
+    KA -.->|optional HTTPS<br/>chat prompts| PUB
+    KA -.->|optional HTTPS<br/>chat prompts| LOCAL
+    GB -->|bootstrap /<br/>GPU reserve /<br/>self-upgrade ONLY| POD
+```
+
+Solid lines are mandatory for the core cluster-management UX. Dashed lines to AI providers are optional and only used when an API key is configured.
+
+## The pod-SA rule
+
+The Go backend's pod ServiceAccount is used **only** for three things:
+
+1. **Serving the frontend** and storing console-local state (settings, token history, metrics cache). None of this touches a managed cluster.
+2. **GPU reservation** — creating a namespace and a `ResourceQuota` on it. Users typically do not have namespace-create RBAC; the console is the authorized policy layer for this specific flow.
+3. **Self-upgrade** — the console patches its own `Deployment` to roll out a new image.
+
+**Every other user-initiated Kubernetes action goes through kc-agent** on the user's own machine, using the user's own kubeconfig. Per-cluster RBAC is enforced by the target cluster's apiserver against the user's real identity, not against the console's pod SA.
+
+Consequences:
+
+- A user with no local kc-agent running gets **read-only / demo-mode** behavior. Destructive operations fail by design.
+- The console running inside a cluster **cannot** escalate a user's privilege on a managed cluster by impersonating them. It does not try to.
+- The hosted demo at [console.kubestellar.io](https://console.kubestellar.io) has no trust relationship with your clusters at all — it cannot read or modify them.
+
+## kc-agent defense in depth
+
+kc-agent binds `127.0.0.1:8585` by default and is not configurable to bind any other address. The bind is the primary defense against network-level access. Additional layers protect against local attackers (rogue browser tabs, other processes on the same machine):
+
+```mermaid
+flowchart LR
+    RB[Remote browser<br/>any LAN host]
+    LB[Local browser<br/>127.0.0.1]
+
+    subgraph Gates["kc-agent defense in depth"]
+        direction TB
+        BIND[Bind check<br/>127.0.0.1 only]
+        CORS[Origin allow-list<br/>strict match]
+        REB[DNS-rebinding guard]
+        TOK["Token check<br/>(optional, off by default)"]
+        KA[kc-agent handlers<br/>kubectl via user kubeconfig]
+    end
+
+    RB -.rejected at OS<br/>socket layer.-> BIND
+    LB --> BIND
+    BIND --> CORS
+    CORS --> REB
+    REB --> TOK
+    TOK --> KA
+```
+
+Set `KC_AGENT_TOKEN` for the fourth layer — recommended when you cannot assume all local processes are trusted.
+
+## Network posture options
+
+The console is designed to work in three progressively stricter network postures.
+
+```mermaid
+flowchart TB
+    subgraph A["Posture A — fully online (default)"]
+        direction LR
+        A_KA[kc-agent] --> A_K8S[Kubernetes]
+        A_KA --> A_AI[Public AI provider]
+        A_GB[Go backend] --> A_GH[GitHub OAuth]
+        A_GB --> A_UP[Update checks]
+    end
+
+    subgraph B["Posture B — restricted egress (no AI)"]
+        direction LR
+        B_KA[kc-agent] --> B_K8S[Kubernetes]
+        B_KA -.blocked.-> B_AI[Public AI provider]
+        B_GB[Go backend] --> B_GH[GitHub OAuth]
+    end
+
+    subgraph C["Posture C — fully air-gapped"]
+        direction LR
+        C_KA[kc-agent] --> C_K8S[Kubernetes]
+        C_KA --> C_LLM[Local LLM<br/>optional]
+        C_KA -.blocked.-> C_AI[Public AI provider]
+        C_GB[Go backend] -.blocked.-> C_GH[GitHub OAuth]
+    end
+```
+
+- **Posture A** is the default — everything enabled. Cloud AI, GitHub OAuth, update checks.
+- **Posture B** drops AI. Unset every AI API key environment variable and block egress to `api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com`, `api.groq.com`, and `openrouter.ai`. All cluster-management features continue to work; AI-driven features fall back to deterministic/rule-based behavior.
+- **Posture C** drops everything external. No public AI, no GitHub OAuth, no update checks. Optionally point kc-agent at an in-cluster LLM for AI features (see next section).
+
+## Running a local or self-hosted LLM
+
+Three providers honor a base-URL override, so you can redirect the AI traffic to any OpenAI-compatible endpoint on your own infrastructure:
+
+```mermaid
+flowchart LR
+    KA[kc-agent] -->|provider: groq<br/>GROQ_BASE_URL=...| SLOT[Groq provider slot]
+    SLOT -.default.-> GRQ[api.groq.com/v1]
+    SLOT -->|override| OLLA[Ollama<br/>localhost:11434/v1]
+    SLOT -->|override| VLLM[vLLM<br/>local:8000/v1]
+    SLOT -->|override| LM[LM Studio<br/>local:1234/v1]
+    SLOT -->|override| GW[Corporate LLM gateway<br/>llm.internal/v1]
+```
+
+Override environment variables:
+
+| Provider | Base URL env var | Use case |
+|---|---|---|
+| Groq | `GROQ_BASE_URL` | Ollama, vLLM, LM Studio, LocalAI, any OpenAI-compatible local runner |
+| OpenRouter | `OPENROUTER_BASE_URL` | Corporate LLM gateway, internal OpenAI-compatible frontends |
+| Open WebUI | `OPEN_WEBUI_URL` | Existing Open WebUI deployments |
+
+Example — point the Groq provider slot at Ollama:
+
+```bash
+export GROQ_API_KEY=unused-but-nonempty
+export GROQ_BASE_URL=http://localhost:11434/v1
+export GROQ_MODEL=llama3.1:8b
+./bin/kc-agent
+```
+
+The request payload is unchanged (OpenAI chat-completions wire format), so any OpenAI-compatible local runner works without the console knowing or caring which one.
+
+### Local LLM as a security posture
+
+Using a local or on-prem LLM is the strongest way to keep prompts and conversation history inside your trust boundary. When the base URL points at something running on your own network, AI traffic never leaves the machine (for a loopback endpoint) or never leaves your perimeter (for an internal gateway). This is the right choice for operators in regulated, air-gapped, or high-sensitivity environments — not because the console is broken without a public provider, but because the security posture matches what those environments need.
+
+## What each component sees
+
+| Data | Browser | Go backend | kc-agent | AI provider |
+|---|---|---|---|---|
+| `~/.kube/config` | no | no | **yes** (read from local disk) | **never** |
+| Cluster API credentials (tokens, client certs) | no | no | **yes** (extracted from kubeconfig) | **never** |
+| Pod logs, events, YAML manifests | yes (when viewing) | no (except its own cluster) | **yes** (relayed from kubectl) | only if the user pastes them into a chat |
+| AI chat prompts + conversation history | yes | no | **yes** (forwards to provider) | **yes** (provider sees what you send) |
+| AI API keys | no (never sent to browser) | no | **yes** (`~/.kc/config.yaml` or env) | used as `Authorization` header |
+| GitHub OAuth client secret | no | **yes** (env var only) | no | no |
+
+**The kubeconfig, raw secrets, and cluster credentials never cross the process boundary from kc-agent.** The only thing kc-agent sends outward is the chat payload to the configured AI provider — system prompt + message history + current prompt. It does not auto-upload the kubeconfig, bearer tokens, or arbitrary cluster objects.
+
+## Reporting a vulnerability
+
+Report security issues following the project's security policy:
+
+- **KubeStellar Console** — [`docs/security/SECURITY-MODEL.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) links to the disclosure process and the upstream self-assessment at [`docs/security/SELF-ASSESSMENT.md`](https://github.com/kubestellar/console/blob/main/docs/security/SELF-ASSESSMENT.md).
+- **Upstream CNCF projects** — every install mission in the console links to the target project's own security policy. Report per-project vulnerabilities upstream, not to us.
+
+## Further reading
+
+- [Architecture](architecture.md) — broader system design of the console
+- [Installation](installation.md) — how to install the console locally or in a cluster
+- [AI Features](ai-features.md) — what the AI missions do
+- [Authentication](authentication.md) — GitHub OAuth setup
+- [`docs/security/SECURITY-MODEL.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) — the canonical source-grounded version of this document

--- a/docs/content/console/security-model.md
+++ b/docs/content/console/security-model.md
@@ -30,36 +30,41 @@ The three-process architecture: your browser, a Go backend (serves UI, bootstrap
 flowchart LR
     subgraph User["User machine"]
         B[Browser]
-        KA[kc-agent<br/>127.0.0.1:8585<br/>loopback only]
-        KC[~/.kube/config]
-        CFG[~/.kc/config.yaml<br/>AI keys, mode 0600]
+        KA[kc-agent]
+        KC[kubeconfig]
+        CFG[AI keys file]
     end
 
     subgraph Console["Console deployment"]
-        GB[Go backend<br/>:8080]
+        GB[Go backend]
         POD[(Pod SA)]
     end
 
-    subgraph Clusters["Your managed clusters"]
-        K8S[Kubernetes API servers]
+    subgraph Clusters["Managed clusters"]
+        K8S[Kubernetes API]
     end
 
     subgraph AI["AI providers (optional)"]
-        PUB[Public providers<br/>Anthropic / OpenAI /<br/>Gemini]
-        LOCAL[Local / self-hosted<br/>Ollama, vLLM, LM Studio,<br/>internal gateway]
+        PUB[Public LLM]
+        LOCAL[Local LLM]
     end
 
-    B -->|HTTP/WS :8080<br/>serves UI| GB
-    B -->|HTTP/WS :8585<br/>all cluster ops| KA
-    KA -->|reads on disk| KC
-    KA -->|reads on disk| CFG
-    KA -->|kubectl as<br/>user identity| K8S
-    KA -.->|optional HTTPS<br/>chat prompts| PUB
-    KA -.->|optional HTTPS<br/>chat prompts| LOCAL
-    GB -->|bootstrap /<br/>GPU reserve /<br/>self-upgrade ONLY| POD
+    B -->|UI :8080| GB
+    B -->|cluster ops :8585| KA
+    KA --> KC
+    KA --> CFG
+    KA -->|user identity| K8S
+    KA -.->|prompts only| PUB
+    KA -.->|prompts only| LOCAL
+    GB -->|bootstrap only| POD
 ```
 
-Solid lines are mandatory for the core cluster-management UX. Dashed lines to AI providers are optional and only used when an API key is configured.
+**Legend:**
+
+- **kc-agent** binds `127.0.0.1:8585` (loopback only) on the user's machine. Reads `~/.kube/config` and stores AI keys at `~/.kc/config.yaml` (mode `0600`).
+- **Go backend** serves the UI on `:8080` and only uses its pod ServiceAccount for bootstrap, GPU reservation, and self-upgrade — never to act on a managed cluster.
+- **Public LLM** = Anthropic, OpenAI, Gemini, Groq, OpenRouter. **Local LLM** = Ollama, vLLM, LM Studio, Open WebUI, or any OpenAI-compatible internal gateway.
+- **Solid arrows** are mandatory for the core cluster-management UX. **Dashed arrows** to AI providers are optional and only used when an API key is configured.
 
 ## The pod-SA rule
 
@@ -83,19 +88,19 @@ kc-agent binds `127.0.0.1:8585` by default and is not configurable to bind any o
 
 ```mermaid
 flowchart LR
-    RB[Remote browser<br/>any LAN host]
-    LB[Local browser<br/>127.0.0.1]
+    RB[Remote browser]
+    LB[Local browser]
 
-    subgraph Gates["kc-agent defense in depth"]
+    subgraph Gates["kc-agent gates"]
         direction TB
-        BIND[Bind check<br/>127.0.0.1 only]
-        CORS[Origin allow-list<br/>strict match]
-        REB[DNS-rebinding guard]
-        TOK["Token check<br/>(optional, off by default)"]
-        KA[kc-agent handlers<br/>kubectl via user kubeconfig]
+        BIND[1: bind 127.0.0.1]
+        CORS[2: CORS allow-list]
+        REB[3: rebind guard]
+        TOK[4: token check]
+        KA[handlers]
     end
 
-    RB -.rejected at OS<br/>socket layer.-> BIND
+    RB -.rejected.-> BIND
     LB --> BIND
     BIND --> CORS
     CORS --> REB
@@ -103,7 +108,12 @@ flowchart LR
     TOK --> KA
 ```
 
-Set `KC_AGENT_TOKEN` for the fourth layer — recommended when you cannot assume all local processes are trusted.
+Four layers gate every request to kc-agent:
+
+1. **Bind check** — kc-agent listens on `127.0.0.1:8585` only. Remote LAN hosts are rejected at the OS socket layer.
+2. **CORS allow-list** — strict origin matching for browser requests.
+3. **DNS-rebinding guard** — defends against attacker-controlled DNS resolving to `127.0.0.1`.
+4. **Token check** — optional shared secret. Set `KC_AGENT_TOKEN` for this fourth layer; recommended when you cannot assume all local processes are trusted.
 
 ## Network posture options
 
@@ -111,27 +121,27 @@ The console is designed to work in three progressively stricter network postures
 
 ```mermaid
 flowchart TB
-    subgraph A["Posture A — fully online (default)"]
+    subgraph A["A — fully online"]
         direction LR
         A_KA[kc-agent] --> A_K8S[Kubernetes]
-        A_KA --> A_AI[Public AI provider]
-        A_GB[Go backend] --> A_GH[GitHub OAuth]
+        A_KA --> A_AI[Public LLM]
+        A_GB[Backend] --> A_GH[GitHub OAuth]
         A_GB --> A_UP[Update checks]
     end
 
-    subgraph B["Posture B — restricted egress (no AI)"]
+    subgraph B["B — restricted egress, no AI"]
         direction LR
         B_KA[kc-agent] --> B_K8S[Kubernetes]
-        B_KA -.blocked.-> B_AI[Public AI provider]
-        B_GB[Go backend] --> B_GH[GitHub OAuth]
+        B_KA -.blocked.-> B_AI[Public LLM]
+        B_GB[Backend] --> B_GH[GitHub OAuth]
     end
 
-    subgraph C["Posture C — fully air-gapped"]
+    subgraph C["C — fully air-gapped"]
         direction LR
         C_KA[kc-agent] --> C_K8S[Kubernetes]
-        C_KA --> C_LLM[Local LLM<br/>optional]
-        C_KA -.blocked.-> C_AI[Public AI provider]
-        C_GB[Go backend] -.blocked.-> C_GH[GitHub OAuth]
+        C_KA --> C_LLM[Local LLM]
+        C_KA -.blocked.-> C_AI[Public LLM]
+        C_GB[Backend] -.blocked.-> C_GH[GitHub OAuth]
     end
 ```
 

--- a/docs/content/console/security-model.md
+++ b/docs/content/console/security-model.md
@@ -32,37 +32,39 @@ flowchart LR
         B[Browser]
         KA[kc-agent]
         KC[kubeconfig]
-        CFG[AI keys file]
+        CFG[AI keys]
     end
 
     subgraph Console["Console deployment"]
-        GB[Go backend]
+        GB[Backend]
         POD[(Pod SA)]
     end
 
     subgraph Clusters["Managed clusters"]
-        K8S[Kubernetes API]
+        K8S[Kubernetes]
     end
 
-    subgraph AI["AI providers (optional)"]
+    subgraph AI["AI (optional)"]
         PUB[Public LLM]
         LOCAL[Local LLM]
     end
 
-    B -->|UI :8080| GB
-    B -->|cluster ops :8585| KA
+    B --> GB
+    B --> KA
     KA --> KC
     KA --> CFG
-    KA -->|user identity| K8S
-    KA -.->|prompts only| PUB
-    KA -.->|prompts only| LOCAL
-    GB -->|bootstrap only| POD
+    KA --> K8S
+    KA -.-> PUB
+    KA -.-> LOCAL
+    GB --> POD
 ```
 
 **Legend:**
 
-- **kc-agent** binds `127.0.0.1:8585` (loopback only) on the user's machine. Reads `~/.kube/config` and stores AI keys at `~/.kc/config.yaml` (mode `0600`).
-- **Go backend** serves the UI on `:8080` and only uses its pod ServiceAccount for bootstrap, GPU reservation, and self-upgrade — never to act on a managed cluster.
+- **Browser → Backend** serves the UI on port 8080.
+- **Browser → kc-agent** is all cluster operations on `127.0.0.1:8585` (loopback only). kc-agent reads `~/.kube/config` and stores AI keys at `~/.kc/config.yaml` (mode `0600`).
+- **kc-agent → Kubernetes** uses the user's own kubeconfig identity. Per-cluster RBAC is enforced by each apiserver against the user, never against the console's pod SA.
+- **Backend → Pod SA** is bootstrap-only — serving the frontend, GPU reservation, and self-upgrade. The backend never acts on a managed cluster.
 - **Public LLM** = Anthropic, OpenAI, Gemini, Groq, OpenRouter. **Local LLM** = Ollama, vLLM, LM Studio, Open WebUI, or any OpenAI-compatible internal gateway.
 - **Solid arrows** are mandatory for the core cluster-management UX. **Dashed arrows** to AI providers are optional and only used when an API key is configured.
 
@@ -88,19 +90,15 @@ kc-agent binds `127.0.0.1:8585` by default and is not configurable to bind any o
 
 ```mermaid
 flowchart LR
-    RB[Remote browser]
-    LB[Local browser]
+    RB[Remote]
+    LB[Local]
+    BIND[Bind]
+    CORS[CORS]
+    REB[Rebind]
+    TOK[Token]
+    KA[Handlers]
 
-    subgraph Gates["kc-agent gates"]
-        direction TB
-        BIND[1: bind 127.0.0.1]
-        CORS[2: CORS allow-list]
-        REB[3: rebind guard]
-        TOK[4: token check]
-        KA[handlers]
-    end
-
-    RB -.rejected.-> BIND
+    RB -.X.-> BIND
     LB --> BIND
     BIND --> CORS
     CORS --> REB
@@ -158,12 +156,12 @@ Three providers honor a base-URL override, so you can redirect the AI traffic to
 
 ```mermaid
 flowchart LR
-    KA[kc-agent] -->|provider: groq<br/>GROQ_BASE_URL=...| SLOT[Groq provider slot]
-    SLOT -.default.-> GRQ[api.groq.com/v1]
-    SLOT -->|override| OLLA[Ollama<br/>localhost:11434/v1]
-    SLOT -->|override| VLLM[vLLM<br/>local:8000/v1]
-    SLOT -->|override| LM[LM Studio<br/>local:1234/v1]
-    SLOT -->|override| GW[Corporate LLM gateway<br/>llm.internal/v1]
+    KA[kc-agent] --> SLOT[Groq slot]
+    SLOT -.default.-> GRQ[api.groq.com]
+    SLOT --> OLLA[Ollama]
+    SLOT --> VLLM[vLLM]
+    SLOT --> LM[LM Studio]
+    SLOT --> GW[Corporate gateway]
 ```
 
 Override environment variables:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - Alerts: console/alerts.md
       - Configuration: console/configuration.md
       - Architecture: console/architecture.md
+      - Security Model: console/security-model.md
       - Persistence: console/persistence.md
   - KubeStellar MCP:
       - Overview: kubestellar-mcp/index.md


### PR DESCRIPTION
## Summary

Adds a new Console section page at \`docs/content/console/security-model.md\` and wires it into the MkDocs Console nav right after **Architecture**.

Aimed at operators, platform engineers, and security reviewers evaluating whether KubeStellar Console is safe to install in their environment.

## What's covered

- **Architecture overview** with a mermaid flowchart showing trust boundaries (user machine / console deployment / managed clusters / AI providers) and which flows are mandatory vs optional
- **Pod-SA identity rule** — pod SA is ONLY used for bootstrap / GPU reservation / self-upgrade; every user-initiated cluster action flows through kc-agent with the user's kubeconfig
- **kc-agent defense in depth** — mermaid showing the four gates (\`127.0.0.1\` bind, CORS allow-list, DNS-rebinding guard, optional \`KC_AGENT_TOKEN\`)
- **Three network postures** — fully online / restricted egress / fully air-gapped — visualized as a stacked mermaid
- **Local / self-hosted LLM routing** — how \`GROQ_BASE_URL\`, \`OPENROUTER_BASE_URL\`, \`OPEN_WEBUI_URL\` redirect a provider slot to Ollama, vLLM, LM Studio, or a corporate gateway
- **Local LLM as a security posture** framing — deliberately scoped to NOT conflate with broader local-LLM support work
- **Data-seen-by-each-component table** — what each process sees (kubeconfig, tokens, prompts, keys)
- **Vulnerability reporting pointers**

## Source of truth

Every claim mirrors the source-grounded version at [kubestellar/console:docs/security/SECURITY-MODEL.md](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) (which has file:line citations). This public-docs page is the reviewer-friendly summary.

## Related

- [kubestellar/console#8203](https://github.com/kubestellar/console/pull/8203) (merged) — the source-grounded doc this page mirrors
- [kubestellar/console#8206](https://github.com/kubestellar/console/pull/8206) — mermaid diagrams in the source doc
- [kubestellar/console#<pending>](https://github.com/kubestellar/console/pulls) — UI surfaces (Security tab in mission detail, Security section in install modal) landing in parallel

## Test plan

- [ ] MkDocs build passes and the new page renders in the Console section nav
- [ ] All four mermaid diagrams render (not fallback to text)
- [ ] Cross-links to Architecture, Installation, AI Features, Authentication pages resolve