### PR TITLE
📖 docs(console): restore rich mermaid + disable HTML labels

### DIFF
--- a/docs/content/console/security-model.md
+++ b/docs/content/console/security-model.md
@@ -27,12 +27,37 @@ The canonical, code-grounded version of this document lives in the source tree a
 The three-process architecture: your browser, a Go backend (serves UI, bootstrap-only identity), and `kc-agent` running on your own machine (identity is your kubeconfig). Every cluster mutation flows through kc-agent.
 
 ```mermaid
+%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
 flowchart LR
-    B[Browser] --> GB[Backend]
-    B --> KA[kc-agent]
-    KA --> K8S[Kubernetes]
-    KA -.-> AI[AI]
-    GB --> POD[Pod SA]
+    subgraph User["User machine"]
+        B[Browser]
+        KA[kc-agent]
+        KC[kubeconfig]
+        CFG[AI keys]
+    end
+
+    subgraph Console["Console deployment"]
+        GB[Backend]
+        POD[(Pod SA)]
+    end
+
+    subgraph Clusters["Managed clusters"]
+        K8S[Kubernetes]
+    end
+
+    subgraph AI["AI (optional)"]
+        PUB[Public LLM]
+        LOCAL[Local LLM]
+    end
+
+    B --> GB
+    B --> KA
+    KA --> KC
+    KA --> CFG
+    KA --> K8S
+    KA -.-> PUB
+    KA -.-> LOCAL
+    GB --> POD
 ```
 
 **Legend:**
@@ -65,6 +90,7 @@ Consequences:
 kc-agent binds `127.0.0.1:8585` by default and is not configurable to bind any other address. The bind is the primary defense against network-level access. Additional layers protect against local attackers (rogue browser tabs, other processes on the same machine):
 
 ```mermaid
+%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
 flowchart LR
     RB[Remote]
     LB[Local]
@@ -96,6 +122,7 @@ The console is designed to work in three progressively stricter network postures
 **Posture A — fully online (default):** everything enabled.
 
 ```mermaid
+%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
 flowchart LR
     A_KA[kc-agent] --> A_K8S[Kubernetes]
     A_KA --> A_AI[Public LLM]
@@ -106,6 +133,7 @@ flowchart LR
 **Posture B — restricted egress, no AI:** all cluster-management features still work.
 
 ```mermaid
+%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
 flowchart LR
     B_KA[kc-agent] --> B_K8S[Kubernetes]
     B_KA -.blocked.-> B_AI[Public LLM]
@@ -115,6 +143,7 @@ flowchart LR
 **Posture C — fully air-gapped:** no public AI, no GitHub OAuth, optional local LLM.
 
 ```mermaid
+%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
 flowchart LR
     C_KA[kc-agent] --> C_K8S[Kubernetes]
     C_KA --> C_LLM[Local LLM]
@@ -131,6 +160,7 @@ flowchart LR
 Three providers honor a base-URL override, so you can redirect the AI traffic to any OpenAI-compatible endpoint on your own infrastructure:
 
 ```mermaid
+%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
 flowchart LR
     KA[kc-agent] --> SLOT[Groq slot]
     SLOT -.default.-> GRQ[api.groq.com]


### PR DESCRIPTION
## Summary

Fixes the mermaid label truncation in [docs/content/console/security-model.md](https://github.com/kubestellar/docs/blob/main/docs/content/console/security-model.md) by restoring the rich trust-boundary content (subgraphs, classDef coloring, descriptive labels) and adding the upstream-recommended init directive to disable HTML labels.

## Background

The previous 'flatten the component diagram' commit on main removed all the descriptive labels and trust-boundary classDef coloring in an attempt to work around the mermaid label truncation. That was treating the symptom — the real fix is to disable HTML foreignObject label rendering, which mermaid v9.2+ uses by default and which the docs renderer mis-measures (chopping the last character off every label).

The official upstream workaround is the init directive:

\`\`\`
%%{init: {'flowchart': {'htmlLabels': false, 'useMaxWidth': false}}}%%
\`\`\`

This forces mermaid to render labels as SVG \`<text>\` elements instead of HTML \`foreignObject\` elements. SVG text is sized correctly by every mermaid renderer (GitHub, mkdocs-material, mermaid-cli, etc.).

## Verified working on kubestellar/console

The same fix landed on [kubestellar/console#main:docs/security/SECURITY-MODEL.md](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) (commit 5d1a3d4d, direct push per user authorization). Visual verification via Chrome DevTools Protocol screenshots of the GitHub-rendered page confirms every label in every diagram now renders completely with no truncation.

## What changes

- Reverts \`security-model.md\` to the rich content from the original PR #1476 merge state:
  - Component diagram with 4 trust-boundary subgraphs (User machine / Console deployment / Managed clusters / AI providers) and classDef coloring
  - kc-agent gates diagram with the 4 numbered defense-in-depth layers
  - 3 stacked posture diagrams (fully online / restricted egress / fully air-gapped) with blocked-arrow indicators
  - Local-LLM routing diagram showing the Groq slot redirect to Ollama / vLLM / LM Studio / corporate gateway
- Adds the \`htmlLabels: false\` init directive to all 6 mermaid blocks
- No content changes other than the init directive

## Sources

- [mermaid-js/mermaid#7354](https://github.com/mermaid-js/mermaid/issues/7354) — flowchart node label truncation bug (open)
- [mermaid-js/mermaid#3525](https://github.com/mermaid-js/mermaid/issues/3525) — text truncation in nodes (workarounds)
- [mermaid-js/mermaid#1540](https://github.com/mermaid-js/mermaid/issues/1540) — truncated text and custom font families

## Test plan

- [x] All 6 mermaid blocks parse (mermaid-cli local render passes)
- [x] Same fix verified working on kubestellar/console GitHub render
- [ ] After merge, verify https://docs.kubestellar.io/en/console/security-model/ shows all labels completely (CDP screenshot inspection)