### PR TITLE
📝 docs: add console v0.3.20 to version dropdown

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -21,6 +21,11 @@
         "label": "v0.1.0",
         "branch": "docs/console/0.1.0",
         "isDefault": false
+      },
+      "0.3.20": {
+        "label": "v0.3.20",
+        "branch": "docs/console/0.3.20",
+        "isDefault": false
       }
     },
     "kubestellar": {
@@ -251,5 +256,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-04-09T12:00:00.000Z"
+  "updatedAt": "2026-04-16T01:14:47.569Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -207,6 +207,11 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: true,
   },
+  "0.3.20": {
+    label: "v0.3.20",
+    branch: "docs/console/0.3.20",
+    isDefault: false,
+  },
   "0.3.19": {
     label: "v0.3.19",
     branch: "docs/console/0.3.19",


### PR DESCRIPTION
## Summary

Latest stable release [`kubestellar/console@v0.3.20`](https://github.com/kubestellar/console/releases/tag/v0.3.20) shipped 2026-04-12. Adds the entry to `CONSOLE_VERSIONS` in `src/config/versions.ts` and the matching row in `public/config/shared.json`.

**Not set as latest** — the console dropdown defaults to `main` per the existing pattern.

## Next step (after merge)

Once this merges, I'll create the `docs/console/0.3.20` branch from post-merge main:

```bash
git push origin main:docs/console/0.3.20
```

Creating the version branch **before** this PR merges would bake a stale dropdown into the branch deploy (the deploy reads its own local `shared.json`, not production's), so the new version wouldn't appear in its own dropdown.

## Test plan

- [x] `node scripts/update-version.js --project console --version 0.3.20 --branch docs/console/0.3.20` — ran successfully
- [x] diff limited to `versions.ts` + `shared.json`
- [ ] After merge: verify `v0.3.20` appears in the console dropdown on the main branch deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)