### PR TITLE
📖 Console docs sync: Apr 10–15, 2026

### DIFF
--- a/docs/content/console/acmm-dashboard.md
+++ b/docs/content/console/acmm-dashboard.md
@@ -1,0 +1,69 @@
+---
+title: "AI Codebase Maturity Model (ACMM) Dashboard"
+linkTitle: "ACMM Dashboard"
+weight: 19
+description: >
+  Assess any GitHub repository against the AI Codebase Maturity Model — a 5-level framework with 33 feedback loops measuring how well a codebase leverages AI-assisted development.
+keywords:
+  - acmm
+  - ai codebase maturity
+  - ai maturity model
+  - github repo assessment
+  - feedback loops
+---
+
+# AI Codebase Maturity Model Dashboard
+
+The `/acmm` dashboard assesses any GitHub repository against the [AI Codebase Maturity Model](https://arxiv.org/abs/2604.09388) (ACMM) — a 5-level framework with 33 feedback loops that measure how well a codebase leverages AI-assisted development.
+
+ACMM was published as an arXiv paper (`cs.SE`, 2604.09388). The console implementation adds three supplementary sources beyond the core ACMM spec: `fullsend`, `agentic-engineering-framework`, and `claude-reflect` — each contributing additional criteria via a plugin registry.
+
+## How it works
+
+1. Paste any `owner/repo` in the **Repo Picker** at the top (defaults to `kubestellar/console`).
+2. The backend scans the GitHub tree API once + parallelizes PR/issue search aggregation.
+3. All four cards update together from the scan results.
+
+Results are cached for 15 minutes. When no GitHub access is available, demo data kicks in.
+
+## The four cards
+
+### ACMM Level (ring gauge)
+
+Shows the repository's current maturity level (L1 through L5) as a ring gauge, the matching role description, and a progress bar toward the next level.
+
+| Level | Name | AI Contribution Target |
+|---|---|---|
+| L1 | Assisted | ~25% |
+| L2 | Augmented | ~40% |
+| L3 | Collaborative | ~55% |
+| L4 | Autonomous | ~70% |
+| L5 | Self-Evolving | ~85% |
+
+### ACMM Balance (trend chart)
+
+Weekly bar chart showing the ratio of AI-generated vs human-authored contributions. A level-anchored target slider lets you set a goal (e.g., "aim for L3 = 55% AI"). Click a "Use L{n}" snap button to jump to that level's target. The target persists per-repo in localStorage.
+
+### Feedback Loop Inventory
+
+Filterable inventory of all 33 ACMM feedback loops (plus criteria from the three supplementary sources), showing which are detected in the repo and which are missing. Filter by source (`acmm`, `fullsend`, `agentic-engineering-framework`, `claude-reflect`) or by detected/missing status.
+
+Click any missing feedback loop to open a side panel with a description and a Console-specific reference showing how to implement it.
+
+### Recommendations
+
+Role-aware top-5 list of missing criteria prioritized for reaching the next level. Each recommendation links to the relevant feedback loop in the inventory card.
+
+## Backend
+
+The scan runs via a Netlify Function at `GET /api/acmm/scan?repo=owner/repo` (`web/netlify/functions/acmm-scan.mts`). It:
+- Hits the GitHub tree API once per scan
+- Parallelizes PR and issue search aggregation
+- Caches results for 15 minutes (LRU)
+- Falls back to demo data when the GitHub API is unreachable or rate-limited
+- Has an MSW passthrough rule for demo mode
+
+## Related
+
+- [ACMM paper on arXiv](https://arxiv.org/abs/2604.09388)
+- Console PR: #8260

--- a/docs/content/console/ai-features.md
+++ b/docs/content/console/ai-features.md
@@ -32,11 +32,14 @@ KubeStellar Console uses AI Missions to automate multi-cluster Kubernetes operat
 AI Missions are conversations with AI to solve problems. You can start a mission from two places:
 
 - The **AI Missions** button in the top navigation bar (desktop and overflow menu on narrow viewports)
+- The **Agent** button in the top nav (renamed from "AI" in Apr 2026 for kc-agent connection clarity — PR #8209)
 - The **AI Missions** floating button at the bottom right
 
 ![AI Missions Navbar Button](images/ai-missions-navbar-apr02.jpg)
 
 The navbar button shows an attention badge when missions need your input. For complex multi-project deployments, use the **Mission Control** wizard (accessible from the AI Missions panel).
+
+> **Note (Apr 2026):** The top-level navbar button was renamed from "AI" to "Agent" to clarify that it connects to kc-agent (the local agent bridging your kubeconfig), not a cloud AI service. Existing screenshots may still show the old label.
 
 ### What Can You Do?
 

--- a/docs/content/console/all-cards.md
+++ b/docs/content/console/all-cards.md
@@ -118,7 +118,7 @@ The console ships with 120+ built-in cards, and you can create more using the Ca
 
 ---
 
-### CNCF Ecosystem Cards (4)
+### CNCF Ecosystem Cards (6)
 
 | # | Card | What it shows |
 |---|------|---------------|
@@ -126,6 +126,8 @@ The console ships with 120+ built-in cards, and you can create more using the Ca
 | 119 | **KEDA** | Operator health, scaled object stats with replica progress bars, trigger details |
 | 120 | **Strimzi Kafka** | Cluster health, broker readiness, topic status, consumer group lag |
 | 121 | **OpenFeature** | Provider health (flagd, LaunchDarkly, Split), feature flag stats, evaluation counts |
+| 122 | **Drasi Reactive Graph** | Reactive data pipeline visualization — sources, continuous queries, reactions with animated flow lines, live SSE streaming, full CRUD, CodeMirror Cypher editor, per-language stream-consumer code samples, flow discovery. Supports drasi-server, drasi-platform, and drasi-lib. See [Drasi Dashboard](drasi-dashboard.md) for full docs. |
+| 123 | **Keycloak Monitoring** | Keycloak instance health, realm counts, client counts, user session metrics |
 
 ---
 
@@ -357,6 +359,19 @@ The console ships with 120+ built-in cards, and you can create more using the Ca
 |------|--------------|
 | **Crossplane Managed Resources** | Managed resource count, provider health, composite resource status, resource table with sync/ready status |
 | **Cloud Native Buildpacks** | Build counts, success rates, active builders, recent builds with duration and builder info |
+
+### AI Codebase Maturity (ACMM) Cards (4)
+
+| # | Card | What it shows |
+|---|------|---------------|
+| 124 | **ACMM Level** | L1–L5 ring gauge showing the scanned repo's AI codebase maturity level, role, and next-level progress |
+| 125 | **ACMM Balance** | Weekly AI vs human contribution bar chart with a level-anchored target slider |
+| 126 | **ACMM Feedback Loops** | Inventory of 33 feedback loops filtered by source and detected/missing status |
+| 127 | **ACMM Recommendations** | Role-aware top-5 missing criteria prioritized for reaching the next level |
+
+All four cards are driven by a single GitHub scan. See [ACMM Dashboard](acmm-dashboard.md) for full docs.
+
+---
 
 ### Additional Cards (44+)
 

--- a/docs/content/console/architecture.md
+++ b/docs/content/console/architecture.md
@@ -76,6 +76,15 @@ The Backend is the OAuth Client in the OAuth 2.0 flow. It receives the authoriza
 | `pkg/claude` | AI integration (future) |
 | `pkg/store` | SQLite database layer |
 | `pkg/models` | Data structures |
+| `pkg/auth` | Authentication middleware, session management |
+
+#### kc-agent migration (Apr 2026)
+
+The console is actively migrating cluster-mutating operations from the pod ServiceAccount backend to **kc-agent** running on the user's machine. This means operations like Helm rollback/uninstall/upgrade, ArgoCD sync, drift detection, kubectl sync, GPU health cronjob management, and namespace create/delete now route through kc-agent instead of the backend's pod-SA. The backend retains pod-SA only for bootstrap, GPU reservation, and self-upgrade (the "pod-SA rule" — see [Security Model](security-model.md)).
+
+This migration landed across PRs #8028, #8033, #8036, #8038, #8039, #8044 (phases 2–4 of the #7993 meta-issue). A `Privileged Client Lint` CI check (#8161) now enforces the boundary — new backend code that tries to use the pod-SA for cluster mutations will fail CI.
+
+Additionally, `pods/exec` now has an explicit RBAC authorization check (#8134) — the backend verifies the user has `pods/exec` permission before opening an exec stream, closing a privilege-escalation gap.
 
 ### MCP Bridge
 

--- a/docs/content/console/drasi-dashboard.md
+++ b/docs/content/console/drasi-dashboard.md
@@ -1,0 +1,118 @@
+---
+title: "Drasi Reactive Pipeline Dashboard"
+linkTitle: "Drasi Dashboard"
+weight: 18
+description: >
+  Visualize, manage, and consume Drasi reactive data pipelines — Sources, Continuous Queries, and Reactions — directly from the KubeStellar Console.
+keywords:
+  - drasi
+  - reactive pipelines
+  - continuous queries
+  - server-sent events
+  - SSE streaming
+  - kubernetes event-driven
+---
+
+# Drasi Reactive Pipeline Dashboard
+
+The `/drasi` dashboard provides a real-time visualization of [Drasi](https://drasi.io) reactive data pipelines — Sources, Continuous Queries, and Reactions — with full CRUD management, live SSE streaming, and per-language code samples for consuming query result streams.
+
+Drasi is a CNCF Sandbox project by Microsoft that enables continuous, event-driven queries over changing data. The console integration supports all three Drasi deployment modes equally: **drasi-server** (standalone REST), **drasi-platform** (Kubernetes operator), and **drasi-lib** (embedded Rust, via drasi-server REST).
+
+## Getting started
+
+### Demo mode (no Drasi install required)
+
+Navigate to `/drasi` on your console. Without any configuration, the card runs in **demo mode** with four pre-seeded Drasi connections (retail-analytics, iot-telemetry, fraud-detection, supply-chain) — each showing a different themed pipeline with three independent flows. Switch between servers and flows using the dropdowns at the top of the card.
+
+### Live mode (real Drasi install)
+
+1. Open the Drasi Reactive Graph card.
+2. Click the ⚙ gear icon in the header strip → **"Drasi Connections"** modal.
+3. Click **"+ Add Connection"**.
+4. Choose mode:
+   - **drasi-server (REST)** — enter the URL (e.g., `http://localhost:8090`).
+   - **drasi-platform (Kubernetes)** — enter the kubeconfig context name (e.g., `prow`).
+5. Save and select the new connection → the card fetches real Sources, Continuous Queries, and Reactions from your install.
+
+If you don't have Drasi installed yet, click the **"Install Drasi"** banner at the top of the card → it deep-links to the `/missions/install-drasi` AI mission.
+
+## Features
+
+### Pipeline visualization
+
+The card renders a 6-column grid layout:
+
+- **Sources** (left) — HTTP, Postgres, CosmosDB, Gremlin, SQL data sources
+- **Continuous Queries** (center) — Cypher/GQL queries that run continuously over the sources
+- **Reactions** (right) — SSE, SignalR, Webhook, Kafka subscribers to query results
+
+Animated SVG flow lines connect sources → queries → reactions with state-aware colors:
+- Emerald = active flow
+- Slate = idle
+- Red = error
+- Grey = stopped
+
+Lines animate with traffic dots whose count and spacing vary per line (solo dot, tight cluster, even stream, burst + trail). Hover any node to highlight its connected subgraph and dim everything else.
+
+### Flow discovery
+
+The card automatically derives **flows** (connected components of the source→query→reaction graph) and exposes them in a **Flow** dropdown next to the server selector. Select a flow to focus the view on one pipeline at a time.
+
+In demo mode each themed server has 3 disjoint flows — for example, `retail-analytics` has `abandoned-carts`, `low-stock-alerts`, and `vip-customer-activity`.
+
+### Full CRUD
+
+- **Create**: Click the **+** button next to any column header (Sources, Continuous Queries, Reactions) to add a new resource. Sources and Queries open a Configure modal; Reactions create a default SSE reaction.
+- **Edit**: Click the ⚙ gear icon on any node card to open the Configure modal. The Continuous Query modal includes a **CodeMirror editor** with Cypher syntax highlighting.
+- **Delete**: Click the 🗑 trash icon on any node card → a themed confirm dialog (not a browser `window.confirm`) asks for confirmation before calling DELETE through the proxy.
+- **Download YAML**: Inside any Source or Query Configure modal (edit mode), click **"Download YAML"** to export the resource spec as a `.yaml` file.
+
+All mutations route through the backend's generic `/api/drasi/proxy/*` reverse proxy, which forwards to either the drasi-server REST API or the drasi-platform in-cluster API based on the active connection.
+
+### Live results streaming
+
+When a drasi-server connection is active, clicking a Continuous Query populates a **live results table** via Server-Sent Events (SSE). The table:
+- Shows dynamic columns derived from the query's result schema
+- Updates in real-time as result deltas (`added`, `updated`, `deleted`) arrive
+- Supports **column sorting** (click any header → asc → desc → clear)
+- Supports **row detail drawer** (click any row → slide-in right panel with the full JSON)
+
+For drasi-platform connections, an **"Enable live results"** button appears that one-click-creates a Result reaction scoped to the selected query.
+
+### Code samples ("Consume this stream")
+
+Click **"Consume stream"** in the header strip (or in the results-table header) to open a drawer with per-language snippets showing how to subscribe to the Drasi SSE output from external code:
+
+- **JavaScript** (browser `EventSource`)
+- **Node.js** (`eventsource` npm package)
+- **Python** (`httpx` streaming)
+- **curl**
+- **Go** (`net/http` + `bufio`)
+- **C# / .NET** (`HttpClient`)
+
+Snippets are templated with the real stream URL in live mode, or a placeholder URL in demo mode. Each has a copy button.
+
+### Pipeline KPIs
+
+A strip above the graph shows four at-a-glance counters: Events/s, Result Rows, Sources, and Reactions. In live mode these track the SSE stream's row arrival rate; in demo mode they're derived from the rolling result set.
+
+## Connection management
+
+Connections are stored in the browser's `localStorage` — no backend persistence required. Environment variables (`VITE_DRASI_SERVER_URL`, `VITE_DRASI_PLATFORM_CLUSTER`) are auto-seeded into the list on first use so existing deployments keep working without manual setup.
+
+The connections modal supports full CRUD (add, edit, delete, select) modeled after the AI/ML endpoint management pattern.
+
+## Drasi deployment modes
+
+| Mode | How the console reaches it | Configuration |
+|---|---|---|
+| **drasi-server** (standalone) | Direct REST calls via `/api/drasi/proxy?target=server&url=<url>` | Connection URL in the manager |
+| **drasi-platform** (Kubernetes) | K8s API Service proxy via `/api/drasi/proxy?target=platform&cluster=<ctx>` | Connection cluster context in the manager |
+| **drasi-lib** (embedded Rust) | Same as drasi-server — embedders expose the standard REST API | Connection URL pointing at the embedder's endpoint |
+
+## Related
+
+- [Drasi project](https://drasi.io) — official Drasi documentation
+- Upstream issues filed during integration: [drasi-project/drasi-platform#425](https://github.com/drasi-project/drasi-platform/issues/425), [#426](https://github.com/drasi-project/drasi-platform/issues/426), [#427](https://github.com/drasi-project/drasi-platform/issues/427)
+- Console PRs: #8158 (real integration), #8163 (visual polish), #8186 (Wave A — CRUD), #8199 (Wave B — CodeMirror + sorting), #8208 (Wave C — connections + stream samples), #8215 (flows + themes), #8222 (confirm modal + layout fixes)

--- a/docs/content/console/security-model.md
+++ b/docs/content/console/security-model.md
@@ -135,6 +135,19 @@ Report security issues following the project's security policy:
 - **KubeStellar Console** — [`docs/security/SECURITY-MODEL.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) links to the disclosure process and the upstream self-assessment at [`docs/security/SELF-ASSESSMENT.md`](https://github.com/kubestellar/console/blob/main/docs/security/SELF-ASSESSMENT.md).
 - **Upstream CNCF projects** — every install mission in the console links to the target project's own security policy. Report per-project vulnerabilities upstream, not to us.
 
+## AI automation threat model
+
+The console also has an **AI-specific security document** covering the threat surfaces of its LLM-backed workflows (Claude Code review, auto-qa, GA4 error monitor, kc-agent/MCP). It addresses six threat categories: external prompt injection, insider/compromised credentials, DoS/resource exhaustion, agent drift, supply chain, and agent-to-agent injection.
+
+See [`docs/security/SECURITY-AI.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-AI.md) in the console repo for the full threat model and audit checklist.
+
+## Recent security hardening (Apr 2026)
+
+- **pods/exec RBAC check** (#8134) — the backend now verifies the user has `pods/exec` permission before opening an exec WebSocket stream, closing a privilege-escalation gap.
+- **RefreshToken body leak** (#8107) — fixed a regression where the token refresh endpoint returned the token in the JSON body in addition to the HttpOnly cookie.
+- **Privileged Client Lint** (#8161) — new CI check that enforces the pod-SA rule: backend code that tries to use the pod ServiceAccount for cluster mutations fails CI automatically.
+- **kc-agent migration (phases 2–4)** — cluster-mutating operations (Helm, ArgoCD, kubectl sync, GPU health, namespaces) moved from the pod-SA backend to kc-agent, reducing the backend's attack surface.
+
 ## Further reading
 
 - [Architecture](architecture.md) — broader system design of the console
@@ -142,3 +155,4 @@ Report security issues following the project's security policy:
 - [AI Features](ai-features.md) — what the AI missions do
 - [Authentication](authentication.md) — GitHub OAuth setup
 - [`docs/security/SECURITY-MODEL.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md) — the canonical source-grounded version of this document
+- [`docs/security/SECURITY-AI.md`](https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-AI.md) — AI automation threat model (prompt injection, supply chain, agent drift)


### PR DESCRIPTION
## Summary

Covers **523 console PRs** merged since the last sync (PR #1379, Apr 9).

### New pages

- **`docs/content/console/drasi-dashboard.md`** — Full page for the Drasi reactive pipeline dashboard (\`/drasi\`). Covers demo mode (4 themed servers × 3 flows each), live mode (connection CRUD), visualization, flow discovery, CRUD, SSE streaming, CodeMirror Cypher editor, "Consume stream" 6-language code-sample drawer, pipeline KPIs. All 3 Drasi deployment modes documented.

- **`docs/content/console/acmm-dashboard.md`** — Full page for the AI Codebase Maturity Model dashboard (\`/acmm\`). 4 cards driven by a single GitHub scan: level gauge (L1–L5), balance trend chart, feedback-loop inventory, and role-aware recommendations. References the arXiv paper.

### Updated pages

- **`all-cards.md`** — Added Drasi Reactive Graph (#122), Keycloak Monitoring (#123), and 4 ACMM cards (#124-127).

- **`architecture.md`** — New "kc-agent migration (Apr 2026)" section covering phases 2–4 of the #7993 meta-issue: Helm, ArgoCD, kubectl sync, GPU health, namespace ops all moved from pod-SA to kc-agent. Also mentions the new Privileged Client Lint CI check and pods/exec RBAC hardening.

- **`security-model.md`** — New "AI automation threat model" section cross-referencing \`SECURITY-AI.md\` (prompt injection, supply chain, agent drift). New "Recent security hardening" section covering pods/exec RBAC (#8134), RefreshToken body leak (#8107), Privileged Client Lint (#8161), kc-agent migration.

- **`ai-features.md`** — Note that the top-level navbar button was renamed from "AI" to "Agent" (#8209). Existing screenshots may show the old label.

### Key features covered

| Feature | Console PR(s) |
|---|---|
| Drasi dashboard (14 PRs total) | #8158, #8163, #8186, #8199, #8208, #8215, #8222, #8233, etc. |
| ACMM dashboard (4 cards + Netlify scan function) | #8260 |
| Groq + OpenRouter AI providers | #8166, #8047 |
| Local LLM providers (Ollama, llama.cpp, LocalAI, vLLM, LM Studio, RHAIIS) | #8248, #8256 |
| Keycloak monitoring card | #6893 |
| Windows (WSL2) agent setup | #6238 |
| kc-agent migration phases 2–4 | #8028, #8033, #8036, #8038, #8039, #8044 |
| pods/exec RBAC hardening | #8134 |
| RefreshToken body leak fix | #8107 |
| "AI" → "Agent" navbar rename | #8209 |
| SECURITY-AI.md threat model | #8249 |
| Tier-based change classification | #8251 |
| Dead Copilot workflow cleanup | #8252 |
| Decomposed Claude Code review prompt | #8253 |
| Services card: TTL, port names, orphaned detection | #6177 |
| Remove cluster button | #6097, #5908 |
| AI Missions + button | #6101 |
| WorkloadDeployment reconciliation loop | #6934 |
| Rewards + token usage persistence | #6032 |

### No screenshots

CDP was not available during this sync. Screenshots can be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)