### PR TITLE
🐛 fix(navbar): remove conflicting hidden/lg:flex from GitHub dropdown menu (#1468)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -926,7 +926,7 @@ export default function Navbar() {
                 </div>
                 <div
                   data-dropdown-menu
-                  className="absolute hidden lg:flex right-0 mt-1 w-48 bg-gray-800/95 backdrop-blur-sm rounded-md shadow-lg border border-gray-700 before:content-[''] before:absolute before:bottom-full before:left-0 before:right-0 before:h-2 before:bg-transparent"
+                  className="absolute right-0 mt-1 w-48 bg-gray-800/95 backdrop-blur-sm rounded-md shadow-lg border border-gray-700 before:content-[''] before:absolute before:bottom-full before:left-0 before:right-0 before:h-2 before:bg-transparent"
                   style={{ display: "none" }}
                 >
                   <a


### PR DESCRIPTION
## Summary

- The GitHub dropdown menu in `src/components/Navbar.tsx` had both `className="absolute hidden lg:flex ..."` AND `style={{ display: "none" }}` applied simultaneously
- When the init script ran `menu.style.display = "block"`, inline style won the specificity battle but the `lg:flex` layout class was still sitting on the element, creating contradictory display declarations
- The sibling Contribute / Community dropdowns in the same file use the clean pattern — class owns layout, inline style owns show/hide. Aligned the GitHub dropdown to match
- Removed `hidden lg:flex` from the menu's className; the parent wrapper is already `hidden lg:flex` so the dropdown is already gated to large screens

## Test plan

- [x] `npm run build` — passes
- [ ] Hover the GitHub icon in the navbar at ≥1024px — dropdown opens as before
- [ ] Inspect the menu DOM — class no longer contains `hidden lg:flex`; only inline `style="display: block/none"` controls visibility

Fixes #1468