### PR TITLE
📝 fix: replace outdated Netlify URL with canonical console.kubestellar.io

### DIFF
--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -17,7 +17,7 @@ keywords:
 
 This guide covers all deployment options for KubeStellar Console, the multi-cluster Kubernetes dashboard with AI-powered operations.
 
-> **Try it first!** See a live preview at [kubestellarconsole.netlify.app](https://kubestellarconsole.netlify.app)
+> **Try it first!** See a live preview at [console.kubestellar.io](https://console.kubestellar.io)
 
 ---
 

--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -16,7 +16,7 @@ keywords:
 
 Get KubeStellar Console running locally for development or evaluation.
 
-> **Try it first!** See a live preview at [kubestellarconsole.netlify.app](https://kubestellarconsole.netlify.app) - no installation needed.
+> **Try it first!** See a live preview at [console.kubestellar.io](https://console.kubestellar.io) - no installation needed.
 
 !!! important "Claude Code is required for AI features"
     This Quick Start uses **[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)**, Anthropic's CLI tool, to install and manage the kubestellar-mcp plugins that connect the console to your clusters. Claude Code requires an Anthropic API subscription.


### PR DESCRIPTION
## Summary
- Replace `kubestellarconsole.netlify.app` with `console.kubestellar.io` in `quickstart.md` and `installation.md`
- Transferred from kubestellar/console#8412

## Test plan
- [ ] Verify links in quickstart and installation docs point to `console.kubestellar.io`

Fixes kubestellar/console#8412
Fixes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)