### PR TITLE
🐛 fix(leaderboard): link social column to GitHub profiles, add affiliate CTA

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -165,25 +165,36 @@ function BreakdownPills({ breakdown }: { breakdown: LeaderboardBreakdown }) {
 
 // ── Social/affiliate badge ────────────────────────────────────────────
 
-function SocialBadge({ data }: { data: AffiliateData | undefined }) {
-  if (!data) return null;
-  if (data.clicks === 0) {
+function SocialBadge({ login, data }: { login: string; data: AffiliateData | undefined }) {
+  const githubUrl = `https://github.com/${login}`;
+  if (!data || data.clicks === 0) {
     return (
-      <span className="text-xs text-gray-600" title="No affiliate clicks yet">
-        —
-      </span>
+      <a
+        href={githubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-gray-600 hover:text-gray-400 transition-colors"
+        title={`View ${login} on GitHub`}
+      >
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+      </a>
     );
   }
   return (
-    <span
-      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-pink-400 bg-pink-500/10"
-      title={`${data.clicks} clicks from ${data.unique_users} unique users via affiliate link`}
+    <a
+      href={githubUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-pink-400 bg-pink-500/10 hover:bg-pink-500/20 transition-colors"
+      title={`${data.clicks} clicks from ${data.unique_users} unique users via affiliate link — view ${login} on GitHub`}
     >
       <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
       </svg>
       {data.clicks}
-    </span>
+    </a>
   );
 }
 
@@ -473,7 +484,7 @@ export default function LeaderboardPage() {
 
                     {/* Social */}
                     <div className="flex justify-start sm:justify-center pl-11 sm:pl-0">
-                      <SocialBadge data={affiliateData[entry.login]} />
+                      <SocialBadge login={entry.login} data={affiliateData[entry.login]} />
                     </div>
 
                     {/* Breakdown */}
@@ -516,6 +527,33 @@ export default function LeaderboardPage() {
                 <p className="mt-4 text-xs text-gray-600">
                   This leaderboard tracks GitHub contributions only (PRs, issues). Your total in the console may be higher because it includes coins earned from in-app activity (missions, games, sharing) which are stored locally in your browser.
                 </p>
+              </div>
+            )}
+
+            {/* Affiliate program CTA */}
+            {!isLoading && !error && filteredEntries.length > 0 && (
+              <div className="mt-8 bg-gradient-to-r from-pink-500/10 via-purple-500/10 to-blue-500/10 backdrop-blur-md rounded-lg border border-white/10 p-6">
+                <h3 className="text-sm font-semibold text-white mb-2 flex items-center gap-2">
+                  <svg className="w-4 h-4 text-pink-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                  </svg>
+                  Earn Social Clicks with Your Affiliate Link
+                </h3>
+                <p className="text-sm text-gray-300 mb-3">
+                  Share any KubeStellar URL with your personal UTM tag and get credited on the leaderboard.
+                  Open to <span className="text-white font-medium">anyone with a GitHub account</span>.
+                </p>
+                <div className="bg-gray-900/60 rounded-md p-3 font-mono text-xs text-gray-400 overflow-x-auto">
+                  <span className="text-gray-500">https://console.kubestellar.io</span>
+                  <span className="text-pink-400">?utm_source=social&amp;utm_medium=</span>
+                  <span className="text-purple-400">linkedin</span>
+                  <span className="text-pink-400">&amp;utm_campaign=contributor_affiliate&amp;utm_term=</span>
+                  <span className="text-blue-400">your-github-handle</span>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-4 text-xs text-gray-500">
+                  <span><code className="text-pink-400">utm_term</code> = your GitHub handle, lowercase</span>
+                  <span><code className="text-pink-400">utm_medium</code> = twitter, linkedin, blog, youtube, devto, etc.</span>
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Social column now shows a clickable GitHub icon for **every** contributor (previously returned `null` for those without affiliate data)
- Contributors with affiliate clicks still get the pink badge, but it links to their GitHub profile instead of being a static span
- Adds an affiliate program CTA below the point values section explaining the UTM format — open to anyone with a GitHub account, not just intern-style handles

## Changes

**`src/app/[locale]/leaderboard/page.tsx`:**
- `SocialBadge` now takes a `login` prop and always renders (GitHub icon for 0 clicks, pink badge+link for >0 clicks)
- New "Earn Social Clicks with Your Affiliate Link" section with the UTM format and parameter docs

## Test plan

- [x] `npx next build` passes
- [ ] Verify on Netlify preview: social column shows GitHub icons for all contributors
- [ ] Verify affiliate badge links to `https://github.com/{login}` for contributors with clicks
- [ ] Verify affiliate CTA section renders below point values