### PR TITLE
🐛 fix: replace window.closeLangSwitcher with React-free event pattern (#1456)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -62,11 +62,7 @@ export default function Navbar() {
             });
 
             // Close language switcher when hovering other dropdowns
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            if (typeof (window as any).closeLangSwitcher === "function") {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (window as any).closeLangSwitcher();
-            }
+            document.dispatchEvent(new CustomEvent("close-lang-switcher"));
 
             // Ensure menu is visible
             menu.style.display = "block";
@@ -145,11 +141,7 @@ export default function Navbar() {
           });
 
           // Also close language switcher
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if (typeof (window as any).closeLangSwitcher === "function") {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (window as any).closeLangSwitcher();
-          }
+          document.dispatchEvent(new CustomEvent("close-lang-switcher"));
 
           setIsDropdownOpen(false);
           setIsContributeOpen(false);
@@ -326,20 +318,15 @@ export default function Navbar() {
           }
         };
 
-        // Add method to global scope for other dropdowns to call
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).closeLangSwitcher = closeLangSwitcher;
+        // Listen for close events dispatched by other dropdowns
+        document.addEventListener("close-lang-switcher", closeLangSwitcher);
 
         langSwitcher.addEventListener("mouseenter", handleMouseEnter);
         langSwitcher.addEventListener("mouseleave", handleMouseLeave);
         cleanups.push(() => {
           langSwitcher.removeEventListener("mouseenter", handleMouseEnter);
           langSwitcher.removeEventListener("mouseleave", handleMouseLeave);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if ((window as any).closeLangSwitcher === closeLangSwitcher) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (window as any).closeLangSwitcher = undefined;
-          }
+          document.removeEventListener("close-lang-switcher", closeLangSwitcher);
         });
 
         // Handle dropdown menu hover with improved detection


### PR DESCRIPTION
## Summary

- Replaces global `window.closeLangSwitcher` with a custom DOM event (`close-lang-switcher`) dispatched on `document`
- Eliminates global namespace pollution, removes 6 `eslint-disable` comments, and ensures proper cleanup on unmount
- No behavior change — dropdown hover and Escape key still close the language switcher

## Details

The Navbar component attached `closeLangSwitcher` to the global `window` object so that dropdown hover handlers and the Escape key handler could close the LanguageSwitcher dropdown. This is an anti-pattern:

1. **Global namespace pollution** — any script can overwrite it
2. **Fragile coupling** — callers must check `typeof window.closeLangSwitcher === "function"` before calling
3. **No type safety** — required `(window as any)` casts and eslint-disable comments

The fix uses `document.dispatchEvent(new CustomEvent("close-lang-switcher"))` at the call sites and `document.addEventListener("close-lang-switcher", closeLangSwitcher)` at the registration site. Cleanup removes the listener on unmount.

Fixes #1456

## Test plan

- [ ] Hover over nav dropdowns (Contribute, Community, GitHub) — language switcher should close
- [ ] Hover over language switcher — other dropdowns should close
- [ ] Press Escape — all dropdowns including language switcher should close
- [ ] Navigate away and back — no stale event listeners