### PR TITLE
🐛 fix(leaderboard): restore Social column to show affiliate clicks

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -165,36 +165,24 @@ function BreakdownPills({ breakdown }: { breakdown: LeaderboardBreakdown }) {
 
 // ── Social/affiliate badge ────────────────────────────────────────────
 
-function SocialBadge({ login, data }: { login: string; data: AffiliateData | undefined }) {
-  const githubUrl = `https://github.com/${login}`;
+function SocialBadge({ data }: { data: AffiliateData | undefined }) {
   if (!data || data.clicks === 0) {
     return (
-      <a
-        href={githubUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-xs text-gray-600 hover:text-gray-400 transition-colors"
-        title={`View ${login} on GitHub`}
-      >
-        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-        </svg>
-      </a>
+      <span className="text-xs text-gray-600" title="No affiliate clicks yet">
+        —
+      </span>
     );
   }
   return (
-    <a
-      href={githubUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-pink-400 bg-pink-500/10 hover:bg-pink-500/20 transition-colors"
-      title={`${data.clicks} clicks from ${data.unique_users} unique users via affiliate link — view ${login} on GitHub`}
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-pink-400 bg-pink-500/10"
+      title={`${data.clicks} clicks from ${data.unique_users} unique users via affiliate link`}
     >
       <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
       </svg>
       {data.clicks}
-    </a>
+    </span>
   );
 }
 
@@ -484,7 +472,7 @@ export default function LeaderboardPage() {
 
                     {/* Social */}
                     <div className="flex justify-start sm:justify-center pl-11 sm:pl-0">
-                      <SocialBadge login={entry.login} data={affiliateData[entry.login]} />
+                      <SocialBadge data={affiliateData[entry.login]} />
                     </div>
 
                     {/* Breakdown */}


### PR DESCRIPTION
## Summary

- Reverts PR #1490's change that replaced affiliate click counts with GitHub profile icons in the Social column
- Restores the original behavior: dash (`—`) for users with no clicks, pink click-count badge for users with clicks
- GitHub profile links are already available in the Contributor column, so the Social column was redundant

## Context

The Social column's purpose is to show affiliate link click counts (as indicated by its tooltip "Affiliate link clicks from social sharing"). PR #1490 changed it to show GitHub profile icons for everyone, which confused users into thinking the click data was replaced with GitHub IDs.

Fixes #1492

## Test plan

- [ ] Verify the leaderboard Social column shows `—` for contributors without affiliate data
- [ ] Verify contributors with affiliate clicks (e.g., rishi-jat, xonas1101) show the pink click-count badge
- [ ] Verify the GitHub profile link in the Contributor column still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)