### PR TITLE
🐛 Fix TOC active heading highlighting on scroll (#1494)

### DIFF
--- a/src/components/docs/TableOfContents.tsx
+++ b/src/components/docs/TableOfContents.tsx
@@ -73,8 +73,8 @@ export function TableOfContents({ toc }: TableOfContentsProps) {
         });
       },
       {
-        rootMargin: '0px 0px -80% 0px',
-        threshold: 1.0,
+        rootMargin: '-20% 0px -60% 0px',
+        threshold: 0,
       }
     );
 


### PR DESCRIPTION
### 📌 Fixes

Fixes #1494

---

### 📝 Summary of Changes

- Fixed the `IntersectionObserver` configuration in `src/components/docs/TableOfContents.tsx` which was incorrectly preventing the active heading indicator from highlighting as the user scrolls.
- Updated `threshold` to `0` and optimized `rootMargin` to track an intersection zone properly matching industry-standard documentation sites, ensuring high visibility of the active scroll tracker.

---

### Changes Made

- [x] Updated `src/components/docs/TableOfContents.tsx` intersection parameters.
- [ ] Refactored 
- [x] Fixed broken / incorrectly updating Table of Contents active-link highlighting on long document views.
- [ ] Added tests for 

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.

---

### Screenshots or Logs (if applicable)

*N/A - Functional fix adjusting standard viewport observer physics.*

---

### 👀 Reviewer Notes

_The original `IntersectionObserver` config demanded a `1.0` threshold paired with a `-80%` bottom margin cut-off. This paradoxically forced headings to be absolutely 100% visible inside a very narrow 20% viewport slice relative to the screen size. By migrating to a `threshold: 0` approach, any intersection within the specifically designated offset zone (`-20% 0px -60% 0px`) triggers an update, rendering the Table of Contents infinitely smoother and more reliable._
