### PR TITLE
🐛 Retry affiliate fetch so leaderboard social column isn't empty on cold start

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -47,8 +47,13 @@ interface AffiliateData {
 
 /** URL for the affiliate clicks API (hosted on console.kubestellar.io) */
 const AFFILIATE_API_URL = "https://console.kubestellar.io/api/affiliate/clicks";
-/** Fetch timeout for affiliate data (5 seconds — non-critical) */
-const AFFILIATE_FETCH_TIMEOUT_MS = 5_000;
+/** Fetch timeout for affiliate data (15 seconds — the console.kubestellar.io
+ *  endpoint is served by Netlify Functions which can cold-start past a
+ *  tighter budget on first visit, making the social section appear empty
+ *  until the user refreshes the page). */
+const AFFILIATE_FETCH_TIMEOUT_MS = 15_000;
+/** Delay before retrying a failed affiliate fetch (ms). One retry only. */
+const AFFILIATE_RETRY_DELAY_MS = 2_000;
 
 // ── Contributor level colors (mirrors console's CONTRIBUTOR_LEVELS) ───
 
@@ -271,15 +276,27 @@ export default function LeaderboardPage() {
   }, [fetchLeaderboard]);
 
   // Fetch affiliate click data (non-blocking, best-effort)
+  // Retries once after a short delay so the social section doesn't show
+  // empty after a cold-start timeout on the first page load (#8858).
   useEffect(() => {
-    fetch(AFFILIATE_API_URL, {
-      signal: AbortSignal.timeout(AFFILIATE_FETCH_TIMEOUT_MS),
-    })
-      .then((res) => (res.ok ? res.json() : {}))
-      .then((json: Record<string, AffiliateData>) => setAffiliateData(json))
-      .catch(() => {
-        // Affiliate data is optional — silently ignore failures
-      });
+    const fetchAffiliates = () =>
+      fetch(AFFILIATE_API_URL, {
+        signal: AbortSignal.timeout(AFFILIATE_FETCH_TIMEOUT_MS),
+      })
+        .then((res) => (res.ok ? res.json() : {}))
+        .then((json: Record<string, AffiliateData>) => setAffiliateData(json));
+
+    let retryHandle: ReturnType<typeof setTimeout> | undefined;
+    fetchAffiliates().catch(() => {
+      retryHandle = setTimeout(() => {
+        fetchAffiliates().catch(() => {
+          // Both attempts failed — affiliate data is optional; leave empty.
+        });
+      }, AFFILIATE_RETRY_DELAY_MS);
+    });
+    return () => {
+      if (retryHandle) clearTimeout(retryHandle);
+    };
   }, []);
 
   const filteredEntries = useMemo(() => {


### PR DESCRIPTION
## Summary

Cross-repo fix for **[kubestellar/console#8858](https://github.com/kubestellar/console/issues/8858)** — reporter @xonas1101 via the Console feedback flow: "On opening the leaderboard, no values are loaded initially for the social section. However after a refresh or two, it loads."

### Root cause

The affiliate data comes from `https://console.kubestellar.io/api/affiliate/clicks`, which is served by Netlify Functions and can cold-start past a 5-second budget. The existing `.catch(() => {})` silently swallowed the `AbortError` and left `affiliateData` as `{}` until the next full page load. On refresh the endpoint is warm, so the fetch succeeds — matching the reporter's symptom exactly.

### Fix

In `src/app/[locale]/leaderboard/page.tsx`:

1. Bump `AFFILIATE_FETCH_TIMEOUT_MS` from 5s → 15s so a cold start usually succeeds on the first try.
2. On failure, retry once after `AFFILIATE_RETRY_DELAY_MS` (2s). Both attempts share the same success handler. If the second also fails we keep the existing silent-fallback behavior (affiliate data is optional; the leaderboard itself still renders).
3. Add a `useEffect` cleanup that clears the retry timeout on unmount.

### Scope

+27 / -10 in a single file. No changes to the happy-path or to the independent leaderboard-entries fetch.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/app/[locale]/leaderboard/page.tsx` — clean
- [ ] Manual verify on deploy-preview: open `/leaderboard` after the Netlify Function has been idle; social column should populate within ~17s worst case (15s timeout + 2s retry buffer) instead of requiring a page refresh.

Reported-by: @xonas1101 via kubestellar/console#8858