### PR TITLE
📖 docs(leaderboard): explain why Social click counts may look stuck

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -559,6 +559,35 @@ export default function LeaderboardPage() {
                   <span><code className="text-pink-400">utm_term</code> = your GitHub handle, lowercase</span>
                   <span><code className="text-pink-400">utm_medium</code> = twitter, linkedin, blog, youtube, devto, etc.</span>
                 </div>
+
+                {/* Why counts may look "stuck" — reduce support churn */}
+                <details className="mt-4 text-xs text-gray-500">
+                  <summary className="cursor-pointer text-gray-400 hover:text-white transition-colors">
+                    Why is my Social count not updating?
+                  </summary>
+                  <ul className="mt-2 ml-4 list-disc space-y-1.5">
+                    <li>
+                      <span className="text-gray-300">Google Analytics attribution lag:</span> The
+                      <code className="mx-1 text-pink-400">utm_campaign</code> /
+                      <code className="mx-1 text-pink-400">utm_term</code> dimensions take
+                      <span className="text-white font-medium"> 24&ndash;48 hours</span> to finalize after a click.
+                      Same-day shares typically appear here the next day.
+                    </li>
+                    <li>
+                      <span className="text-gray-300">Chat apps strip UTM tags:</span> WhatsApp, Discord, Messenger, and some LinkedIn preview renderers strip the
+                      <code className="mx-1 text-pink-400">?utm_*=&hellip;</code> query string when generating link previews. Recipients who click the previewed
+                      (un-tagged) link land as <span className="text-gray-400">direct</span> / <span className="text-gray-400">(not set)</span> traffic and cannot be credited back to you. Prefer plain-text shares via email, SMS, GitHub comments, or blog posts where the query string is preserved.
+                    </li>
+                    <li>
+                      <span className="text-gray-300">Sessions, not page views:</span> One recipient clicking your link multiple times within a 30-minute window counts as a single session. To grow the count, share to
+                      <span className="text-white"> more people</span>, not the same people more often.
+                    </li>
+                    <li>
+                      <span className="text-gray-300">Legacy <code className="text-pink-400">intern-0X</code> links keep working,</span> but new shares should use
+                      <code className="mx-1 text-pink-400">utm_term=your-github-handle</code> so credits roll up under your GitHub identity rather than a numbered slot.
+                    </li>
+                  </ul>
+                </details>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Adds a collapsible "Why is my Social count not updating?" block below the existing "Earn Social Clicks" CTA on the leaderboard page. Covers four real reasons contributors see counts that don't match the number of people they shared with, so maintainers stop fielding the same Slack question from every new intern.

## Reasons documented

1. **GA4 attribution lag** — `utm_campaign` / `utm_term` take 24-48h to finalize.
2. **Chat apps strip UTM tags** — WhatsApp/Discord/Messenger preview-renderers drop the `?utm_*=` query string; recipients land as `direct`/`(not set)`.
3. **Sessions, not page views** — repeat clicks from the same person in a 30-min window count as 1.
4. **Legacy `intern-0X` still works**, but new shares should use `utm_term=<github-handle>` so credits roll up under GitHub identity.

## Context

Slack reports (2026-04-20) from Rishi, Ghanshyam, Arnav, Aarush, Arpit all asking why their counts were stuck. Investigation on the GA4 side confirmed the counts are accurate — the reports reflect real data leaks (mostly UTM stripping in chat apps).

## Paired PR

- `kubestellar/console#9153` — fixes a silent-drop bug in the affiliate-clicks Netlify function where `utm_campaign=intern_outreach` + `utm_term=<github-login>` rows were dropped entirely.

## Test plan

- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [ ] Manual: visit `/leaderboard`, click the new collapsible, verify copy renders correctly and matches the tone of the surrounding page.