### PR TITLE
feat: contributor hover card on leaderboard usernames

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -196,6 +196,239 @@ function SocialBadge({ data, loading }: { data: AffiliateData | undefined; loadi
   );
 }
 
+// ── Contributor hover card ────────────────────────────────────────────
+
+interface CadenceData {
+  avg_per_week: number;
+  by_day_of_week: number[];
+  by_hour_of_day: number[];
+  current_streak_weeks: number;
+  longest_streak_weeks: number;
+  trend: "ramping_up" | "steady" | "slowing_down" | "inactive";
+}
+
+interface TimelineEntry {
+  month: string;
+  issue_count: number;
+}
+
+interface ContributorPreview {
+  login: string;
+  avatar_url: string;
+  total_points: number;
+  total_issues_opened: number;
+  level: string;
+  rank: number;
+  cadence: CadenceData;
+  activity_timeline: TimelineEntry[];
+}
+
+const TREND_DISPLAY: Record<string, { label: string; color: string; arrow: string }> = {
+  ramping_up: { label: "Ramping Up", color: "text-green-400", arrow: "\u2191" },
+  steady: { label: "Steady", color: "text-blue-400", arrow: "\u2192" },
+  slowing_down: { label: "Slowing Down", color: "text-yellow-400", arrow: "\u2193" },
+  inactive: { label: "Inactive", color: "text-gray-500", arrow: "\u2014" },
+};
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+/** Delay (ms) before fetching contributor data on hover — avoids fetch spam on quick mouse passes. */
+const HOVER_FETCH_DELAY_MS = 300;
+
+const profileCache = new Map<string, ContributorPreview>();
+
+function ContributorHoverCard({
+  login,
+  onClose,
+}: {
+  login: string;
+  onClose: () => void;
+}) {
+  const [data, setData] = useState<ContributorPreview | null>(profileCache.get(login) || null);
+  const [loading, setLoading] = useState(!profileCache.has(login));
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (profileCache.has(login)) {
+      setData(profileCache.get(login)!);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/data/contributors/${login}.json`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json: ContributorPreview | null) => {
+        if (cancelled || !json) return;
+        profileCache.set(login, json);
+        setData(json);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [login]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  if (loading) {
+    return (
+      <div
+        ref={cardRef}
+        className="absolute left-0 top-full mt-2 z-50 w-80 bg-gray-900/95 backdrop-blur-lg rounded-xl border border-white/10 shadow-2xl p-4"
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-gray-700 animate-pulse" />
+          <div className="flex-1 space-y-2">
+            <div className="h-3 w-24 bg-gray-700 rounded animate-pulse" />
+            <div className="h-2 w-16 bg-gray-700 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const style = LEVEL_STYLES[data.level] || LEVEL_STYLES.Observer;
+  const trend = TREND_DISPLAY[data.cadence.trend] || TREND_DISPLAY.inactive;
+  const maxDay = Math.max(...data.cadence.by_day_of_week, 1);
+  const maxHour = Math.max(...data.cadence.by_hour_of_day, 1);
+  const timelineMax = Math.max(...data.activity_timeline.map((t) => t.issue_count), 1);
+  /** Maximum bar height for timeline sparkline in pixels */
+  const SPARKLINE_BAR_MAX_PX = 32;
+  /** Minimum visible bar height in pixels */
+  const SPARKLINE_BAR_MIN_PX = 2;
+
+  return (
+    <div
+      ref={cardRef}
+      className="absolute left-0 top-full mt-2 z-50 w-96 bg-gray-900/95 backdrop-blur-lg rounded-xl border border-white/10 shadow-2xl overflow-hidden"
+      onMouseLeave={onClose}
+    >
+      {/* Header */}
+      <div className="p-4 pb-3 border-b border-white/5">
+        <div className="flex items-center gap-3">
+          <Image
+            src={data.avatar_url}
+            alt={data.login}
+            width={40}
+            height={40}
+            className="w-10 h-10 rounded-full"
+            unoptimized
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-white truncate">{data.login}</span>
+              <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium border ${style.bg} ${style.text} ${style.border}`}>
+                {data.level}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-gray-400 mt-0.5">
+              <span>Rank #{data.rank}</span>
+              <span className="text-yellow-400 font-semibold">{data.total_points.toLocaleString()} pts</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Cadence */}
+      <div className="px-4 py-3 border-b border-white/5">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] uppercase tracking-wider text-gray-500">Cadence</span>
+            {data.cadence.current_streak_weeks > 0 && (
+              <span className="text-[10px] text-orange-400" title={`Longest: ${data.cadence.longest_streak_weeks} weeks`}>
+                🔥 {data.cadence.current_streak_weeks}w streak
+              </span>
+            )}
+          </div>
+          <span className={`text-[10px] ${trend.color}`}>
+            {trend.arrow} {trend.label}
+          </span>
+        </div>
+        <div className="flex gap-4">
+          {/* By day */}
+          <div className="flex-1">
+            <div className="text-[9px] text-gray-600 mb-1">BY DAY</div>
+            <div className="flex gap-0.5">
+              {data.cadence.by_day_of_week.map((count, i) => {
+                const intensity = count / maxDay;
+                const MIN_CELL_OPACITY = 0.05;
+                return (
+                  <div key={DAY_LABELS[i]} className="flex flex-col items-center gap-0.5" title={`${DAY_LABELS[i]}: ${count}`}>
+                    <div
+                      className="w-5 h-5 rounded-sm border border-white/5"
+                      style={{ backgroundColor: `rgba(59, 130, 246, ${Math.max(MIN_CELL_OPACITY, intensity)})` }}
+                    />
+                    <span className="text-[7px] text-gray-600">{DAY_LABELS[i][0]}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          {/* By hour (compact — just a single row of 24 tiny cells) */}
+          <div className="flex-1">
+            <div className="text-[9px] text-gray-600 mb-1">BY HOUR (UTC)</div>
+            <div className="flex gap-px flex-wrap" style={{ maxWidth: "144px" }}>
+              {data.cadence.by_hour_of_day.map((count, h) => {
+                const intensity = count / maxHour;
+                const MIN_CELL_OPACITY = 0.05;
+                return (
+                  <div
+                    key={h}
+                    className="w-[5px] h-[5px] rounded-[1px]"
+                    style={{ backgroundColor: `rgba(59, 130, 246, ${Math.max(MIN_CELL_OPACITY, intensity)})` }}
+                    title={`${h}:00 UTC: ${count}`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Activity Timeline */}
+      <div className="px-4 py-3">
+        <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Activity Timeline</div>
+        <div className="flex items-end gap-px h-10">
+          {data.activity_timeline.map((entry) => {
+            const height = (entry.issue_count / timelineMax) * SPARKLINE_BAR_MAX_PX;
+            return (
+              <div
+                key={entry.month}
+                className="flex-1 bg-blue-500/40 rounded-t-sm"
+                style={{ height: `${Math.max(SPARKLINE_BAR_MIN_PX, height)}px` }}
+                title={`${entry.month}: ${entry.issue_count} issues`}
+              />
+            );
+          })}
+        </div>
+        <div className="flex justify-between mt-1">
+          <span className="text-[7px] text-gray-600">{data.activity_timeline[0]?.month.slice(5)}</span>
+          <span className="text-[7px] text-gray-600">{data.activity_timeline[data.activity_timeline.length - 1]?.month.slice(5)}</span>
+        </div>
+      </div>
+
+      {/* Footer link */}
+      <Link
+        href={`/leaderboard/${data.login}`}
+        className="block px-4 py-2 text-[10px] text-center text-blue-400 hover:text-blue-300 bg-white/[0.02] border-t border-white/5 transition-colors"
+      >
+        View full profile →
+      </Link>
+    </div>
+  );
+}
+
 // ── Leaderboard data URL ──────────────────────────────────────────────
 const LEADERBOARD_DATA_PATH = "/data/leaderboard.json";
 
@@ -237,6 +470,8 @@ export default function LeaderboardPage() {
   const [affiliateData, setAffiliateData] = useState<Record<string, AffiliateData>>({});
   const [affiliateLoading, setAffiliateLoading] = useState(true);
   const [affiliateBannerOpen, setAffiliateBannerOpen] = useState(false);
+  const [hoveredLogin, setHoveredLogin] = useState<string | null>(null);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchLeaderboard = useCallback(() => {
     fetch(LEADERBOARD_DATA_PATH)
@@ -494,7 +729,7 @@ export default function LeaderboardPage() {
 
             {/* Leaderboard table */}
             {!isLoading && !error && filteredEntries.length > 0 && (
-              <div className="bg-gray-800/40 backdrop-blur-md rounded-xl border border-white/10 overflow-hidden">
+              <div className="bg-gray-800/40 backdrop-blur-md rounded-xl border border-white/10 overflow-visible">
                 {/* Table header */}
                 <div className="hidden sm:grid sm:grid-cols-[60px_1fr_120px_120px_60px_1fr] gap-4 px-6 py-3 border-b border-white/5 text-xs text-gray-500 uppercase tracking-wider">
                   <div className="text-center">Rank</div>
@@ -535,7 +770,16 @@ export default function LeaderboardPage() {
                           {entry.login[0]?.toUpperCase()}
                         </div>
                       )}
-                      <div className="flex items-center gap-1.5 min-w-0">
+                      <div
+                        className="relative flex items-center gap-1.5 min-w-0"
+                        onMouseEnter={() => {
+                          if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+                          hoverTimerRef.current = setTimeout(() => setHoveredLogin(entry.login), HOVER_FETCH_DELAY_MS);
+                        }}
+                        onMouseLeave={() => {
+                          if (hoverTimerRef.current) { clearTimeout(hoverTimerRef.current); hoverTimerRef.current = null; }
+                        }}
+                      >
                         <Link
                           href={`/leaderboard/${entry.login}`}
                           className="text-sm font-medium text-white hover:text-blue-400 transition-colors truncate"
@@ -553,6 +797,12 @@ export default function LeaderboardPage() {
                             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                           </svg>
                         </a>
+                        {hoveredLogin === entry.login && (
+                          <ContributorHoverCard
+                            login={entry.login}
+                            onClose={() => setHoveredLogin(null)}
+                          />
+                        )}
                       </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Hovering over a contributor's username on the leaderboard shows a compact preview card
- Card lazy-fetches the contributor's profile JSON on hover (300ms delay to avoid fetch spam), cached in-memory for instant re-display
- Shows: avatar, name, level badge, rank, points, contribution cadence (streak + by-day heatmap + by-hour grid), activity timeline sparkline, and "View full profile" link
- Loading state shows a skeleton shimmer while data fetches

## Test plan
- [ ] Hover over any contributor name — card appears after 300ms
- [ ] Card shows cadence heatmaps and timeline sparkline
- [ ] Quick mouse-through doesn't trigger fetches
- [ ] Card disappears on mouse leave
- [ ] Clicking "View full profile" navigates to the full profile page
- [ ] `next build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)