### PR TITLE
✨ Add expertise radar chart to leaderboard hover card

### DIFF
--- a/src/app/[locale]/leaderboard/[username]/page.tsx
+++ b/src/app/[locale]/leaderboard/[username]/page.tsx
@@ -9,6 +9,13 @@ import {
   Navbar,
   Footer,
 } from "../../../../components/index";
+import {
+  RADAR_AXIS_COUNT,
+  RADAR_DIMENSIONS,
+  RADAR_MIN_DISPLAY_SCORE,
+  computeRadarScores,
+  radarPoint,
+} from "../../../../lib/radar";
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -142,135 +149,14 @@ const REPO_COLORS: Record<string, string> = {
 };
 
 // ── Radar Chart ──────────────────────────────────────────────────────
+// Shared constants & functions imported from src/lib/radar.ts
 
-/** Number of axes in the radar chart */
-const RADAR_AXIS_COUNT = 6;
 /** Radar chart radius in SVG units */
 const RADAR_RADIUS = 120;
 /** Center coordinate for the radar chart SVG */
 const RADAR_CENTER = 150;
 /** Number of concentric grid rings */
 const RADAR_GRID_RINGS = 4;
-/** Minimum score threshold to display a dimension (avoids empty-looking charts) */
-const RADAR_MIN_DISPLAY_SCORE = 0.08;
-
-/**
- * The 6 contribution dimensions, each with keywords that map topics to that axis.
- * Keywords are matched case-insensitively against topic cluster names.
- */
-const RADAR_DIMENSIONS = [
-  {
-    label: "Operations",
-    keywords: [
-      "cluster", "health", "monitor", "kubectl", "k8s", "node", "kubeconfig",
-      "context", "multicluster", "connect", "deployment", "deploy", "unhealthy",
-      "api", "handler", "endpoint", "backend", "server", "route", "store",
-      "resource", "compute", "capacity", "provision", "helm", "gitops",
-      "cicd", "pipeline", "release", "rollout", "startup", "dependency",
-      "build", "npm", "pull",
-    ],
-  },
-  {
-    label: "Dashboard",
-    keywords: [
-      "dashboard", "card", "widget", "layout", "grid", "drag", "drop",
-      "chart", "graph", "visualize", "bar", "line", "pie", "sparkline",
-      "drilldown", "timeseries", "css", "style", "theme", "ui", "component",
-      "sidebar", "collapse", "popup", "icon", "panel", "display", "view",
-      "tab", "settings", "preference", "onboard", "tour", "wizard",
-      "marketplace", "install",
-    ],
-  },
-  {
-    label: "Agents",
-    keywords: [
-      "agent", "kagent", "kagenti", "mcp", "protocol", "ai", "assist",
-      "automate", "llm", "model", "provider", "openai", "claude", "gemini",
-      "fallback", "inference", "vllm",
-    ],
-  },
-  {
-    label: "Missions",
-    keywords: [
-      "mission", "mission-control", "browser", "deploy", "workflow",
-      "objective", "goal", "task", "export", "yaml", "markdown", "json",
-      "history", "pagination",
-    ],
-  },
-  {
-    label: "Testing",
-    keywords: [
-      "test", "coverage", "nightly", "e2e", "playwright", "jest", "spec",
-      "fixture", "mock", "stub", "fork", "ci", "workflow", "automation",
-    ],
-  },
-  {
-    label: "Security",
-    keywords: [
-      "rbac", "auth", "oauth", "login", "session", "token", "permission",
-      "role", "security", "vulnerability", "scan", "compliance", "trivy",
-      "kubescape", "validation", "encryption", "middleware", "policy",
-    ],
-  },
-] as const;
-
-/**
- * Compute radar scores from topic clusters.
- * Each dimension gets a score proportional to the issue count of topics
- * whose names match that dimension's keywords.
- */
-function computeRadarScores(topics: TopicCluster[]): number[] {
-  if (!topics || topics.length === 0) {
-    return new Array(RADAR_AXIS_COUNT).fill(0);
-  }
-
-  const rawScores = new Array(RADAR_AXIS_COUNT).fill(0);
-
-  for (const topic of topics) {
-    const topicWords = topic.name.toLowerCase().split(/[\s,]+/);
-
-    for (let i = 0; i < RADAR_DIMENSIONS.length; i++) {
-      const dimension = RADAR_DIMENSIONS[i];
-      let matchStrength = 0;
-
-      for (const keyword of dimension.keywords) {
-        for (const word of topicWords) {
-          if (word.includes(keyword) || keyword.includes(word)) {
-            matchStrength++;
-          }
-        }
-      }
-
-      if (matchStrength > 0) {
-        rawScores[i] += topic.issue_count * matchStrength;
-      }
-    }
-  }
-
-  // Normalize to 0..1 range
-  const maxScore = Math.max(...rawScores, 1);
-  return rawScores.map((s) => Math.max(s / maxScore, 0));
-}
-
-/**
- * Calculate a point on the radar chart given an axis index, score (0..1),
- * and chart parameters.
- */
-function radarPoint(
-  axisIndex: number,
-  score: number,
-  radius: number,
-  center: number,
-): { x: number; y: number } {
-  /** Offset so first axis points straight up (negative Y) */
-  const ANGLE_OFFSET = -Math.PI / 2;
-  const angle =
-    ANGLE_OFFSET + (2 * Math.PI * axisIndex) / RADAR_AXIS_COUNT;
-  return {
-    x: center + radius * score * Math.cos(angle),
-    y: center + radius * score * Math.sin(angle),
-  };
-}
 
 /**
  * Pure SVG radar/spider chart showing contribution distribution

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   GridLines,
   StarField,
@@ -10,6 +11,14 @@ import {
   Navbar,
   Footer,
 } from "../../../components/index";
+import {
+  RADAR_AXIS_COUNT,
+  RADAR_DIMENSIONS,
+  RADAR_MIN_DISPLAY_SCORE,
+  computeRadarScores,
+  radarPoint,
+} from "../../../lib/radar";
+import type { RadarTopicCluster } from "../../../lib/radar";
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -221,6 +230,7 @@ interface ContributorPreview {
   rank: number;
   cadence: CadenceData;
   activity_timeline: TimelineEntry[];
+  topics?: RadarTopicCluster[];
 }
 
 const TREND_DISPLAY: Record<string, { label: string; color: string; arrow: string }> = {
@@ -237,6 +247,87 @@ const HOVER_FETCH_DELAY_MS = 300;
 
 const profileCache = new Map<string, ContributorPreview>();
 
+// ── Mini Radar Chart for hover card ──────────────────────────────────
+
+const MINI_RADAR_RADIUS = 50;
+const MINI_RADAR_CENTER = 60;
+const MINI_RADAR_GRID_RINGS = 3;
+
+function MiniRadarChart({ topics }: { topics: RadarTopicCluster[] }) {
+  const scores = useMemo(() => computeRadarScores(topics), [topics]);
+  const hasData = scores.some((s) => s > RADAR_MIN_DISPLAY_SCORE);
+
+  if (!hasData) return null;
+
+  const dataPoints = scores.map((score, i) =>
+    radarPoint(i, Math.max(score, RADAR_MIN_DISPLAY_SCORE), MINI_RADAR_RADIUS, MINI_RADAR_CENTER),
+  );
+  const dataPath = dataPoints
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+    .join(" ") + " Z";
+
+  const gridRings = Array.from({ length: MINI_RADAR_GRID_RINGS }, (_, ringIdx) => {
+    const fraction = (ringIdx + 1) / MINI_RADAR_GRID_RINGS;
+    const ringPoints = Array.from({ length: RADAR_AXIS_COUNT }, (_, axisIdx) =>
+      radarPoint(axisIdx, fraction, MINI_RADAR_RADIUS, MINI_RADAR_CENTER),
+    );
+    return ringPoints
+      .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+      .join(" ") + " Z";
+  });
+
+  const axisEndpoints = Array.from({ length: RADAR_AXIS_COUNT }, (_, i) =>
+    radarPoint(i, 1, MINI_RADAR_RADIUS, MINI_RADAR_CENTER),
+  );
+
+  const LABEL_OFFSET_RADIUS = 56;
+  const labelPositions = Array.from({ length: RADAR_AXIS_COUNT }, (_, i) =>
+    radarPoint(i, 1, LABEL_OFFSET_RADIUS, MINI_RADAR_CENTER),
+  );
+
+  return (
+    <div className="px-4 py-3 border-b border-white/5">
+      <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">Expertise</div>
+      <div className="flex items-center gap-3">
+        <svg
+          viewBox="0 0 120 120"
+          className="w-[100px] h-[100px] flex-shrink-0"
+          role="img"
+          aria-label="Expertise radar chart"
+        >
+          {gridRings.map((path, i) => (
+            <path key={`ring-${i}`} d={path} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth="0.5" />
+          ))}
+          {axisEndpoints.map((point, i) => (
+            <line key={`axis-${i}`} x1={MINI_RADAR_CENTER} y1={MINI_RADAR_CENTER} x2={point.x} y2={point.y} stroke="rgba(255,255,255,0.06)" strokeWidth="0.5" />
+          ))}
+          <path d={dataPath} fill="rgba(34,211,238,0.15)" stroke="rgba(34,211,238,0.6)" strokeWidth="1.5" />
+          {dataPoints.map((point, i) => (
+            <circle key={`dot-${i}`} cx={point.x} cy={point.y} r="2" fill={scores[i] > RADAR_MIN_DISPLAY_SCORE ? "rgba(34,211,238,0.9)" : "rgba(107,114,128,0.4)"} />
+          ))}
+          {labelPositions.map((pos, i) => (
+            <text key={`label-${i}`} x={pos.x} y={pos.y} textAnchor="middle" dominantBaseline="central" className="fill-amber-400" style={{ fontSize: "5px", fontFamily: "inherit" }}>
+              {RADAR_DIMENSIONS[i].label}
+            </text>
+          ))}
+        </svg>
+        <div className="flex flex-col gap-0.5 min-w-0">
+          {RADAR_DIMENSIONS.map((dim, i) => {
+            const pct = Math.round(scores[i] * 100);
+            return (
+              <div key={dim.label} className="flex items-center gap-1.5">
+                <div className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ backgroundColor: pct > 0 ? "rgba(34,211,238,0.8)" : "rgba(107,114,128,0.4)" }} />
+                <span className="text-[9px] text-gray-400 truncate">{dim.label}</span>
+                <span className="text-[9px] text-cyan-300/70 ml-auto">{pct}%</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ContributorHoverCard({
   login,
   onClose,
@@ -244,6 +335,7 @@ function ContributorHoverCard({
   login: string;
   onClose: () => void;
 }) {
+  const router = useRouter();
   const [data, setData] = useState<ContributorPreview | null>(profileCache.get(login) || null);
   const [loading, setLoading] = useState(!profileCache.has(login));
   const cardRef = useRef<HTMLDivElement>(null);
@@ -311,8 +403,12 @@ function ContributorHoverCard({
   return (
     <div
       ref={cardRef}
-      className="absolute left-0 top-full mt-2 z-50 w-96 bg-gray-900/95 backdrop-blur-lg rounded-xl border border-white/10 shadow-2xl overflow-hidden"
+      className="absolute left-0 top-full mt-2 z-50 w-96 bg-gray-900/95 backdrop-blur-lg rounded-xl border border-white/10 shadow-2xl overflow-hidden cursor-pointer"
       onMouseLeave={onClose}
+      onClick={() => router.push(`/leaderboard/${data.login}`)}
+      role="link"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === "Enter") router.push(`/leaderboard/${data.login}`); }}
     >
       {/* Header */}
       <div className="p-4 pb-3 border-b border-white/5">
@@ -397,7 +493,7 @@ function ContributorHoverCard({
       </div>
 
       {/* Activity Timeline */}
-      <div className="px-4 py-3">
+      <div className="px-4 py-3 border-b border-white/5">
         <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Activity Timeline</div>
         <div className="flex items-end gap-px h-10">
           {data.activity_timeline.map((entry) => {
@@ -418,13 +514,13 @@ function ContributorHoverCard({
         </div>
       </div>
 
-      {/* Footer link */}
-      <Link
-        href={`/leaderboard/${data.login}`}
-        className="block px-4 py-2 text-[10px] text-center text-blue-400 hover:text-blue-300 bg-white/[0.02] border-t border-white/5 transition-colors"
-      >
+      {/* Expertise Radar */}
+      {data.topics && data.topics.length > 0 && <MiniRadarChart topics={data.topics} />}
+
+      {/* Footer */}
+      <div className="block px-4 py-2 text-[10px] text-center text-blue-400 bg-white/[0.02] border-t border-white/5">
         View full profile →
-      </Link>
+      </div>
     </div>
   );
 }

--- a/src/lib/radar.ts
+++ b/src/lib/radar.ts
@@ -1,0 +1,132 @@
+/**
+ * Shared radar chart constants and computation logic.
+ * Used by both the full profile radar chart and the leaderboard hover mini radar.
+ */
+
+export interface RadarTopicCluster {
+  name: string;
+  issue_count: number;
+}
+
+/** Number of axes in the radar chart */
+export const RADAR_AXIS_COUNT = 6;
+/** Minimum score threshold to display a dimension (avoids empty-looking charts) */
+export const RADAR_MIN_DISPLAY_SCORE = 0.08;
+
+/**
+ * The 6 contribution dimensions, each with keywords that map topics to that axis.
+ * Keywords are matched case-insensitively against topic cluster names.
+ */
+export const RADAR_DIMENSIONS = [
+  {
+    label: "Operations",
+    keywords: [
+      "cluster", "health", "monitor", "kubectl", "k8s", "node", "kubeconfig",
+      "context", "multicluster", "connect", "deployment", "deploy", "unhealthy",
+      "api", "handler", "endpoint", "backend", "server", "route", "store",
+      "resource", "compute", "capacity", "provision", "helm", "gitops",
+      "cicd", "pipeline", "release", "rollout", "startup", "dependency",
+      "build", "npm", "pull",
+    ],
+  },
+  {
+    label: "Dashboard",
+    keywords: [
+      "dashboard", "card", "widget", "layout", "grid", "drag", "drop",
+      "chart", "graph", "visualize", "bar", "line", "pie", "sparkline",
+      "drilldown", "timeseries", "css", "style", "theme", "ui", "component",
+      "sidebar", "collapse", "popup", "icon", "panel", "display", "view",
+      "tab", "settings", "preference", "onboard", "tour", "wizard",
+      "marketplace", "install",
+    ],
+  },
+  {
+    label: "Agents",
+    keywords: [
+      "agent", "kagent", "kagenti", "mcp", "protocol", "ai", "assist",
+      "automate", "llm", "model", "provider", "openai", "claude", "gemini",
+      "fallback", "inference", "vllm",
+    ],
+  },
+  {
+    label: "Missions",
+    keywords: [
+      "mission", "mission-control", "browser", "deploy", "workflow",
+      "objective", "goal", "task", "export", "yaml", "markdown", "json",
+      "history", "pagination",
+    ],
+  },
+  {
+    label: "Testing",
+    keywords: [
+      "test", "coverage", "nightly", "e2e", "playwright", "jest", "spec",
+      "fixture", "mock", "stub", "fork", "ci", "workflow", "automation",
+    ],
+  },
+  {
+    label: "Security",
+    keywords: [
+      "rbac", "auth", "oauth", "login", "session", "token", "permission",
+      "role", "security", "vulnerability", "scan", "compliance", "trivy",
+      "kubescape", "validation", "encryption", "middleware", "policy",
+    ],
+  },
+] as const;
+
+/**
+ * Compute radar scores from topic clusters.
+ * Each dimension gets a score proportional to the issue count of topics
+ * whose names match that dimension's keywords.
+ */
+export function computeRadarScores(topics: RadarTopicCluster[]): number[] {
+  if (!topics || topics.length === 0) {
+    return new Array(RADAR_AXIS_COUNT).fill(0);
+  }
+
+  const rawScores = new Array(RADAR_AXIS_COUNT).fill(0);
+
+  for (const topic of topics) {
+    const topicWords = topic.name.toLowerCase().split(/[\s,]+/);
+
+    for (let i = 0; i < RADAR_DIMENSIONS.length; i++) {
+      const dimension = RADAR_DIMENSIONS[i];
+      let matchStrength = 0;
+
+      for (const keyword of dimension.keywords) {
+        for (const word of topicWords) {
+          if (word.includes(keyword) || keyword.includes(word)) {
+            matchStrength++;
+          }
+        }
+      }
+
+      if (matchStrength > 0) {
+        rawScores[i] += topic.issue_count * matchStrength;
+      }
+    }
+  }
+
+  // Normalize to 0..1 range
+  const maxScore = Math.max(...rawScores, 1);
+  return rawScores.map((s) => Math.max(s / maxScore, 0));
+}
+
+/**
+ * Calculate a point on the radar chart given an axis index, score (0..1),
+ * and chart parameters.
+ */
+export function radarPoint(
+  axisIndex: number,
+  score: number,
+  radius: number,
+  center: number,
+): { x: number; y: number } {
+  /** Offset so first axis points straight up (negative Y) */
+  const ANGLE_OFFSET = -Math.PI / 2;
+  const angle =
+    ANGLE_OFFSET + (2 * Math.PI * axisIndex) / RADAR_AXIS_COUNT;
+  return {
+    x: center + radius * score * Math.cos(angle),
+    y: center + radius * score * Math.sin(angle),
+  };
+}


### PR DESCRIPTION
## Summary

Adds a mini expertise radar chart to the contributor hover card on the leaderboard page, and makes the entire hover card clickable to open the contributor's full profile.

### Changes

1. **Shared radar module** (`src/lib/radar.ts`) — extracts radar dimensions, scoring logic, and `radarPoint` geometry so both the hover card and full profile page use the same computation. No more drift risk.

2. **Mini radar chart in hover card** — compact SVG radar showing 6 expertise dimensions (Operations, Dashboard, Agents, Missions, Testing, Security) with a side legend. Only renders when the contributor has topic data.

3. **Clickable hover card** — clicking anywhere on the hover card navigates to the full profile page (`/leaderboard/{username}`). Uses `router.push()` instead of a wrapping `<Link>` to avoid nested `<a>` elements. Includes keyboard accessibility (Enter key).

4. **Profile page refactor** — the `[username]/page.tsx` profile page now imports radar constants/functions from the shared module instead of defining its own copy.

### Screenshots

The hover card now shows (from top to bottom):
- Header (avatar, name, level badge, rank, points)
- Cadence (streak, by-day heatmap, by-hour heatmap)
- Activity Timeline sparkline
- **NEW: Expertise radar chart** (mini version of the profile page radar)
- "View full profile →" footer (whole card is clickable)
