### PR TITLE
📖 document OAuth setup wizard in authentication and local-setup guides

### DIFF
--- a/docs/content/console/authentication.md
+++ b/docs/content/console/authentication.md
@@ -48,6 +48,15 @@ Full GitHub authentication with multi-user support.
 - The access token is used server-side only to fetch the user profile
 - CSRF protection is enforced on the callback (state parameter validation)
 
+#### First-Time Setup Wizard
+
+When the console starts without `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` configured, the login page displays an interactive setup wizard instead of silently entering demo mode. The wizard offers two paths:
+
+- **"Set up GitHub Sign-In"** — Expands an inline guide that walks you through creating a GitHub OAuth App, with copy-to-clipboard buttons for the callback URL and `.env` template
+- **"Continue in Demo Mode"** — Enters demo mode immediately (same as previous behavior)
+
+This replaces the previous behavior where unconfigured consoles would silently auto-login as a demo user with no indication that GitHub authentication was available.
+
 ### 2. Development Mode (`start-dev.sh`)
 
 No authentication required. A local `dev-user` session is created automatically.

--- a/docs/content/console/local-setup.md
+++ b/docs/content/console/local-setup.md
@@ -81,6 +81,18 @@ The Vite dev server proxies API requests to the Go backend on port 8080.
 
 For multi-user deployments or to test the complete authentication flow.
 
+> **💡 New: Setup Wizard (Recommended)**
+>
+> As of v0.3.18, you can skip the manual steps below. Simply start the console without OAuth credentials:
+>
+> ```bash
+> ./startup-oauth.sh
+> ```
+>
+> Visit `http://localhost:8080` and the login page will show an interactive **Setup Wizard** that walks you through creating a GitHub OAuth App, with copy-to-clipboard buttons for all values. You can also choose "Continue in Demo Mode" to skip OAuth entirely.
+>
+> The manual steps below are still available if you prefer to configure OAuth before first startup.
+
 ### Step 1: Create a GitHub OAuth App
 
 1. Go to **[GitHub Developer Settings](https://github.com/settings/developers)** > **OAuth Apps** > **New OAuth App**


### PR DESCRIPTION
Updates docs to reference the new GitHub sign-in setup wizard introduced in console PR kubestellar/console#8545.

## Changes
- **local-setup.md**: Added recommended Setup Wizard note before manual OAuth steps
- **authentication.md**: Added First-Time Setup Wizard subsection under OAuth Mode

The wizard shows an interactive guide when console starts without OAuth credentials, replacing the previous silent demo-mode fallback.