### PR TITLE
✨ add TypeScript & ESLint CI check for PRs

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,44 @@
+name: TypeScript & Lint Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "*.ts"
+      - "*.tsx"
+      - "tsconfig.json"
+      - "package.json"
+      - ".eslintrc*"
+      - "next.config.*"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "*.ts"
+      - "*.tsx"
+      - "tsconfig.json"
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: TypeScript & ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript type check
+        run: npm run type-check
+
+      - name: ESLint
+        run: npm run lint


### PR DESCRIPTION
## Problem
Type errors and lint failures are only caught during Netlify's production build — **after** code is merged to main. This causes failed deploys (e.g., unused `Link` import, wrong `GridLines` props in the ACMM leaderboard page).

## Solution
Adds a `typecheck.yml` workflow that runs on every PR touching `src/` or config files:
- `npm run type-check` (`tsc --noEmit`) — catches type errors
- `npm run lint` (`next lint`) — catches unused vars, ESLint violations

Both scripts already exist in `package.json` — this just wires them into CI.

## Impact
PRs will now fail before merge if they have type or lint errors, preventing broken Netlify deploys on main.