### PR TITLE
🐛 Add console repos to contribution ladder data sources

### DIFF
--- a/.github/workflows/devstat-funcs.js
+++ b/.github/workflows/devstat-funcs.js
@@ -1,5 +1,8 @@
 const DEFAULT_REPOS = [
   "kubestellar/a2a",
+  "kubestellar/console",
+  "kubestellar/console-marketplace",
+  "kubestellar/console-kb",
   // 'kubestellar/community',
   // 'kubestellar/core',
   "kubestellar/docs",


### PR DESCRIPTION
Fixes #1517

Adds `kubestellar/console`, `kubestellar/console-marketplace`, and `kubestellar/console-kb` to the `DEFAULT_REPOS` list in `.github/workflows/devstat-funcs.js`.

**Root cause:** The leaderboard generation script (`generate-leaderboard.mjs`) already included these repos, but the Google Sheets devstat helper functions did not. This meant the spreadsheet-based contribution tracking was missing all console repo activity (issues, PRs, etc.).

**Fix:** Added the three console repos to `DEFAULT_REPOS` in `devstat-funcs.js` so contribution points from these repos are properly reflected in the contribution ladder.