### PR TITLE
🐛 Add kubestellar/kubestellar to leaderboard repos

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -33,6 +33,7 @@ const POINTS_PR_MERGED = 500;
 
 // ── Repos to scan ─────────────────────────────────────────────────────
 const REPOS = [
+  "kubestellar/kubestellar",
   "kubestellar/console",
   "kubestellar/console-marketplace",
   "kubestellar/console-kb",


### PR DESCRIPTION
Fixes #1517

The leaderboard generation script (`scripts/generate-leaderboard.mjs`) only scanned 4 repos:
- kubestellar/console
- kubestellar/console-marketplace
- kubestellar/console-kb
- kubestellar/docs

The main `kubestellar/kubestellar` repository was missing, meaning contributors to the core project received no contribution points on the leaderboard.

This adds `kubestellar/kubestellar` to the REPOS array so all contributions are reflected after the next scheduled leaderboard generation run.