### PR TITLE
fix: revert leaderboard to all-time scoring

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -53,8 +53,6 @@ const CONTRIBUTOR_LEVELS = [
 ];
 
 // ── GitHub API constants ──────────────────────────────────────────────
-/** Current-year start in ISO-8601 (matches console rewards scope) */
-const YEAR_START = `${new Date().getFullYear()}-01-01T00:00:00Z`;
 /** Items per page for REST API pagination */
 const REST_PER_PAGE = 100;
 /** Maximum pages to fetch per repo (100 items/page = 10,000 items max) */
@@ -140,7 +138,7 @@ async function fetchAllItems(repo) {
   const allItems = [];
 
   for (let page = 1; page <= REST_MAX_PAGES; page++) {
-    const url = `${API_BASE}/repos/${repo}/issues?state=all&per_page=${REST_PER_PAGE}&page=${page}&sort=created&direction=desc&since=${YEAR_START}`;
+    const url = `${API_BASE}/repos/${repo}/issues?state=all&per_page=${REST_PER_PAGE}&page=${page}&sort=created&direction=desc`;
 
     if (page > 1) await delay(REST_PAGE_DELAY_MS);
 
@@ -167,7 +165,6 @@ function scoreAllContributors(allItems) {
     const login = item.user?.login;
     if (!login || item.user?.type !== "User") continue;
     if (EXCLUDED_LOGINS.has(login)) continue;
-    if (item.created_at < YEAR_START) continue;
 
     if (!contributors.has(login)) {
       contributors.set(login, {

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -697,7 +697,8 @@ export default function LeaderboardPage() {
                 repositories
               </p>
               <p className="mt-3 text-sm text-gray-500 max-w-2xl mx-auto">
-                Tracking {new Date().getFullYear()} contributions across{" "}
+                All-time contributions across{" "}
+                <a href="https://github.com/kubestellar/kubestellar" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-blue-400 transition-colors">kubestellar</a>,{" "}
                 <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-blue-400 transition-colors">console</a>,{" "}
                 <a href="https://github.com/kubestellar/console-marketplace" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-blue-400 transition-colors">console-marketplace</a>,{" "}
                 <a href="https://github.com/kubestellar/console-kb" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-blue-400 transition-colors">console-kb</a>, and{" "}


### PR DESCRIPTION
## Summary

- PR #1503 scoped the leaderboard to current calendar year only, causing contributor totals to appear dramatically lower than before
- Contributors with years of history showed only ~4 months of 2026 activity (e.g., KPRoche: 16,950 pts vs. expected 50k+ all-time)
- User reports this as a critical regression — leaderboard looks broken
- Revert to all-time scoring by removing the `YEAR_START` filter from both the API query and client-side filtering
- Update the subtitle from "Tracking 2026 contributions" to "All-time contributions"
- Add `kubestellar/kubestellar` link to the repo list in the subtitle (the script already tracks it since #1519, but the UI text didn't reflect it)

Fixes #1520

## Test plan
- [ ] Run `node scripts/generate-leaderboard.mjs` — should produce higher totals for established contributors like KPRoche, MikeSpreitzer
- [ ] Leaderboard page subtitle shows "All-time contributions across kubestellar, console, ..."
- [ ] clubanderson rank stays #1 with expected all-time point total

🤖 Generated with [Claude Code](https://claude.com/claude-code)