### PR TITLE
🐛 fix: repair leaderboard generation workflow

### DIFF
--- a/public/data/leaderboard.json
+++ b/public/data/leaderboard.json
@@ -1,6 +1,7 @@
 {
   "generated_at": "2026-04-24T22:16:13.542Z",
   "git_hash": "fc63628",
+  "year_start": "2026-01-01T00:00:00Z",
   "entries": [
     {
       "login": "clubanderson",

--- a/scripts/check-leaderboard-regression.mjs
+++ b/scripts/check-leaderboard-regression.mjs
@@ -9,8 +9,13 @@
  * sufficient — a scoring bug severe enough to matter will always affect
  * high-volume contributors most.
  *
+ * Year-boundary handling: if the scoring window changed (e.g. the previous
+ * snapshot was generated in 2026 and the new one uses 2027-01-01 as YEAR_START)
+ * the check is automatically skipped so the first run of the new year does not
+ * need a manual LEADERBOARD_FORCE override.
+ *
  * Set LEADERBOARD_FORCE=1 to bypass — use when an intentional scope change
- * (e.g. switching from all-time to current-year) is expected to lower scores.
+ * (e.g. switching scoring repos) is expected to lower scores.
  *
  * Usage (called by generate-leaderboard.yml after generation):
  *   node scripts/check-leaderboard-regression.mjs
@@ -65,6 +70,16 @@ function main() {
     process.exit(0);
   }
 
+  // Auto-skip when the scoring year flipped (e.g. Jan 1 rollover).
+  // YEAR_START comes from the generate script; both snapshots embed it so we
+  // can detect the transition without requiring a manual force override.
+  if (prevData.year_start && newData.year_start && prevData.year_start !== newData.year_start) {
+    console.log(
+      `Scoring year changed (${prevData.year_start} → ${newData.year_start}) — skipping regression check.`
+    );
+    process.exit(0);
+  }
+
   const prevMap = new Map(prevData.entries.map((e) => [e.login, e.total_points]));
 
   // Check the current top N from the newly generated data
@@ -108,8 +123,9 @@ function main() {
         ` (−${r.drop.toLocaleString()}, −${(r.dropPct * 100).toFixed(1)}%)`
     );
   }
-  console.error("\nScoring bug likely (filter change, missing repo, API truncation).");
-  console.error("If intentional, re-run the workflow with force=true.");
+  console.error("\nThis usually means a scoring bug (e.g. a filter change dropping contributions).");
+  console.error("If this drop is intentional (e.g. scope change), trigger the workflow manually");
+  console.error("via Actions → Generate Leaderboard Data → Run workflow, with 'Skip regression check' checked.");
   console.error("\nLeaderboard data has NOT been committed.");
   process.exit(1);
 }

--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -351,6 +351,7 @@ async function main() {
   const output = {
     generated_at: new Date().toISOString(),
     git_hash: gitHash,
+    year_start: YEAR_START,
     entries,
   };
 


### PR DESCRIPTION
Fixes #1523

## What

Addresses the root cause of the regression-check false positive that triggered issue #1523, and adds a guard to prevent the same failure pattern every January 1.

## Changes

1. **Embed `year_start` in `leaderboard.json`** — the generate script now writes the scoring window start date (`YEAR_START`) into the JSON output alongside `generated_at` and `git_hash`.

2. **Auto-skip regression check on year rollover** — the regression guard compares the previous snapshot's `year_start` to the new one. When they differ (e.g. a Jan 1 run changes the window from `2026-01-01` to `2027-01-01`), the check is automatically skipped. Without this, the first scheduled run each year would always fail because every contributor's year-to-date score resets to near-zero.

3. **Better error message** — the failure output now says *"trigger the workflow manually via Actions → Generate Leaderboard Data → Run workflow, with 'Skip regression check' checked"* instead of the vague *"re-run with force=true"* hint.

4. **Backfill `year_start` in committed `leaderboard.json`** — so the very next scheduled run can immediately compare scoring windows.

## Root cause recap

Run [24911428688](https://github.com/kubestellar/docs/actions/runs/24911428688) failed because:
- The scoring window was changed between runs (all-time ↔ 2026-only), causing 7 contributors to lose >10% of their points.
- The regression check at the time tested **all** contributors, making it very sensitive to any scoring algorithm change.

The scoring fix landed in #1522 and the check was narrowed to top-3 in #1524/#1525. This PR adds the missing year-boundary guard so the same class of failure cannot recur automatically each January.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>