### PR TITLE
📖 Add community meetings docs page

### DIFF
--- a/docs/content/community/index.md
+++ b/docs/content/community/index.md
@@ -22,13 +22,7 @@
 
 ### Community Meetings
 
-1. Join our [Developer mailing list](https://groups.google.com/g/kubestellar-dev) to get your community meeting invitation.
-2. You can also directly [subscribe to the community calendar](https://calendar.google.com/calendar/ical/b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com/public/basic.ics), or view our [calendar](https://calendar.google.com/calendar/embed?src=b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com&ctz=America%2FNew_York)
-3. See [upcoming]({{ config.repo_url }}/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-meeting) and [past]({{ config.repo_url }}/issues?q=is%3Aissue+is%3Aclosed+label%3Acommunity-meeting) community meeting agendas and notes
-4. Sign up to discuss a topic in the [KubeStellar Community Meeting Agenda](https://docs.google.com/document/d/1XppfxSOD7AOX1lVVVIPWjpFkrxakfBfVzcybRg17-PM/edit?usp=share_link)
+Meeting invitations, calendar links, agendas, notes, and recordings are centralized on the [Community meetings](./meetings.md) page.
 
 ### Other Resources
 - [Google Drive](https://drive.google.com/drive/u/1/folders/1p68MwkX0sYdTvtup0DcnAEsnXElobFLS)
-
-<br/>
-<iframe src="https://calendar.google.com/calendar/embed?src=b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/docs/content/community/meetings.md
+++ b/docs/content/community/meetings.md
@@ -1,0 +1,23 @@
+# Community meetings
+
+KubeStellar community meetings are the place to follow current work, bring questions, and propose topics for discussion.
+
+## Join a meeting
+
+1. Join the [Developer mailing list](https://groups.google.com/g/kubestellar-dev) to receive meeting invitations and updates.
+2. Subscribe to the [community calendar](https://calendar.google.com/calendar/ical/b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com/public/basic.ics), or view the [calendar in your browser](https://calendar.google.com/calendar/embed?src=b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com&ctz=America%2FNew_York).
+3. Join the [KubeStellar Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M) for questions between meetings.
+
+## Agendas and notes
+
+- [Upcoming agendas](https://github.com/kubestellar/kubestellar/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-meeting)
+- [Past agendas and notes](https://github.com/kubestellar/kubestellar/issues?q=is%3Aissue+is%3Aclosed+label%3Acommunity-meeting)
+- [Community meeting agenda document](https://docs.google.com/document/d/1XppfxSOD7AOX1lVVVIPWjpFkrxakfBfVzcybRg17-PM/edit?usp=share_link)
+
+## Recordings
+
+Meeting recordings and demos are published on the [KubeStellar YouTube channel](https://www.youtube.com/@kubestellar).
+
+## Calendar
+
+<iframe title="KubeStellar community calendar" src="https://calendar.google.com/calendar/embed?src=b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0; width: 100%" height="600" frameborder="0" scrolling="no" loading="lazy"></iframe>

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -371,6 +371,7 @@ const NAV_STRUCTURE_COMMUNITY: Array<{ title: string; items: NavItem[] }> = [
     title: 'Community',
     items: [
       { 'Get Involved': 'community/index.md' },
+      { 'Community Meetings': 'community/meetings.md' },
     ]
   }
 ]


### PR DESCRIPTION
Fixes kubestellar/kubestellar#3434.

## Summary
- add a dedicated Community meetings page with meeting invite, calendar, agenda, notes, Slack, and recording links
- add the page to the Community docs sidebar
- replace the inline meeting details on the Community page with a link to the new centralized page

## Validation
- npx prettier --check docs/content/community/meetings.md docs/content/community/index.md src/app/docs/page-map.ts
- npm run type-check
- git diff --check
- npm run build