### PR TITLE
📖 Document OpenShift cluster-info warning

### DIFF
--- a/docs/content/kubestellar/troubleshooting.md
+++ b/docs/content/kubestellar/troubleshooting.md
@@ -43,6 +43,48 @@ verbosity (`-v`) of various controllers.
 
 We have [the start of a list](known-issues.md).
 
+## OpenShift WEC registration warning about `cluster-info`
+
+When registering an OpenShift cluster as a WEC, `clusteradm join` can
+print a warning like the following.
+
+```console
+W0131 11:43:03.072250   76891 exec.go:204] Failed looking for cluster endpoint for the registering klusterlet: configmaps "cluster-info" not found
+```
+
+OpenShift clusters do not always have the `kube-public/cluster-info`
+ConfigMap that `clusteradm` tries to inspect during this preflight
+path. This message is a warning, not necessarily a failed join. In
+known cases, `clusteradm join` still created a CSR on the hub. Do not
+retry only because this warning appeared; first check whether the CSR
+was created.
+
+After running `clusteradm join` from the WEC context, check the ITS or
+hub context for a CSR whose name starts with the WEC cluster name.
+
+```shell
+kubectl --context its1 get csr
+```
+
+If the CSR exists, approve it in the usual way.
+
+```shell
+clusteradm --context its1 accept --clusters <wec-cluster-name>
+```
+
+If you retried `clusteradm join` several times while investigating the
+warning, you may see multiple pending CSRs for the same WEC. Keep the
+latest one and delete the stale attempts before approving. Sorting by
+creation timestamp can make this easier to see.
+
+```shell
+kubectl --context its1 get csr --sort-by=.metadata.creationTimestamp
+```
+
+```shell
+kubectl --context its1 delete csr <stale-csr-name>
+```
+
 ## Making a good trouble report
 
 Basic configuration information.

--- a/docs/content/kubestellar/wec-registration.md
+++ b/docs/content/kubestellar/wec-registration.md
@@ -198,6 +198,10 @@ clusteradm --context its1 get token | grep '^clusteradm join' | \
 clusteradm --context its1 accept --clusters openshift-cluster
 ```
 
+If `clusteradm join` prints a warning about a missing `cluster-info`
+ConfigMap, check whether the CSR was still created before retrying. See
+[OpenShift WEC registration warning about `cluster-info`](troubleshooting.md#openshift-wec-registration-warning-about-cluster-info).
+
 ### Cloud Provider Clusters
 
 For clusters from cloud providers (EKS, GKE, AKS, etc.):


### PR DESCRIPTION
## Summary
- document the OpenShift WEC registration warning when clusteradm cannot find kube-public/cluster-info
- tell users to check for and approve the CSR before retrying the join
- link the note from the OpenShift registration instructions

## Related issue
Addresses kubestellar/kubestellar#1687

## Upstream follow-up
- open-cluster-management-io/ocm#1499

## Testing
- git diff --check
- npx prettier --check docs/content/kubestellar/troubleshooting.md docs/content/kubestellar/wec-registration.md
- npm run type-check
- npm run build