### PR TITLE
🐛 Fix leaderboard points mismatch between global and profile pages

### DIFF
--- a/src/app/[locale]/leaderboard/[username]/page.tsx
+++ b/src/app/[locale]/leaderboard/[username]/page.tsx
@@ -77,6 +77,28 @@ interface ContributorProfile {
   activity_timeline: TimelineEntry[];
 }
 
+interface LeaderboardEntry {
+  login: string;
+  avatar_url: string;
+  total_points: number;
+  level: string;
+  level_rank: number;
+  rank: number;
+  breakdown: {
+    bug_issues: number;
+    feature_issues: number;
+    other_issues: number;
+    prs_opened: number;
+    prs_merged: number;
+  };
+  bonus_points: number;
+}
+
+interface LeaderboardData {
+  generated_at: string;
+  entries: LeaderboardEntry[];
+}
+
 // ── Constants ─────────────────────────────────────────────────────────
 
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -531,16 +553,37 @@ export default function ContributorProfilePage({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`/data/contributors/${username}.json`)
+    const profileFetch = fetch(`/data/contributors/${username}.json`)
       .then((res) => {
         if (!res.ok)
           throw new Error(
             res.status === 404 ? "not_found" : `HTTP ${res.status}`
           );
-        return res.json();
-      })
-      .then((data: ContributorProfile) => {
-        setProfile(data);
+        return res.json() as Promise<ContributorProfile>;
+      });
+
+    const leaderboardFetch = fetch("/data/leaderboard.json")
+      .then((res) => (res.ok ? (res.json() as Promise<LeaderboardData>) : null))
+      .catch(() => null);
+
+    Promise.all([profileFetch, leaderboardFetch])
+      .then(([profileData, leaderboardData]) => {
+        // Merge authoritative scoring fields from leaderboard.json
+        // (single source of truth) into the contributor profile.
+        // Profile generation can lag behind leaderboard generation,
+        // so leaderboard values take precedence for points/rank/level.
+        if (leaderboardData) {
+          const lbEntry = leaderboardData.entries.find(
+            (e) => e.login.toLowerCase() === username.toLowerCase()
+          );
+          if (lbEntry) {
+            profileData.total_points = lbEntry.total_points;
+            profileData.rank = lbEntry.rank;
+            profileData.level = lbEntry.level;
+            profileData.level_rank = lbEntry.level_rank;
+          }
+        }
+        setProfile(profileData);
         setIsLoading(false);
       })
       .catch((err) => {
@@ -914,3 +957,4 @@ export default function ContributorProfilePage({
     </div>
   );
 }
+___BEGIN___COMMAND_DONE_MARKER___0

--- a/src/app/[locale]/leaderboard/[username]/page.tsx
+++ b/src/app/[locale]/leaderboard/[username]/page.tsx
@@ -957,4 +957,3 @@ export default function ContributorProfilePage({
     </div>
   );
 }
-___BEGIN___COMMAND_DONE_MARKER___0


### PR DESCRIPTION
Fixes #1532

## Problem

The profile page (`/leaderboard/[username]`) shows significantly different (lower) points than the global leaderboard page (`/leaderboard`). For example, a user might show ~37,700 pts on the leaderboard but only ~1,700 pts on their profile.

### Root Cause

Two separate data sources:
| Source | Updates | Used by |
|--------|---------|---------|
| `/data/leaderboard.json` | Every 4 hours (reliable) | Global leaderboard page |
| `/data/contributors/{login}.json` | Same workflow, but `continue-on-error: true` + 5-min timeout | Profile page |

The profile generator (`generate-contributor-profiles.mjs`) does expensive TF-IDF clustering on issue bodies and frequently times out. When it fails, the leaderboard gets committed with fresh scores but profiles retain old `total_points` values.

**Current drift:** Leaderboard generated Apr 25; profiles still from Apr 24 — some users off by 10x+.

## Fix

The profile page now fetches **both** data sources in parallel:
1. `/data/contributors/{username}.json` — for topic clusters, cadence, suggestions
2. `/data/leaderboard.json` — as the **single source of truth** for scoring fields

Authoritative fields merged from leaderboard: `total_points`, `rank`, `level`, `level_rank`.

Falls back gracefully to profile-only data if the leaderboard fetch fails.

## Performance

The leaderboard JSON is ~71 entries, static, and CDN-cached. The additional fetch adds negligible latency (both requests run in parallel via `Promise.all`).

## Future Work

- Consider splitting profile generation into its own workflow job so it doesn't block/get blocked by leaderboard generation
- Add freshness monitoring for profile data staleness