### PR TITLE
fix: add pull-rebase retry to leaderboard workflow push step

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -53,7 +53,12 @@ jobs:
           git add public/data/leaderboard.json public/data/contributors/
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "chore: update leaderboard and contributor profile data"
-          git push
+          MAX_RETRIES=3
+          for i in $(seq 1 $MAX_RETRIES); do
+            git pull --rebase origin main && git push && break
+            echo "Push attempt $i failed, retrying..."
+            sleep 2
+          done
 
       - name: Create issue on failure
         if: failure()


### PR DESCRIPTION
## Summary
- The Generate Leaderboard Data workflow failed on [run 24963581733](https://github.com/kubestellar/docs/actions/runs/24963581733) because `git push` was rejected — a concurrent commit landed on `main` during the ~7 minute generation window
- Adds `git pull --rebase origin main` before `git push` with a retry loop (up to 3 attempts) to handle this race condition

Fixes #1539

## Test plan
- [ ] Re-run the Generate Leaderboard Data workflow manually to verify it succeeds even if another commit lands during generation
- [ ] Verify the retry loop handles the case where no race occurs (immediate success on first attempt)