### PR TITLE
fix: leaderboard push retry defeated by bash set -e

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -53,12 +53,18 @@ jobs:
           git add public/data/leaderboard.json public/data/contributors/
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "chore: update leaderboard and contributor profile data"
-          MAX_RETRIES=3
+          MAX_RETRIES=5
+          RETRY_DELAY_SECONDS=3
           for i in $(seq 1 $MAX_RETRIES); do
-            git pull --rebase origin main && git push && break
-            echo "Push attempt $i failed, retrying..."
-            sleep 2
+            if git pull --rebase origin main && git push; then
+              echo "Push succeeded on attempt $i"
+              exit 0
+            fi
+            echo "Push attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_DELAY_SECONDS}s..."
+            sleep "$RETRY_DELAY_SECONDS"
           done
+          echo "All $MAX_RETRIES push attempts failed"
+          exit 1
 
       - name: Create issue on failure
         if: failure()


### PR DESCRIPTION
## Summary
- The retry loop added in #1540 used `&& break` which causes `bash -e` (GitHub Actions default shell) to exit the script on the first `git push` failure, before the retry loop ever gets to attempt #2
- Wraps the pull+push in an `if-then` block so failures are caught by the conditional (which is exempt from `set -e` per POSIX spec) instead of killing the script
- Increases retries from 3 to 5 with a 3-second delay, and adds explicit `exit 1` after exhausting all attempts

## Root cause
GitHub Actions runs bash steps with `set -e` by default. In the previous code:
```bash
git pull --rebase origin main && git push && break
```
When `git push` fails, the `&&` chain returns non-zero, and `set -e` terminates the script immediately. The retry loop never executes a second iteration.

## Fix
```bash
if git pull --rebase origin main && git push; then
  exit 0
fi
```
The condition of an `if` statement is exempt from `set -e` — failed commands inside it do not trigger script exit.

Fixes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)