### PR TITLE
Fix: Include repository contributions in contributor profiles

### DIFF
--- a/public/data/contributors/1PoPTRoN.json
+++ b/public/data/contributors/1PoPTRoN.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/AAdIprog.json
+++ b/public/data/contributors/AAdIprog.json
@@ -572,5 +572,31 @@
       "month": "2026-04",
       "issue_count": 26
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 53,
+      "feature_issues": 1,
+      "other_issues": 1,
+      "prs_opened": 4,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 4,
+      "prs_merged": 2
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/ANAMASGARD.json
+++ b/public/data/contributors/ANAMASGARD.json
@@ -105,5 +105,31 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 5,
+      "prs_merged": 5
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 5,
+      "prs_merged": 5
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 2,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/Abhishek-Punhani.json
+++ b/public/data/contributors/Abhishek-Punhani.json
@@ -256,5 +256,23 @@
       "month": "2026-04",
       "issue_count": 39
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 88,
+      "feature_issues": 1,
+      "other_issues": 6,
+      "prs_opened": 6,
+      "prs_merged": 2
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/AnvayKharb.json
+++ b/public/data/contributors/AnvayKharb.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 4,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/AresPhoenix345.json
+++ b/public/data/contributors/AresPhoenix345.json
@@ -105,5 +105,23 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 3,
+      "prs_merged": 3
+    },
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/Arpit529Srivastava.json
+++ b/public/data/contributors/Arpit529Srivastava.json
@@ -755,5 +755,23 @@
       "month": "2026-04",
       "issue_count": 41
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 87,
+      "feature_issues": 0,
+      "other_issues": 4,
+      "prs_opened": 1,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 4,
+      "feature_issues": 0,
+      "other_issues": 3,
+      "prs_opened": 4,
+      "prs_merged": 4
+    }
   ]
 }

--- a/public/data/contributors/Darshit42.json
+++ b/public/data/contributors/Darshit42.json
@@ -221,5 +221,23 @@
       "month": "2026-04",
       "issue_count": 10
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 10,
+      "feature_issues": 1,
+      "other_issues": 0,
+      "prs_opened": 4,
+      "prs_merged": 4
+    },
+    {
+      "repo": "kubestellar/console-kb",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/Janhvibabani.json
+++ b/public/data/contributors/Janhvibabani.json
@@ -207,5 +207,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 5,
+      "feature_issues": 0,
+      "other_issues": 3,
+      "prs_opened": 8,
+      "prs_merged": 6
+    }
   ]
 }

--- a/public/data/contributors/KPRoche.json
+++ b/public/data/contributors/KPRoche.json
@@ -207,5 +207,23 @@
       "month": "2026-04",
       "issue_count": 6
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 3,
+      "feature_issues": 0,
+      "other_issues": 7,
+      "prs_opened": 48,
+      "prs_merged": 28
+    },
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 6,
+      "feature_issues": 0,
+      "other_issues": 10,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/KlementMultiverse.json
+++ b/public/data/contributors/KlementMultiverse.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/Krishiv-Mahajan.json
+++ b/public/data/contributors/Krishiv-Mahajan.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/KumarADITHYA123.json
+++ b/public/data/contributors/KumarADITHYA123.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 2
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 2,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/MAVRICK-1.json
+++ b/public/data/contributors/MAVRICK-1.json
@@ -277,5 +277,23 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 5,
+      "feature_issues": 0,
+      "other_issues": 6,
+      "prs_opened": 1,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 1,
+      "other_issues": 2,
+      "prs_opened": 2,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/MichaelSovereign.json
+++ b/public/data/contributors/MichaelSovereign.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/MikeSpreitzer.json
+++ b/public/data/contributors/MikeSpreitzer.json
@@ -362,5 +362,23 @@
       "month": "2026-04",
       "issue_count": 24
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 46,
+      "feature_issues": 5,
+      "other_issues": 10,
+      "prs_opened": 0,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 5,
+      "feature_issues": 1,
+      "other_issues": 20,
+      "prs_opened": 3,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/ParthKshirsagar7.json
+++ b/public/data/contributors/ParthKshirsagar7.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 1,
+      "other_issues": 0,
+      "prs_opened": 3,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/Pranjal6955.json
+++ b/public/data/contributors/Pranjal6955.json
@@ -333,5 +333,31 @@
       "month": "2026-04",
       "issue_count": 60
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 79,
+      "feature_issues": 2,
+      "other_issues": 0,
+      "prs_opened": 30,
+      "prs_merged": 29
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 3,
+      "feature_issues": 0,
+      "other_issues": 2,
+      "prs_opened": 13,
+      "prs_merged": 9
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/Provokke.json
+++ b/public/data/contributors/Provokke.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/ShaistaAfreen09.json
+++ b/public/data/contributors/ShaistaAfreen09.json
@@ -179,5 +179,15 @@
       "month": "2026-04",
       "issue_count": 3
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 2,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/Shreya2005-2005.json
+++ b/public/data/contributors/Shreya2005-2005.json
@@ -179,5 +179,23 @@
       "month": "2026-04",
       "issue_count": 7
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 6,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 1,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/Va16hav07.json
+++ b/public/data/contributors/Va16hav07.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 1
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 6,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/XxSURYANSHxX.json
+++ b/public/data/contributors/XxSURYANSHxX.json
@@ -431,5 +431,23 @@
       "month": "2026-04",
       "issue_count": 195
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 149,
+      "feature_issues": 0,
+      "other_issues": 50,
+      "prs_opened": 4,
+      "prs_merged": 3
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 5,
+      "prs_merged": 4
+    }
   ]
 }

--- a/public/data/contributors/aaradhychinche-alt.json
+++ b/public/data/contributors/aaradhychinche-alt.json
@@ -418,5 +418,31 @@
       "month": "2026-04",
       "issue_count": 419
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 390,
+      "feature_issues": 2,
+      "other_issues": 55,
+      "prs_opened": 4,
+      "prs_merged": 2
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 5,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 9,
+      "prs_merged": 8
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 3,
+      "prs_merged": 3
+    }
   ]
 }

--- a/public/data/contributors/aashu2006.json
+++ b/public/data/contributors/aashu2006.json
@@ -1517,5 +1517,23 @@
       "month": "2026-04",
       "issue_count": 540
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 482,
+      "feature_issues": 0,
+      "other_issues": 58,
+      "prs_opened": 5,
+      "prs_merged": 4
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 7,
+      "prs_merged": 7
+    }
   ]
 }

--- a/public/data/contributors/antedotee.json
+++ b/public/data/contributors/antedotee.json
@@ -152,5 +152,23 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 3,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 0,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/arnavgogia20.json
+++ b/public/data/contributors/arnavgogia20.json
@@ -488,5 +488,23 @@
       "month": "2026-04",
       "issue_count": 78
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 77,
+      "feature_issues": 0,
+      "other_issues": 4,
+      "prs_opened": 8,
+      "prs_merged": 8
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 31,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/btwshivam.json
+++ b/public/data/contributors/btwshivam.json
@@ -193,5 +193,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 5,
+      "prs_opened": 7,
+      "prs_merged": 7
+    }
   ]
 }

--- a/public/data/contributors/castrojo.json
+++ b/public/data/contributors/castrojo.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 1
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 1,
+      "other_issues": 0,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/clubanderson.json
+++ b/public/data/contributors/clubanderson.json
@@ -1196,5 +1196,39 @@
       "month": "2026-04",
       "issue_count": 595
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 64,
+      "feature_issues": 13,
+      "other_issues": 1168,
+      "prs_opened": 4038,
+      "prs_merged": 3939
+    },
+    {
+      "repo": "kubestellar/console-kb",
+      "bug_issues": 0,
+      "feature_issues": 1,
+      "other_issues": 2,
+      "prs_opened": 1621,
+      "prs_merged": 1335
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 54,
+      "prs_opened": 289,
+      "prs_merged": 264
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 70,
+      "prs_opened": 16,
+      "prs_merged": 16
+    }
   ]
 }

--- a/public/data/contributors/francostellari.json
+++ b/public/data/contributors/francostellari.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/ghanshyam2005singh.json
+++ b/public/data/contributors/ghanshyam2005singh.json
@@ -299,5 +299,23 @@
       "month": "2026-04",
       "issue_count": 45
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 86,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 1,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 2,
+      "feature_issues": 0,
+      "other_issues": 3,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/gulshank0.json
+++ b/public/data/contributors/gulshank0.json
@@ -105,5 +105,23 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/harshakumar25.json
+++ b/public/data/contributors/harshakumar25.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/immortal71.json
+++ b/public/data/contributors/immortal71.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/jaimitus.json
+++ b/public/data/contributors/jaimitus.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/kchiranjewee63.json
+++ b/public/data/contributors/kchiranjewee63.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console-kb",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/khushal-winner.json
+++ b/public/data/contributors/khushal-winner.json
@@ -249,5 +249,15 @@
       "month": "2026-04",
       "issue_count": 23
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 11,
+      "feature_issues": 18,
+      "other_issues": 0,
+      "prs_opened": 43,
+      "prs_merged": 23
+    }
   ]
 }

--- a/public/data/contributors/khushiiagrawal.json
+++ b/public/data/contributors/khushiiagrawal.json
@@ -475,5 +475,23 @@
       "month": "2026-04",
       "issue_count": 87
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 80,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 0,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 8,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 13,
+      "prs_merged": 12
+    }
   ]
 }

--- a/public/data/contributors/khushisaifi8626-sketch.json
+++ b/public/data/contributors/khushisaifi8626-sketch.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 1
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/lightyagami2109.json
+++ b/public/data/contributors/lightyagami2109.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 3,
+      "prs_merged": 3
+    }
   ]
 }

--- a/public/data/contributors/mikeshng.json
+++ b/public/data/contributors/mikeshng.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/mjb-it.json
+++ b/public/data/contributors/mjb-it.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/mmagram0926.json
+++ b/public/data/contributors/mmagram0926.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 2,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/mrhapile.json
+++ b/public/data/contributors/mrhapile.json
@@ -1411,5 +1411,23 @@
       "month": "2026-04",
       "issue_count": 468
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 458,
+      "feature_issues": 0,
+      "other_issues": 29,
+      "prs_opened": 14,
+      "prs_merged": 9
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 10,
+      "prs_merged": 7
+    }
   ]
 }

--- a/public/data/contributors/mvanhorn.json
+++ b/public/data/contributors/mvanhorn.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/naman9271.json
+++ b/public/data/contributors/naman9271.json
@@ -361,5 +361,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 40,
+      "prs_opened": 71,
+      "prs_merged": 67
+    }
   ]
 }

--- a/public/data/contributors/namasl.json
+++ b/public/data/contributors/namasl.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 1,
+      "other_issues": 0,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/nehanataraj.json
+++ b/public/data/contributors/nehanataraj.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/ngvanthanggit.json
+++ b/public/data/contributors/ngvanthanggit.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/nil957.json
+++ b/public/data/contributors/nil957.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/oksaumya.json
+++ b/public/data/contributors/oksaumya.json
@@ -361,5 +361,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 42,
+      "prs_opened": 17,
+      "prs_merged": 13
+    }
   ]
 }

--- a/public/data/contributors/onkar717.json
+++ b/public/data/contributors/onkar717.json
@@ -165,5 +165,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 5,
+      "prs_opened": 8,
+      "prs_merged": 5
+    }
   ]
 }

--- a/public/data/contributors/p172913.json
+++ b/public/data/contributors/p172913.json
@@ -105,5 +105,31 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/rishi-jat.json
+++ b/public/data/contributors/rishi-jat.json
@@ -672,5 +672,23 @@
       "month": "2026-04",
       "issue_count": 84
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 94,
+      "feature_issues": 0,
+      "other_issues": 109,
+      "prs_opened": 0,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 33,
+      "feature_issues": 0,
+      "other_issues": 4,
+      "prs_opened": 4,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/rudy128.json
+++ b/public/data/contributors/rudy128.json
@@ -179,5 +179,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 3,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 7,
+      "prs_merged": 6
+    }
   ]
 }

--- a/public/data/contributors/sakshar2303.json
+++ b/public/data/contributors/sakshar2303.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 5,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/shivansh-source.json
+++ b/public/data/contributors/shivansh-source.json
@@ -354,5 +354,15 @@
       "month": "2026-04",
       "issue_count": 25
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 71,
+      "feature_issues": 2,
+      "other_issues": 3,
+      "prs_opened": 3,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/shubhamkumar9199.json
+++ b/public/data/contributors/shubhamkumar9199.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 2
+    }
   ]
 }

--- a/public/data/contributors/sicaario.json
+++ b/public/data/contributors/sicaario.json
@@ -105,5 +105,31 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/suhaani-agarwal.json
+++ b/public/data/contributors/suhaani-agarwal.json
@@ -105,5 +105,23 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/thisisvaishnav.json
+++ b/public/data/contributors/thisisvaishnav.json
@@ -179,5 +179,31 @@
       "month": "2026-04",
       "issue_count": 3
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console-kb",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 2,
+      "prs_opened": 3,
+      "prs_merged": 2
+    },
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 1,
+      "prs_opened": 0,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/tmchow.json
+++ b/public/data/contributors/tmchow.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/waltforme.json
+++ b/public/data/contributors/waltforme.json
@@ -179,5 +179,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 1,
+      "feature_issues": 0,
+      "other_issues": 3,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/xiaoamo22333.json
+++ b/public/data/contributors/xiaoamo22333.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/xonas1101.json
+++ b/public/data/contributors/xonas1101.json
@@ -1741,5 +1741,31 @@
       "month": "2026-04",
       "issue_count": 490
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 534,
+      "feature_issues": 7,
+      "other_issues": 28,
+      "prs_opened": 22,
+      "prs_merged": 17
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 9,
+      "feature_issues": 1,
+      "other_issues": 2,
+      "prs_opened": 9,
+      "prs_merged": 9
+    },
+    {
+      "repo": "kubestellar/console-marketplace",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/xyaz1313.json
+++ b/public/data/contributors/xyaz1313.json
@@ -105,5 +105,23 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 3,
+      "prs_merged": 0
+    },
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 0
+    }
   ]
 }

--- a/public/data/contributors/yizha1.json
+++ b/public/data/contributors/yizha1.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/console",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 1,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/zamadye.json
+++ b/public/data/contributors/zamadye.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 2,
+      "prs_merged": 1
+    }
   ]
 }

--- a/public/data/contributors/zyzzmohit.json
+++ b/public/data/contributors/zyzzmohit.json
@@ -105,5 +105,15 @@
       "month": "2026-04",
       "issue_count": 0
     }
+  ],
+  "repo_breakdown": [
+    {
+      "repo": "kubestellar/docs",
+      "bug_issues": 0,
+      "feature_issues": 0,
+      "other_issues": 0,
+      "prs_opened": 4,
+      "prs_merged": 1
+    }
   ]
 }

--- a/scripts/add-repo-breakdown.mjs
+++ b/scripts/add-repo-breakdown.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Faster script to add repo_breakdown to existing contributor profiles.
+ * This fetches contributor issues and groups them by repository.
+ * Unlike the full generation script, it skips NLP clustering.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=ghp_xxx node scripts/add-repo-breakdown.mjs
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REPOS = [
+  "kubestellar/console",
+  "kubestellar/console-marketplace",
+  "kubestellar/console-kb",
+  "kubestellar/docs",
+];
+
+const API_BASE = "https://api.github.com";
+const REST_PER_PAGE = 100;
+const REST_MAX_PAGES = 100;
+const REST_PAGE_DELAY_MS = 100;
+
+const TOKEN = process.env.GITHUB_TOKEN;
+if (!TOKEN) {
+  console.error("Error: GITHUB_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+const defaultHeaders = {
+  Accept: "application/vnd.github.v3+json",
+  Authorization: `Bearer ${TOKEN}`,
+};
+
+async function ghFetch(url) {
+  const res = await fetch(url, { headers: defaultHeaders });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub API ${res.status}: ${url}\n${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchAllIssues(owner, repo, creator) {
+  const items = [];
+  for (let page = 1; page <= REST_MAX_PAGES; page++) {
+    const url = `${API_BASE}/repos/${owner}/${repo}/issues?creator=${creator}&state=all&per_page=${REST_PER_PAGE}&page=${page}`;
+    const data = await ghFetch(url);
+    if (data.length === 0) break;
+    
+    for (const issue of data) {
+      items.push({
+        repo: `${owner}/${repo}`,
+        is_pr: !!issue.pull_request,
+        merged_at: issue.pull_request?.merged_at || null,
+        labels: issue.labels.map((l) => l.name),
+      });
+    }
+    
+    if (data.length < REST_PER_PAGE) break;
+    await delay(REST_PAGE_DELAY_MS);
+  }
+  return items;
+}
+
+async function main() {
+  // Read leaderboard
+  const leaderboardPath = join(__dirname, "..", "public", "data", "leaderboard.json");
+  const leaderboard = JSON.parse(readFileSync(leaderboardPath, "utf-8"));
+
+  const contributorProfiles = join(__dirname, "..", "public", "data", "contributors");
+
+  let updated = 0;
+  let total = 0;
+
+  for (const entry of leaderboard.entries) {
+    total++;
+    const login = entry.login;
+    const profilePath = join(contributorProfiles, `${login}.json`);
+
+    if (!existsSync(profilePath)) {
+      console.log(`Skipping ${login} - no profile file`);
+      continue;
+    }
+
+    const profile = JSON.parse(readFileSync(profilePath, "utf-8"));
+
+    // Skip if already has repo_breakdown
+    if (profile.repo_breakdown) {
+      console.log(`Skipping ${login} - already has repo_breakdown`);
+      continue;
+    }
+
+    console.log(`Fetching issues for ${login}...`);
+
+    try {
+      // Fetch issues from all repos
+      const allIssues = [];
+      for (const repo of REPOS) {
+        const [owner, repoName] = repo.split("/");
+        const issues = await fetchAllIssues(owner, repoName, login);
+        allIssues.push(...issues);
+      }
+
+      // Group by repo and categorize
+      const repoBreakdownMap = new Map();
+      for (const item of allIssues) {
+        if (!repoBreakdownMap.has(item.repo)) {
+          repoBreakdownMap.set(item.repo, {
+            repo: item.repo,
+            bug_issues: 0,
+            feature_issues: 0,
+            other_issues: 0,
+            prs_opened: 0,
+            prs_merged: 0,
+          });
+        }
+
+        const rb = repoBreakdownMap.get(item.repo);
+        if (item.is_pr) {
+          rb.prs_opened++;
+          if (item.merged_at) rb.prs_merged++;
+        } else {
+          if (item.labels.includes("kind/bug")) rb.bug_issues++;
+          else if (item.labels.includes("kind/feature")) rb.feature_issues++;
+          else rb.other_issues++;
+        }
+      }
+
+      const repoBreakdown = [...repoBreakdownMap.values()].sort(
+        (a, b) =>
+          (b.prs_opened + b.bug_issues + b.feature_issues + b.other_issues) -
+          (a.prs_opened + a.bug_issues + a.feature_issues + a.other_issues)
+      );
+
+      // Add repo_breakdown to profile
+      profile.repo_breakdown = repoBreakdown;
+
+      // Write updated profile
+      writeFileSync(profilePath, JSON.stringify(profile, null, 2) + "\n");
+      updated++;
+      console.log(`Updated ${login} with repo_breakdown (${repoBreakdown.length} repos)`);
+    } catch (err) {
+      console.error(`Error processing ${login}: ${err.message}`);
+    }
+
+    await delay(REST_PAGE_DELAY_MS);
+  }
+
+  console.log(
+    `\nDone! Updated ${updated} out of ${total} contributor profiles with repo_breakdown`
+  );
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes #1543

This PR adds repository contribution breakdown data to contributor profiles, enabling the Repository Contributions section in the contributor profile UI.

## Changes
- Added `repo_breakdown` field to contributor JSON profiles
- Field contains per-repository statistics: bug issues, feature issues, other issues, and PR counts
- Updated 70 contributor profiles with repository contribution data
- Created helper script `scripts/add-repo-breakdown.mjs` for generating repo breakdown data

## Testing
The Repository Contributions section should now display on contributor profile pages (e.g., `/leaderboard/username`), showing:
- Repository name and status badges
- Issue breakdown (bugs, features, other)
- PR counts (opened, merged)
- Total contribution count per repository