### PR TITLE
🐛 Fix console version menu: add v0.3.23, remove broken links

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -71,6 +71,19 @@
 [context."docs/kubeflex/0.7.0"]
   command = "NEXT_PUBLIC_BRANCH=docs/kubeflex/0.7.0 npm run build"
 
+# Console version branches
+[context."docs/console/0.3.20"]
+  command = "NEXT_PUBLIC_BRANCH=docs/console/0.3.20 npm run build"
+
+[context."docs/console/0.3.19"]
+  command = "NEXT_PUBLIC_BRANCH=docs/console/0.3.19 npm run build"
+
+[context."docs/console/0.3.6"]
+  command = "NEXT_PUBLIC_BRANCH=docs/console/0.3.6 npm run build"
+
+[context."docs/console/0.1.0"]
+  command = "NEXT_PUBLIC_BRANCH=docs/console/0.1.0 npm run build"
+
 # CORS headers for shared config (allows branch deploys to fetch from production)
 [[headers]]
   for = "/config/*"

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -2,10 +2,21 @@
   "surveyUrl": "https://forms.gle/Md2381TQ8CcjZv3LA",
   "versions": {
     "console": {
-      "main": {
-        "label": "main (latest)",
+      "latest": {
+        "label": "v0.3.23 (Latest)",
         "branch": "main",
         "isDefault": true
+      },
+      "main": {
+        "label": "main (dev)",
+        "branch": "main",
+        "isDefault": false,
+        "isDev": true
+      },
+      "0.3.20": {
+        "label": "v0.3.20",
+        "branch": "docs/console/0.3.20",
+        "isDefault": false
       },
       "0.3.19": {
         "label": "v0.3.19",
@@ -20,21 +31,6 @@
       "0.1.0": {
         "label": "v0.1.0",
         "branch": "docs/console/0.1.0",
-        "isDefault": false
-      },
-      "0.3.20": {
-        "label": "v0.3.20",
-        "branch": "docs/console/0.3.20",
-        "isDefault": false
-      },
-      "0.3.21": {
-        "label": "v0.3.21",
-        "branch": "docs/console/0.3.21",
-        "isDefault": false
-      },
-      "0.3.22": {
-        "label": "v0.3.22",
-        "branch": "docs/console/0.3.22",
         "isDefault": false
       }
     },
@@ -199,7 +195,7 @@
     "console": {
       "name": "KubeStellar Console",
       "basePath": "console",
-      "currentVersion": "main"
+      "currentVersion": "0.3.23"
     },
     "kubestellar": {
       "name": "KubeStellar",

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -207,20 +207,16 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // The "latest" entry tracks the most recent stable weekly release.
 // The goodnight workflow auto-updates this when a new release is detected.
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
-  main: {
-    label: "main (latest)",
+  latest: {
+    label: "v0.3.23 (Latest)",
     branch: "main",
     isDefault: true,
   },
-  "0.3.22": {
-    label: "v0.3.22",
-    branch: "docs/console/0.3.22",
+  main: {
+    label: "main (dev)",
+    branch: "main",
     isDefault: false,
-  },
-  "0.3.21": {
-    label: "v0.3.21",
-    branch: "docs/console/0.3.21",
-    isDefault: false,
+    isDev: true,
   },
   "0.3.20": {
     label: "v0.3.20",
@@ -290,7 +286,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "main",
+    currentVersion: "0.3.23",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
Fixes #1546

## Problem
The version dropdown for Console docs:
- Did NOT include v0.3.23 (the latest weekly release)
- Included v0.3.21 and v0.3.22 which linked to non-existent Netlify branch deploys (no `docs/console/0.3.21` or `docs/console/0.3.22` branches exist)

## Changes
- **`src/config/versions.ts`**: Added v0.3.23 as `latest` (default), changed `main` to dev, removed v0.3.21/v0.3.22 (no branches), updated `currentVersion` to `0.3.23`
- **`public/config/shared.json`**: Mirrored same version changes for runtime config
- **`netlify.toml`**: Added deploy contexts for existing console branches (0.3.20, 0.3.19, 0.3.6, 0.1.0) so their branch deploys build correctly