### PR TITLE
feat: leaderboard activity trend sparkline + sort by recent activity

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -51,6 +51,10 @@ const CONTRIBUTOR_LEVELS = [
   { rank: 8, name: "Legend", minCoins: 500000 },
 ];
 
+// ── Weekly activity trend constants ───────────────────────────────────
+const ACTIVITY_WEEKS = 12; // number of weeks to include in sparkline
+const RECENCY_HALF_LIFE = 3; // weeks — contribution weight halves every N weeks
+
 // ── GitHub API constants ──────────────────────────────────────────────
 /** Current-year start in ISO-8601 (matches console rewards scope) */
 const YEAR_START = `${new Date().getFullYear()}-01-01T00:00:00Z`;
@@ -263,6 +267,72 @@ async function fetchBonusPoints() {
   return bonuses;
 }
 
+// ── Weekly activity trend computation ─────────────────────────────────
+
+/**
+ * Returns the Monday-based ISO week start for a date string.
+ * Weeks are labeled as ISO dates (YYYY-MM-DD of the Monday).
+ */
+function weekKeyForDate(isoDateStr) {
+  const d = new Date(isoDateStr);
+  const day = d.getUTCDay();
+  const diff = (day === 0 ? -6 : 1) - day; // adjust to Monday
+  d.setUTCDate(d.getUTCDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Generates an array of Monday-based week keys for the last N weeks,
+ * oldest first.
+ */
+function getRecentWeekKeys(numWeeks) {
+  const now = new Date();
+  const keys = [];
+  for (let i = numWeeks - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i * 7);
+    keys.push(weekKeyForDate(d.toISOString()));
+  }
+  return [...new Set(keys)].sort();
+}
+
+/**
+ * Builds a per-login map of weekly contribution counts from all items.
+ * Returns Map<login, Map<weekKey, count>>.
+ */
+function buildWeeklyActivity(allItems) {
+  const activity = new Map();
+
+  for (const item of allItems) {
+    const login = item.user?.login;
+    if (!login || item.user?.type !== "User") continue;
+    if (EXCLUDED_LOGINS.has(login)) continue;
+    if (item.created_at < YEAR_START) continue;
+
+    if (!activity.has(login)) activity.set(login, new Map());
+    const weekMap = activity.get(login);
+    const wk = weekKeyForDate(item.created_at);
+    weekMap.set(wk, (weekMap.get(wk) || 0) + 1);
+  }
+
+  return activity;
+}
+
+/**
+ * Computes a recency-weighted activity score from weekly counts.
+ * Recent weeks count more — weight decays exponentially with half-life.
+ */
+function computeRecentScore(weeklyCounts) {
+  let score = 0;
+  const len = weeklyCounts.length;
+  for (let i = 0; i < len; i++) {
+    const weeksAgo = len - 1 - i;
+    const weight = Math.pow(0.5, weeksAgo / RECENCY_HALF_LIFE);
+    score += weeklyCounts[i] * weight;
+  }
+  return Math.round(score * 100) / 100;
+}
+
 // ── Main ──────────────────────────────────────────────────────────────
 async function main() {
   console.log("Fetching all issues and PRs from repos (bulk REST API)...\n");
@@ -313,11 +383,19 @@ async function main() {
   if (bonusMap.size === 0) console.log("  No bonus awards found.");
   console.log("");
 
+  // 2c. Build weekly activity sparkline data
+  console.log("Computing weekly activity trends...");
+  const weeklyActivityMap = buildWeeklyActivity(allItems);
+  const recentWeeks = getRecentWeekKeys(ACTIVITY_WEEKS);
+  console.log(`  Tracking ${recentWeeks.length} weeks: ${recentWeeks[0]} → ${recentWeeks[recentWeeks.length - 1]}\n`);
+
   // 3. Build sorted entries
   const entries = [];
   for (const [login, data] of contributorMap) {
     const level = getLevelForPoints(data.totalPoints);
     const bonus = bonusMap.get(login);
+    const loginWeeks = weeklyActivityMap.get(login) || new Map();
+    const weeklyCounts = recentWeeks.map((wk) => loginWeeks.get(wk) || 0);
     entries.push({
       login,
       avatar_url: data.avatarUrl,
@@ -326,6 +404,8 @@ async function main() {
       level_rank: level.rank,
       breakdown: data.breakdown,
       ...(bonus ? { bonus_points: bonus.points } : {}),
+      weekly_activity: weeklyCounts,
+      recent_activity_score: computeRecentScore(weeklyCounts),
     });
   }
 
@@ -352,6 +432,7 @@ async function main() {
     generated_at: new Date().toISOString(),
     git_hash: gitHash,
     year_start: YEAR_START,
+    activity_weeks: recentWeeks,
     entries,
   };
 

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -38,11 +38,16 @@ interface LeaderboardEntry {
   level: string;
   level_rank: number;
   breakdown: LeaderboardBreakdown;
+  weekly_activity?: number[];
+  recent_activity_score?: number;
 }
+
+type SortField = "points" | "activity";
 
 interface LeaderboardData {
   generated_at: string;
   git_hash?: string;
+  activity_weeks?: string[];
   entries: LeaderboardEntry[];
 }
 
@@ -174,6 +179,51 @@ function BreakdownPills({ breakdown }: { breakdown: LeaderboardBreakdown }) {
         </span>
       ))}
     </div>
+  );
+}
+
+// ── Activity sparkline ───────────────────────────────────────────────
+
+const SPARKLINE_WIDTH = 96;
+const SPARKLINE_HEIGHT = 24;
+const SPARKLINE_BAR_GAP = 1;
+
+function ActivitySparkline({ data, weeks }: { data: number[]; weeks?: string[] }) {
+  if (!data || data.length === 0) return <span className="text-xs text-gray-600">—</span>;
+
+  const max = Math.max(...data, 1);
+  const barWidth = (SPARKLINE_WIDTH - (data.length - 1) * SPARKLINE_BAR_GAP) / data.length;
+
+  return (
+    <svg
+      width={SPARKLINE_WIDTH}
+      height={SPARKLINE_HEIGHT}
+      viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+      className="flex-shrink-0"
+      role="img"
+      aria-label="Weekly activity trend"
+    >
+      {data.map((count, i) => {
+        const barHeight = Math.max(1, (count / max) * (SPARKLINE_HEIGHT - 2));
+        const x = i * (barWidth + SPARKLINE_BAR_GAP);
+        const y = SPARKLINE_HEIGHT - barHeight;
+        const isRecent = i >= data.length - 2;
+        const weekLabel = weeks?.[i] ?? `Week ${i + 1}`;
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={y}
+            width={barWidth}
+            height={barHeight}
+            rx={1}
+            fill={count === 0 ? "rgba(107,114,128,0.15)" : isRecent ? "rgba(59,130,246,0.7)" : "rgba(59,130,246,0.35)"}
+          >
+            <title>{`${weekLabel}: ${count} contributions`}</title>
+          </rect>
+        );
+      })}
+    </svg>
   );
 }
 
@@ -548,6 +598,7 @@ export default function LeaderboardPage() {
   const [affiliateData, setAffiliateData] = useState<Record<string, AffiliateData>>({});
   const [affiliateLoading, setAffiliateLoading] = useState(true);
   const [affiliateBannerOpen, setAffiliateBannerOpen] = useState(false);
+  const [sortField, setSortField] = useState<SortField>("points");
   const [hoveredLogin, setHoveredLogin] = useState<string | null>(null);
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -616,10 +667,18 @@ export default function LeaderboardPage() {
 
   const filteredEntries = useMemo(() => {
     if (!data?.entries) return [];
-    if (!search.trim()) return data.entries;
-    const q = search.toLowerCase();
-    return data.entries.filter((e) => e.login.toLowerCase().includes(q));
-  }, [data, search]);
+    let entries = data.entries;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      entries = entries.filter((e) => e.login.toLowerCase().includes(q));
+    }
+    if (sortField === "activity") {
+      entries = [...entries].sort((a, b) =>
+        (b.recent_activity_score ?? 0) - (a.recent_activity_score ?? 0)
+      );
+    }
+    return entries;
+  }, [data, search, sortField]);
 
   const lastUpdated = data?.generated_at
     ? new Date(data.generated_at).toLocaleDateString("en-US", {
@@ -799,10 +858,22 @@ export default function LeaderboardPage() {
             {!isLoading && !error && filteredEntries.length > 0 && (
               <div className="bg-gray-800/40 backdrop-blur-md rounded-xl border border-white/10 overflow-visible">
                 {/* Table header */}
-                <div className="hidden sm:grid sm:grid-cols-[60px_1fr_120px_120px_60px_1fr] gap-4 px-6 py-3 border-b border-white/5 text-xs text-gray-500 uppercase tracking-wider">
+                <div className="hidden sm:grid sm:grid-cols-[60px_1fr_120px_110px_120px_60px_1fr] gap-4 px-6 py-3 border-b border-white/5 text-xs text-gray-500 uppercase tracking-wider">
                   <div className="text-center">Rank</div>
                   <div>Contributor</div>
-                  <div className="text-right">Points</div>
+                  <button
+                    className={`text-right cursor-pointer hover:text-white transition-colors ${sortField === "points" ? "text-yellow-400" : ""}`}
+                    onClick={() => setSortField("points")}
+                  >
+                    Points {sortField === "points" ? "▼" : ""}
+                  </button>
+                  <button
+                    className={`text-center cursor-pointer hover:text-white transition-colors ${sortField === "activity" ? "text-blue-400" : ""}`}
+                    onClick={() => setSortField("activity")}
+                    title="Sort by recent activity (last 12 weeks, recency-weighted)"
+                  >
+                    Activity {sortField === "activity" ? "▼" : ""}
+                  </button>
                   <div className="text-center">Level</div>
                   <div className="text-center" title="Affiliate link clicks from social sharing">Social</div>
                   <div>Breakdown</div>
@@ -812,7 +883,7 @@ export default function LeaderboardPage() {
                 {filteredEntries.map((entry) => (
                   <div
                     key={entry.login}
-                    className="grid grid-cols-1 sm:grid-cols-[60px_1fr_120px_120px_60px_1fr] gap-2 sm:gap-4 px-4 sm:px-6 py-4 border-b border-white/5 last:border-0 hover:bg-white/[0.02] transition-colors items-center"
+                    className="grid grid-cols-1 sm:grid-cols-[60px_1fr_120px_110px_120px_60px_1fr] gap-2 sm:gap-4 px-4 sm:px-6 py-4 border-b border-white/5 last:border-0 hover:bg-white/[0.02] transition-colors items-center"
                   >
                     {/* Rank */}
                     <div className="hidden sm:flex justify-center">
@@ -880,6 +951,11 @@ export default function LeaderboardPage() {
                     {/* Points */}
                     <div className="text-right tabular-nums font-semibold text-yellow-400 text-sm pl-11 sm:pl-0">
                       {entry.total_points.toLocaleString()}
+                    </div>
+
+                    {/* Activity sparkline */}
+                    <div className="flex justify-center pl-11 sm:pl-0">
+                      <ActivitySparkline data={entry.weekly_activity || []} weeks={data?.activity_weeks} />
                     </div>
 
                     {/* Level */}


### PR DESCRIPTION
## Summary
- Adds a per-contributor **activity sparkline** to each leaderboard row showing weekly contribution counts over the last 12 weeks
- Adds a **sortable Activity column** — click "Activity" header to sort by most recently active contributors (recency-weighted score with 3-week half-life); click "Points" to return to default ranking
- Data is generated during the daily `generate-leaderboard.mjs` run — no runtime API calls needed

### Data generation changes (`scripts/generate-leaderboard.mjs`)
- Buckets each contribution by ISO week to produce `weekly_activity: number[]` (12 entries, oldest first)
- Computes `recent_activity_score` using exponential decay (half-life of 3 weeks) so recent contributions weigh more
- Adds `activity_weeks: string[]` to the JSON root for tooltip labels

### Frontend changes (`src/app/[locale]/leaderboard/page.tsx`)
- `ActivitySparkline` component renders inline SVG bars (96×24px) per row — recent weeks are brighter
- Column headers for Points and Activity are clickable sort toggles
- Grid layout updated from 6-column to 7-column to accommodate the new Activity column

## Test plan
- [ ] Run `GITHUB_TOKEN=xxx node scripts/generate-leaderboard.mjs` and verify `weekly_activity` + `recent_activity_score` fields in output
- [ ] Load leaderboard page — sparklines render in each row
- [ ] Click "Activity" header — rows reorder by recent activity
- [ ] Click "Points" header — rows return to default points ranking
- [ ] Hover sparkline bars — tooltips show week date and count
- [ ] Mobile layout still renders correctly (sparkline hidden in stacked view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)