### PR TITLE
docs: add hive as top-level project

### DIFF
--- a/docs/content/hive/architecture.md
+++ b/docs/content/hive/architecture.md
@@ -1,0 +1,229 @@
+# Architecture
+
+## Two scheduling models
+
+hive supports two fundamentally different ways to drive an agent. Choose based on how much control you want to keep.
+
+### Model A — Self-scheduling (/loop cron)
+
+The agent registers its own cron job (`/loop 15m …`) and fires on that cadence indefinitely. The supervisor's only job is to keep the session alive and respawn it if it crashes. Low operator involvement; the agent runs autonomously.
+
+**Best for:** Single-agent setups, batch jobs, anything where the cadence is fixed and you trust the agent to stay on task.
+
+### Model B — EXECUTOR MODE (supervisor-driven)
+
+The agent starts, reads its policy, then **waits at the prompt** for the supervisor to send work orders via `tmux send-keys`. No cron, no self-scheduling. The supervisor (another Claude Code session, a script, or a human) decides when to fire and what to do.
+
+**Best for:** Multi-agent setups where you want a single controller to prioritize across several agents, production workflows where you need to inspect output before triggering the next step, or any situation where the agent kept re-starting its own loop despite being told not to.
+
+> **Gotcha — session restore bakes in old crons.** Claude Code restores its previous conversation context on respawn. If the agent ever registered a `/loop` cron before, that cron comes back in the restored context even if the new `AGENT_LOOP_PROMPT` says not to. The preferred fix is to enforce EXECUTOR MODE via policy files the agent re-reads on every firing — not by having the supervisor send a cron-nuke message. Supervisor should never inspect or delete crontabs; policy is the enforcement mechanism.
+
+> **Gotcha — tmux `-l` makes Enter literal.** When dispatching work orders, always split text and Enter into **two separate** `tmux send-keys` calls:
+> ```sh
+> tmux send-keys -t session -l "do the thing"
+> sleep 1
+> tmux send-keys -t session Enter
+> ```
+> Combining them as `tmux send-keys -t session -l "do the thing" Enter` sends the word "Enter" as part of the literal text, leaving the agent stuck with text in its input box.
+
+---
+
+## Four components, four failure modes
+
+| # | Unit | Trigger | Catches |
+|---|---|---|---|
+| 1 | `hive.service` | Always running; internal poll every `AGENT_POLL_SEC` (default 10s) | Agent process crash, tmux session killed, TUI-ready detection for startup prompt injection, auto-approval of a known sensitive-file prompt |
+| 2 | `hive-renew.timer` | Every 6 days + 5 min after boot | Claude Code `/loop` cron auto-expires at 7 days — kills the session so the supervisor re-registers a fresh one. **Disable this in EXECUTOR MODE** — there is no cron to renew. |
+| 3 | `hive-healthcheck.timer` | Every 20 min + 5 min after boot | Agent is "alive" but not making progress (auth loop, stuck prompt, model stuck thinking) — watches heartbeat-file mtime |
+| 4 | ntfy push inside the healthcheck | On stall, on recovery, on escalation | Operator not watching the box — phone push |
+
+## Reactions to each failure mode
+
+### Model A (self-scheduling)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant S as supervisor
+    participant T as tmux session
+    participant A as agent
+    participant L as heartbeat.log
+    participant R as renew.timer
+    participant H as healthcheck.timer
+    participant N as ntfy.sh
+
+    Note over S,T: boot-time / first run
+    S->>T: new-session
+    T->>A: spawn agent
+    S->>T: wait for AGENT_READY_MARKER
+    S->>A: send AGENT_LOOP_PROMPT (/loop 15m …)
+    A->>A: register /loop 15m cron
+
+    loop every 15m (agent's own cron)
+        A->>L: append SCAN_START_ET
+        A->>A: do the work
+        A->>L: append SCAN_END_ET + findings
+    end
+
+    Note over R: every 6d
+    R->>T: kill-session
+    S->>T: new-session (fresh /loop, new 7d TTL)
+
+    Note over H: every 20m
+    H->>L: stat mtime
+    alt mtime fresh (age ≤ AGENT_STALE_MAX_SEC)
+        H->>N: (if was stale) "recovered"
+    else mtime stale
+        H->>T: kill-session
+        S->>T: new-session
+        H->>N: "stalled, respawning (n/MAX)"
+    end
+
+    Note over H: after AGENT_MAX_RESPAWNS failed attempts
+    H->>N: "manual intervention needed"
+    H->>H: stop auto-respawning until recovery
+```
+
+### Model B (EXECUTOR MODE)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as operator / supervisor session
+    participant S as supervisor service
+    participant T as tmux session
+    participant A as agent
+    participant H as healthcheck.timer
+    participant N as ntfy.sh
+
+    Note over S,T: boot-time / crash recovery
+    S->>T: new-session
+    T->>A: spawn agent
+    S->>T: wait for AGENT_READY_MARKER
+    S->>A: send EXECUTOR startup prompt (no /loop)
+    A->>A: reads policy, reports status, waits
+
+    loop operator-driven
+        Op->>T: tmux send-keys -l "work order text"
+        Op->>T: tmux send-keys Enter
+        A->>A: execute work order
+        A->>Op: (visible in pane) result summary
+    end
+
+    Note over H: every 20m
+    H->>H: stat heartbeat mtime (agent writes on each work order)
+    alt mtime stale
+        H->>T: kill-session
+        S->>T: new-session (EXECUTOR startup, cron nuke)
+        H->>N: "stalled, respawning"
+    end
+```
+
+---
+
+## Multi-agent topology
+
+When running several agents on the same machine, the EXECUTOR pattern lets a single supervisor session coordinate all of them without the agents conflicting:
+
+```
+┌─────────────────────────────────────┐
+│   supervisor session (Mac)          │
+│   /loop — sweeps every 20-25 min    │
+│   sends tmux work orders to agents  │
+└──────┬──────────┬──────────┬────────┘
+       │          │          │
+       ▼          ▼          ▼
+  scanner      reviewer   outreach
+  (Opus 4.7)  (Sonnet)   (Sonnet)
+  hive   hive  hive
+  tmux         tmux        tmux
+```
+
+Each agent:
+- Has its own tmux session and systemd service
+- Reads its own policy file from the shared memory directory
+- Writes to a shared work ledger (`bd` / beads) using `--actor <name>` to claim work
+- Skips items already claimed by another actor (`bd list --actor=<other> --status=in_progress`)
+- Notifies the operator via ntfy for decisions that require human judgment
+
+Renew timers are **disabled** for all agents in EXECUTOR MODE. The supervisor sends a fresh startup + cron-nuke on every respawn automatically.
+
+---
+
+## What this deliberately does NOT handle
+
+- **Remote box offline / network partition.** If the whole machine is down, there's no process left to push a stall alert. A secondary watcher outside the box (uptimerobot, healthchecks.io, your laptop) is the correct answer, and is out of scope for this repo.
+- **ntfy.sh downtime.** Free tier, rare, tolerable. Self-host or swap the transport if you need SLAs.
+- **Agent logic bugs.** If the agent decides to do nothing forever but remembers to write the heartbeat, the healthcheck won't catch it. The log format in your policy file should include non-trivial counts (repos scanned, actions taken) so you can spot a "no-op loop" visually.
+- **Secrets management.** Don't put credentials in `agent.env`. The agent should source them from its own credential store (`~/.claude/.credentials.json` for Claude Code, vault / secrets manager for anything else).
+
+---
+
+## Reference deployment: hybrid local scanner + GitHub responders
+
+Models A and B both put the AI agent on a periodic loop. A third pattern — used in production on [KubeStellar](https://kubestellar.io) — **decouples scanning from fixing**:
+
+- A lightweight **bash scanner** runs on a fixed timer (launchd or systemd), polling GitHub for open issues/PRs and writing state to a **SQLite database**. No LLM needed.
+- The **AI agent** reads the database when triggered (by skill invocation, `/loop` cron, or EXECUTOR work order) and fixes what's actionable.
+- **GitHub Actions workflows** on the repo auto-file issues when workflows fail, creating a feedback loop where the scanner picks up the new issue on its next cycle.
+
+This is not a new scheduling model — it's a **composition** of the existing patterns with a deterministic scanner in front and GitHub as an event source.
+
+### Why this pattern exists
+
+| Problem | How the hybrid solves it |
+|---|---|
+| AI session restarts / rate limits cause missed scans | Scanner runs independently — state is never lost |
+| Scanning is deterministic but consumes LLM tokens | Scanner is pure bash — zero LLM cost |
+| No audit trail of what was scanned | `cycles` table in SQLite records every scan |
+| Workflow failures go unnoticed for days | `workflow-failure-issue.yml` auto-files issues within minutes |
+| Fix attempts need backoff | `fix_attempts` counter prevents infinite retries |
+
+### Architecture
+
+```
+                        ┌──────────────────────┐
+                        │  GitHub (source of    │
+                        │  truth for issues/PRs)│
+                        └──────────┬───────────┘
+                                   │
+                    gh issue list / gh pr list
+                                   │
+┌──────────────────────────────────┼──────────────────────────────┐
+│  Local machine (Mac / Linux)     │                              │
+│                                  ▼                              │
+│  ┌─────────┐    ┌──────────┐    ┌──────────┐    ┌───────────┐  │
+│  │ launchd │───▶│worker.sh │───▶│ state.db │◀───│ AI agent  │  │
+│  │ / cron  │    │(scanner) │    │ (SQLite) │    │(reads DB, │  │
+│  └─────────┘    └────┬─────┘    └──────────┘    │ fixes)    │  │
+│                      │                           └─────┬─────┘  │
+│                  ntfy push                        git push      │
+│                      │                           gh pr create   │
+│                      ▼                                 │        │
+│                 ┌──────────┐                           │        │
+│                 │  phone   │                           │        │
+│                 └──────────┘                           │        │
+└────────────────────────────────────────────────────────┼────────┘
+                                                        │
+                                   mutates GitHub state (PRs, merges)
+                                                        │
+                                                        ▼
+                        ┌──────────────────────────────────────┐
+                        │  GitHub Actions (automated responders)│
+                        │                                      │
+                        │  workflow-failure-issue.yml           │
+                        │  → auto-files issue on failure       │
+                        │                                      │
+                        │  ai-fix.yml                          │
+                        │  → auto-dispatches fix on label      │
+                        └──────────────────────────────────────┘
+```
+
+**Data flow boundary**: GitHub Actions write to GitHub (issues, labels). The local scanner reads from GitHub and writes to SQLite. The AI agent reads SQLite and writes to GitHub. No component writes directly to another's state store.
+
+### Reference implementation
+
+- [`examples/worker.sh.example`](../examples/worker.sh.example) — the scanner script
+- [`examples/sqlite-state.md`](../examples/sqlite-state.md) — SQLite schema and query patterns
+- [`examples/kubestellar-fixer.md`](../examples/kubestellar-fixer.md) — full case study with results
+- [`launchd/`](../launchd/) — macOS plist templates for the scanner and supervisor

--- a/docs/content/hive/macos.md
+++ b/docs/content/hive/macos.md
@@ -1,0 +1,178 @@
+# macOS Support (launchd)
+
+The hive runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
+
+This guide shows how to run a supervised agent on a Mac that stays on (Mac Mini, Mac Studio, always-on laptop, etc.).
+
+---
+
+## Concept mapping
+
+| Linux (systemd) | macOS (launchd) | Role |
+|---|---|---|
+| `hive.service` | `LaunchAgent` plist | Keeps the supervisor alive, restarts on crash |
+| `hive-healthcheck.timer` | Second `LaunchAgent` plist with `StartCalendarInterval` | Periodic healthcheck |
+| `hive-renew.timer` | Third plist with 6-day interval | `/loop` cron renewal |
+| `systemctl enable --now` | `launchctl load -w` | Start + enable at login |
+| `systemctl stop` | `launchctl unload` | Stop |
+| `journalctl -u hive` | `StandardOutPath` / `StandardErrorPath` in plist | Logs |
+| `/etc/hive/agent.env` | Plist `EnvironmentVariables` dict or a sourced env file | Config |
+
+---
+
+## Quickstart
+
+### 1. Install prerequisites
+
+```sh
+brew install tmux curl jq
+# Install your AI CLI (e.g., Claude Code)
+npm install -g @anthropic-ai/claude-code
+claude /login
+```
+
+### 2. Create the config directory
+
+```sh
+mkdir -p ~/.config/hive
+cp config/agent.env.example ~/.config/hive/agent.env
+# Edit to match your setup:
+nano ~/.config/hive/agent.env
+```
+
+### 3. Install the LaunchAgent
+
+Copy the example plist, adjust paths, and load it:
+
+```sh
+# Copy the template
+cp launchd/com.hive.plist.example ~/Library/LaunchAgents/com.hive.plist
+
+# Edit: change all /Users/YOURUSER paths to your actual home directory
+nano ~/Library/LaunchAgents/com.hive.plist
+
+# Create log directory
+mkdir -p ~/.local/state/hive
+
+# Load (starts immediately + starts on every login)
+launchctl load -w ~/Library/LaunchAgents/com.hive.plist
+```
+
+### 4. Verify it's running
+
+```sh
+# Check launchd status
+launchctl list | grep hive
+
+# Attach to the tmux session
+tmux attach -t hive
+# Detach: Ctrl+B then D
+```
+
+### 5. Uninstall
+
+```sh
+launchctl unload ~/Library/LaunchAgents/com.hive.plist
+rm ~/Library/LaunchAgents/com.hive.plist
+# Optionally remove config + state:
+# rm -rf ~/.config/hive ~/.local/state/hive
+```
+
+---
+
+## Healthcheck on macOS
+
+On Linux, the healthcheck is a separate systemd timer. On macOS, use a second LaunchAgent with `StartCalendarInterval`:
+
+```xml
+<!-- ~/Library/LaunchAgents/com.hive.healthcheck.plist -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.hive.healthcheck</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/hive/bin/agent-healthcheck.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <!-- Every 20 minutes: :00, :20, :40 -->
+        <dict><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Minute</key><integer>20</integer></dict>
+        <dict><key>Minute</key><integer>40</integer></dict>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>AGENT_LOG_FILE</key>
+        <string>/Users/YOURUSER/.local/state/hive/heartbeat.log</string>
+        <key>AGENT_SESSION_NAME</key>
+        <string>hive</string>
+        <key>AGENT_STALE_MAX_SEC</key>
+        <string>1800</string>
+        <key>AGENT_MAX_RESPAWNS</key>
+        <string>3</string>
+        <key>NTFY_TOPIC</key>
+        <string>your-secret-topic</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/YOURUSER/.local/state/hive/healthcheck.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOURUSER/.local/state/hive/healthcheck.err</string>
+</dict>
+</plist>
+```
+
+---
+
+## Renew timer on macOS
+
+The renew timer kills and respawns the tmux session every 6 days to beat Claude Code's 7-day `/loop` expiry. On macOS, this is harder to express as a calendar interval (launchd doesn't have "every N days" natively).
+
+**Recommended approach**: use a wrapper script that checks the session age:
+
+```bash
+#!/bin/bash
+# renew-if-stale.sh — run hourly via launchd, only acts every 6 days
+SESSION="${AGENT_SESSION_NAME:-hive}"
+STATE_DIR="${HOME}/.local/state/hive"
+STAMP="$STATE_DIR/last-renew"
+
+# If stamp doesn't exist, create it and exit
+[ -f "$STAMP" ] || { date +%s > "$STAMP"; exit 0; }
+
+AGE=$(( $(date +%s) - $(cat "$STAMP") ))
+if [ "$AGE" -ge 518400 ]; then  # 6 days in seconds
+    tmux kill-session -t "$SESSION" 2>/dev/null
+    date +%s > "$STAMP"
+    # Supervisor will detect the missing session and respawn
+fi
+```
+
+Then set a launchd plist with `StartInterval` of 3600 (hourly check).
+
+---
+
+## Differences from Linux
+
+| Area | Linux | macOS |
+|---|---|---|
+| Shell | `/bin/bash` everywhere | `/bin/zsh` default; use `/opt/homebrew/bin/bash` for bash 5+ features (associative arrays) |
+| `stat` flags | `stat -c %Y file` | `stat -f %m file` |
+| Process management | `systemctl start/stop/restart` | `launchctl load/unload` |
+| Auto-start | `systemctl enable` | `load -w` flag persists across reboots |
+| Log viewing | `journalctl -u name -f` | `tail -f /path/to/log` (or Console.app) |
+| File locking | `flock` (coreutils) | `flock` via `brew install util-linux` or use lockfile pattern |
+| `date` command | GNU date (`date -d`) | BSD date (no `-d`; use `date -j -f`) |
+
+---
+
+## Alternative scheduler: standalone scanner script
+
+On macOS, some deployments skip the full supervisor+tmux pattern entirely and use a **standalone scanner script** fired by launchd on a fixed schedule. The script does the scanning/state-tracking work in bash, then triggers the AI agent (via a Copilot CLI skill, tmux work order, or similar) only when there's actionable work.
+
+This pattern is simpler when:
+- The scanning logic is deterministic (no LLM needed for triage)
+- You want the scanner to run even when the AI session is down
+- You want to decouple scan cadence from agent availability
+
+See [`examples/worker.sh.example`](../examples/worker.sh.example) for a reference implementation and [`examples/kubestellar-fixer.md`](../examples/kubestellar-fixer.md) for a full case study of this pattern in production.

--- a/docs/content/hive/outreach-antispam.md
+++ b/docs/content/hive/outreach-antispam.md
@@ -1,0 +1,428 @@
+# Outreach Anti-Spam & Deduplication Ruleset
+
+> **Author:** Outreach agent (self-authored from first principles, 2026-04-24)
+> **Purpose:** Prevent duplicate, unwanted, or spammy outreach across all surfaces — awesome lists,
+> CNCF project issues, directories, forums, comparison sites, community threads — across agent
+> restarts, multiple sessions, and time.
+
+---
+
+## 0. Core Principles
+
+**One action per target, ever.** A "target" is the combination of (surface, entity). For example:
+`github.com / dastergon/awesome-sre` is one target. Opening a second PR there after the first is
+spam, regardless of whether you remember the first. Every rule below enforces this principle.
+
+**One PR per GitHub user/org, ever.** Same owner = same person's inbox. Submitting to
+`dastergon/awesome-sre` AND `dastergon/awesome-chaos-engineering` means that person receives two
+PRs from you. This is spam even if the repos are different. **Before opening any PR, check how
+many open PRs you already have under that owner:**
+
+```bash
+# Pre-flight owner check (MANDATORY — run before every new PR)
+OWNER="<repo-owner>"
+unset GITHUB_TOKEN && gh search prs --author clubanderson --state open --limit 100 \
+  --json repository,number | python3 -c "
+import sys,json
+d=json.loads(sys.stdin.read())
+hits=[p for p in d if p['repository']['nameWithOwner'].startswith('$OWNER/')]
+if hits: print('SKIP — already have', len(hits), 'open PR(s) for', '$OWNER:', [p['repository']['nameWithOwner']+'#'+str(p['number']) for p in hits])
+else: print('OK — no open PRs for $OWNER')
+"
+```
+
+If any open PR already exists under that owner → **SKIP**. Do not open a second one.
+The only exception: a maintainer explicitly invites a resubmission to a different section
+(close the old PR first, then resubmit — still counts as one active PR at a time).
+
+---
+
+## 1. Pre-Flight Checklist (run before ANY outreach action)
+
+Execute every check in order. Stop at the first SKIP signal.
+
+```
+PRE-FLIGHT for target T:
+
+[ ] 1. ARCHIVED?        → gh repo view T --json isArchived | check true → SKIP
+[ ] 2. STALE?           → last commit > 18 months ago → SKIP (no one is merging PRs)
+[ ] 3. GA4 REFERRAL?    → query /api/analytics/dashboard trafficSources for T's domain → already live → SKIP
+[ ] 4. OPEN PR?         → gh search prs --author clubanderson --repo T --state open → exists → SKIP (address feedback instead)
+[ ] 5. CLOSED PR?       → gh search prs --author clubanderson --repo T --state closed → exists → COLD → SKIP
+[ ] 6. OPEN ISSUE?      → gh search issues --author clubanderson --repo T --state open → exists → SKIP
+[ ] 7. BEADS LOG?       → bd list | grep T → exists → check status → if done/cold SKIP
+[ ] 8. OUTREACH LOG?    → grep T docs/outreach-log.md → logged → SKIP
+[ ] 9. CONTRIBUTING.md? → read T's CONTRIBUTING.md for self-promo restrictions → if banned → COLD + SKIP
+[ ] 10. RELEVANCE?      → does T's topic overlap with Console's top GA4 pages? → if no overlap → defer
+[ ] 11. FORMAT CHECK?   → read last 5 entries of target file → can I match format exactly? → if no → research more before proceeding
+
+All checks pass → SAFE TO PROCEED
+```
+
+---
+
+## 2. Persistence Layers (Ground Truth, in Priority Order)
+
+Agent memory is ephemeral. These layers survive restarts:
+
+| Layer | How to Query | Survives Restart? | Authority |
+|-------|-------------|-------------------|-----------|
+| **GitHub itself** | `gh search prs/issues --author clubanderson` | ✅ Always | **Highest** |
+| **GA4 referral data** | `/.netlify/functions/analytics-dashboard` | ✅ Always | High (confirms placement live) |
+| **beads (`bd`)** | `bd list --json` | ✅ Yes (remote) | High |
+| **docs/outreach-log.md** | committed to this repo | ✅ Yes (git) | Medium |
+| **outreach-CLAUDE.md Current Progress** | committed to this repo | ✅ Yes (git) | Medium |
+| `/tmp` files | filesystem | ❌ Lost on reboot | Never rely on |
+| Session SQL | in-process SQLite | ❌ Lost on session end | Never rely on |
+| Agent in-memory variables | process memory | ❌ Lost on restart | Never rely on |
+
+**Rule:** Before any outreach pass, always query GitHub API (layer 1) and GA4 (layer 2) as ground truth. Treat logs as a cache — useful for fast skips but always verify against the source.
+
+### Updating Logs on Every Pass
+
+After each successful outreach action:
+1. Append to `docs/outreach-log.md` (committed)
+2. Update `outreach-CLAUDE.md` Current Progress section
+3. Commit both: `git commit -s -m '📖 Outreach: log [target]'`
+4. `bd create` a record if the action has follow-up needed (awaiting PR merge, waiting for maintainer reply)
+
+---
+
+## 3. Per-Surface Rules
+
+### 3.1 GitHub Awesome Lists
+
+**Nature:** Curated markdown files in public repos. PRs are the only contribution mechanism. Maintainer may take weeks to respond. Automated bots (CodeRabbit, Copilot Reviewer) often comment immediately.
+
+**Rules:**
+- **One PR per repo, ever.** Never open a second PR to the same repo.
+- **Fork under `clubanderson`**, never the org.
+- **Branch name:** `feat/add-kubestellar-console` — consistent, recognizable.
+- **Match the exact format** of the surrounding entries: link style, description length, sort order. Read the last 5 entries before writing.
+- **Placement matters:** Add to the most specific relevant section, not "Other" or "Miscellaneous" unless nothing else fits.
+- **Never add to multiple sections** in the same file — one entry per repo.
+- **Open PR is not closed:** Check for reviewer comments every 7 days for up to 3 cycles. Address all feedback from CodeRabbit/Copilot/humans. After 3 cycles with no maintainer engagement, mark as STALE (keep open, stop checking).
+- **Closed without merge:** Immediately mark COLD in log. Never reopen. Never open a new PR. Respect the decision.
+- **Merged:** Mark DONE. Verify GA4 referral traffic appears within 30 days (confirming it's indexed). No further action.
+
+**Format self-check before opening PR:**
+```
+- Is the repo accepting PRs? (check Issues tab for "not accepting contributions")
+- Does the list sort alphabetically? (place entry in correct position)
+- Are descriptions in sentence case or title case? (match)
+- Are there trailing periods? (match)
+- Does the list use `[Name](url) — description` or `[Name](url) - description`? (match exactly)
+```
+
+### 3.2 CNCF Project Outreach Issues (Install Missions)
+
+**Nature:** Opening GitHub issues on upstream CNCF project repos proposing a guided install mission or ACMM badge. These are long-lived relationships — the maintainer community notices patterns.
+
+**Rules:**
+- **One issue per project per topic.** If an install-mission issue is already open, never open an ACMM issue on the same repo simultaneously — combine into one thread or wait.
+- **Never open an issue AND a PR on the same repo for unrelated purposes in the same week** — it looks like a spam campaign.
+- **Read CONTRIBUTING.md first.** Some projects route external proposals through GitHub Discussions, not Issues.
+- **Tailor every issue body** to the project. Reference the specific project's technology. Never paste a generic template verbatim.
+- **Ping/nudge cadence:** Maximum 2 follow-up comments per issue. Minimum 7 days between comments. Never ping more than twice if there's been no response — mark as COLD and move on.
+- **Maintainer responds negatively:** Close the issue yourself, mark COLD, never reopen.
+- **Maintainer responds positively:** Follow through promptly (within 48h). If they ask for a PR on their docs, open it the same day. Delayed follow-through kills goodwill.
+- **ADOPTERS.md PRs:** Only after explicit maintainer approval in the upstream issue. **Never merge without operator sign-off.** One ADOPTERS PR per project, ever.
+
+### 3.3 Non-GitHub Directories and Registries
+
+**Nature:** CNCF Landscape, Artifact Hub, OperatorHub, StackShare, AlternativeTo, Product Hunt, etc. These are form-based or PR-based submission systems.
+
+**Rules:**
+- **Check if already listed first** via web search: `site:alternativeto.net "kubestellar"` before submitting.
+- **One submission per site, ever.** If the submission was rejected, mark COLD.
+- **Screenshot or log the submission** — these sites don't have a GitHub PR to verify later.
+- **Log to `docs/outreach-log.md`** with date and submission URL/confirmation.
+- **GA4 verification:** If the site starts sending referral traffic to console.kubestellar.io, the listing is live. No re-submission needed.
+
+### 3.4 Community Forums (Reddit, Hacker News, dev.to, Hashnode)
+
+**Nature:** Human communities. Spam is acutely noticed, permanently remembered, and actively harmful. These surfaces must be used sparingly and with genuine value.
+
+**Rules:**
+- **Reddit:** Maximum 1 original post per subreddit per 6 months. Commenting on relevant existing threads is allowed (not limited), but only when the comment genuinely adds value.
+- **HN Show HN:** One-time submission. Never resubmit the same project. Comment on relevant HN threads is fine.
+- **dev.to / Hashnode:** Articles can be published once; update the same article rather than publishing a new one. Never cross-post verbatim across both.
+- **Never use multiple accounts.**
+- **Don't post the same content to overlapping communities in the same week** (e.g., r/kubernetes AND r/devops on the same day with the same post).
+- **Track in log:** date, platform, URL, engagement metric (upvotes/comments) so you can measure whether forum posts drive traffic.
+
+### 3.5 Comparison Sites and Blog Aggregators
+
+**Nature:** Sites that accept tool listings or "best of" roundups (Slant, StackShare, G2, etc.).
+
+**Rules:**
+- **Search before submitting:** `"kubestellar console" site:stackshare.io` etc.
+- **One submission per site.**
+- **Log all submissions** — these sites have no GitHub API to check later.
+- **If GA4 shows referral from the site:** listing is live, mark DONE.
+
+### 3.6 Social Media (LinkedIn, X/Twitter)
+
+**Nature:** Public broadcasts. Not a "target" in the same sense — these don't leave a persistent artifact that can be checked.
+
+**Rules:**
+- **Minimum 14 days between similar posts** on the same platform.
+- **Track post topics in log** to avoid repetition.
+- **Never tag people who haven't engaged** — only tag maintainers who explicitly engaged in an issue/PR.
+
+---
+
+## 4. Cold Target Rules
+
+A target is **COLD** when any of the following are true:
+- PR closed without merge and maintainer left a negative/dismissive comment
+- Issue closed as "not relevant", "spam", or "won't fix"
+- Maintainer explicitly asked to not be contacted again
+- Submission rejected with explanation
+- Repo marked archived or locked after outreach was attempted
+
+**COLD handling:**
+1. Log it: `docs/outreach-log.md` entry with status=COLD and reason
+2. Never re-approach for 12 months minimum
+3. Exception: if the project releases a major version and their posture toward Console has clearly changed (e.g., they now use KubeStellar themselves), you may re-approach once with a fresh framing — note this in the log
+
+**Do not confuse STALE with COLD:**
+- STALE = no response from maintainer after 3 check-ins. Keep the PR open; don't follow up further. It may get merged eventually. Do not re-approach, but do not close.
+- COLD = explicitly rejected or hostile. Never re-approach.
+
+---
+
+## 5. GA4 Referral Signals as Deduplication
+
+The GA4 analytics dashboard (`/.netlify/functions/analytics-dashboard`) is the most authoritative source for confirming a placement is live. Query it before any outreach pass.
+
+### What GA4 tells you
+
+| Signal | Interpretation | Action |
+|--------|---------------|--------|
+| `trafficSources` shows `github.com / referral` with path matching target repo | PR is merged and traffic is flowing | Mark DONE, no follow-up needed |
+| CNCF outreach table shows sessions for project X | Outreach issue is generating visits | Check if sessions increased after last action — good signal to follow through |
+| Organic search sessions rising after a list merge | SEO is working, that list category is valuable | Prioritize more lists in same category |
+| A domain appears in referrers you didn't reach out to | Organic placement exists | Log as DONE (natural), no action needed |
+| `(direct)` traffic spikes after forum post | Post drove awareness | Note which post/subreddit in log |
+
+### GA4-informed prioritization
+
+Every outreach pass should start with a GA4 query and use it to:
+1. **Confirm what's already live** (skip those)
+2. **Identify which page categories get the most traffic** (prioritize lists in those categories)
+3. **Measure outreach ROI** by comparing sessions before/after specific placements
+
+Current GA4 strategic signals (as of 2026-04-24):
+- Google organic = 31 sessions (very low) → massive SEO opportunity; every awesome-list merge helps
+- GitHub referral = 164 sessions → GitHub-based outreach is the highest-ROI channel right now
+- AI/ML pages (AI Codebase Maturity 251 views, AI/ML 194, AI Agents 161) → AI/MLOps lists are high-value
+- Deploy/CI-CD pages popular → GitOps lists are worth targeting
+- India #1 country → Indian DevOps community resources worth targeting
+- Missions: 32 started, 0 completed → don't pitch "mission completion" as a feature yet
+
+---
+
+## 6. Time-Based Pacing
+
+| Surface | Min Interval Between Actions | Max Follow-ups | Follow-up Interval |
+|---------|------------------------------|----------------|-------------------|
+| Awesome list PRs | N/A (one-shot) | 2 follow-up comments | 7 days |
+| CNCF project issues | 14 days between comments | 2 comments | 14 days |
+| ADOPTERS PRs | N/A (one-shot, awaits approval) | 1 ping | 7 days after opening |
+| Reddit posts | 6 months per subreddit | 0 (don't bump your own posts) | N/A |
+| dev.to articles | N/A (publish once, update in-place) | N/A | N/A |
+| HN | One-time | 0 | N/A |
+| Directory submissions | N/A (one-shot) | 1 follow-up if form-based | 30 days |
+| LinkedIn posts | 14 days per topic | N/A | N/A |
+
+---
+
+## 7. Decision Tree (Quick Reference)
+
+```
+Is the target archived or inactive (>18 months)?
+  YES → SKIP
+
+Does GA4 show referral traffic already coming from this target?
+  YES → SKIP (placement is live)
+
+Does `gh search prs --author clubanderson --repo TARGET` show an open PR?
+  YES → SKIP (check for feedback to address instead)
+
+Does `gh search prs --author clubanderson --repo TARGET` show a closed PR?
+  YES → COLD → SKIP
+
+Does `gh search issues --author clubanderson --repo TARGET` show an open issue?
+  YES → SKIP (check for feedback to address instead)
+
+Is the target logged as DONE or COLD in docs/outreach-log.md or beads?
+  YES → SKIP
+
+Does the target's CONTRIBUTING.md prohibit self-promotion?
+  YES → COLD → SKIP
+
+Does the target's topic overlap Console's top GA4 page categories?
+  NO → defer to lower priority
+
+Does the target accept PRs / have recent merge activity?
+  NO → SKIP
+
+Can I match the target's exact format?
+  NO → research more first
+
+→ SAFE TO PROCEED
+   After action: log it, commit log, send ntfy
+```
+
+---
+
+## 8. Log Format
+
+Every outreach action must be appended to `docs/outreach-log.md` in this format:
+
+```
+| DATE       | SURFACE                        | TARGET                          | ACTION        | STATUS  | NOTES                                      |
+|------------|--------------------------------|----------------------------------|---------------|---------|---------------------------------------------|
+| 2026-04-24 | awesome-list                   | dastergon/awesome-sre            | PR #268       | open    | No feedback yet                             |
+| 2026-04-24 | cncf-issue                     | chaos-mesh/chaos-mesh            | Issue #4858   | open    | @STRRL engaged, docs PR opened              |
+| 2026-04-24 | adopters-pr                    | kubestellar/console#7889         | PR open       | pending | Awaiting @STRRL approval                    |
+| 2026-04-24 | directory                      | stackshare.io                    | form-submit   | done    | GA4 confirmed referral 2026-05-01           |
+```
+
+Status values: `open` | `merged` | `closed-cold` | `pending` | `done` | `stale` | `cold`
+
+---
+
+## 9. Awesome-List & External Directory Submission Tracker
+
+This section defines the canonical tracking format for every awesome-list PR and external directory
+submission. It fills the gap that CNCF install missions have detailed per-project tracking but
+awesome-list submissions historically had none.
+
+### Why this matters
+
+Without a persistent log, the agent will:
+- Open duplicate PRs on repos it already submitted to
+- Lose context on which PRs received feedback and went stale
+- Have no way to measure which list categories drive the most GA4 referral traffic
+- Be unable to prioritize follow-up (open PRs with reviewer comments vs. stale PRs vs. merged)
+
+### Tracking file: `docs/outreach-log.md`
+
+All awesome-list PRs and directory submissions are logged in `docs/outreach-log.md` in this repo.
+The file must be committed after every outreach pass. It is the ground-truth complement to GitHub's
+own PR search (which is the canonical dedup check, but not as fast to query in bulk).
+
+### Row format
+
+```
+| DATE       | CATEGORY     | TARGET REPO / SITE              | SECTION ADDED TO        | PR / SUBMISSION URL                     | STATUS   | GA4 REFERRAL? | NOTES                          |
+|------------|-------------|----------------------------------|-------------------------|-----------------------------------------|----------|---------------|-------------------------------|
+| 2026-04-24 | awesome-list | dastergon/awesome-sre            | Monitoring              | https://github.com/…/pull/268           | open     | no            | No feedback yet               |
+| 2026-04-24 | awesome-list | veggiemonk/awesome-docker        | Monitoring & Observ.    | https://github.com/…/pull/1417          | open     | no            | No feedback yet               |
+| 2026-04-24 | directory    | stackshare.io                    | Kubernetes Tools        | https://stackshare.io/…                 | done     | yes           | Confirmed referral 2026-05-01 |
+| 2026-04-24 | awesome-list | tmrts/awesome-kubernetes         | Monitoring              | https://github.com/…/pull/6             | merged   | yes           | 3 referral sessions/month     |
+```
+
+**Status values:**
+
+| Value | Meaning |
+|-------|---------|
+| `open` | PR is open, awaiting review |
+| `merged` | PR was merged ✅ |
+| `rejected` | PR closed without merge, maintainer opposed |
+| `ignored` | PR open > 60 days with zero maintainer engagement |
+| `stale` | 3 check-in cycles with no response; keep open but stop following up |
+| `cold` | Explicitly rejected or maintainer asked not to be contacted; never retry |
+| `done` | Directory/non-PR submission confirmed live (GA4 or manually verified) |
+| `pending` | Submission sent, awaiting confirmation |
+
+### State machine
+
+```
+                  ┌─────────────────┐
+  PR opened  ──▶  │      open       │
+                  └────────┬────────┘
+                           │
+             ┌─────────────┼──────────────┬─────────────┐
+             ▼             ▼              ▼             ▼
+          merged       rejected      ignored (60d)  stale (3 cycles)
+             │             │              │             │
+           DONE          COLD           COLD       keep open,
+         (log GA4)    (never retry)  (never retry) no follow-up
+```
+
+### When to update a row
+
+| Trigger | Action |
+|---------|--------|
+| PR opened | Add row with status=open |
+| CI/bot comments on PR | Note in NOTES, no status change |
+| Human reviewer requests changes | Note in NOTES; address feedback; no status change |
+| PR merged by maintainer | Update status → merged; check GA4 within 30 days |
+| PR closed without merge (dismissively) | Update status → rejected → cold |
+| PR open > 60 days, zero maintainer engagement | Update status → ignored → cold |
+| 3 follow-up cycles with no response | Update status → stale |
+| GA4 shows referral from that domain | Add "yes" to GA4 REFERRAL column |
+
+### Follow-up cadence per PR
+
+```
+Day  0: PR opened
+Day  7: Check for reviewer comments. Address any. Note in log.
+Day 14: Second check. If reviewer comments unaddressed, address now.
+Day 21: Third check (final). If still no engagement, mark stale.
+Day 60: If still open and stale, mark ignored → cold in log.
+```
+
+Maximum 2 proactive follow-up comments on any single PR. Only comment if:
+- A reviewer left actionable feedback you're responding to, OR
+- It has been > 30 days and you are doing a hygiene pass (one brief ping max)
+
+### Querying the log
+
+To quickly see what's already been targeted:
+
+```bash
+# All open PRs
+grep "| open" docs/outreach-log.md
+
+# All merged (confirm GA4)
+grep "| merged" docs/outreach-log.md | grep "no" | awk '{print $3}'
+
+# All cold targets (never re-approach)
+grep "| cold\|rejected\|ignored" docs/outreach-log.md
+
+# Repos already tried (dedup check)
+grep "awesome-list" docs/outreach-log.md | awk -F'|' '{print $3}' | sort -u
+```
+
+### Cross-check with GitHub API (required on every pass)
+
+The log can become stale if a PR is merged without the agent noticing. Always verify:
+
+```bash
+# Get ground truth for all open clubanderson PRs
+unset GITHUB_TOKEN && gh search prs --author clubanderson --state open --limit 50 \
+  --json repository,number,title,updatedAt
+
+# Get closed PRs (merged or rejected) — update log if found
+unset GITHUB_TOKEN && gh search prs --author clubanderson --state closed --limit 50 \
+  --json repository,number,title,updatedAt
+```
+
+Reconcile any discrepancy between GitHub state and log state immediately — GitHub wins.
+
+---
+
+## 10. Anti-Spam Invariants (Never Break These)
+
+1. **Never open two PRs to the same repo.** Not even with different content.
+2. **Never open an issue on a repo where a PR is already open**, unless the issue is about something entirely unrelated (which is unlikely in outreach context).
+3. **Never post the same content to two overlapping communities in the same week.**
+4. **Never ping a maintainer more than twice** with no response.
+5. **Never misrepresent KubeStellar's relationship to a project.** "Guided install mission available" is true. "KubeVirt uses KubeStellar Console" is not (unless confirmed).
+6. **Never submit to a directory without checking if already listed.**
+7. **Never rely on memory alone.** Always verify via GitHub API or GA4 before acting.
+8. **Always log before you forget.** Log the action immediately after taking it, not at the end of the pass.

--- a/docs/content/hive/readme.md
+++ b/docs/content/hive/readme.md
@@ -1,0 +1,311 @@
+# hive
+
+**One command starts everything. Your phone, Slack, or Discord buzzes if anything needs you.**
+
+![hive dashboard](https://raw.githubusercontent.com/kubestellar/hive/main/docs/dashboard-screenshot.png)
+
+---
+
+![hive architecture](https://raw.githubusercontent.com/kubestellar/hive/main/docs/hive-arch.svg)
+
+---
+
+## Setup
+
+```bash
+# 1. install tmux
+sudo apt install tmux
+
+# 2. install hive
+curl -fsSL https://raw.githubusercontent.com/kubestellar/hive/main/install.sh | sudo bash
+
+# 3. configure
+sudo nano /etc/hive/hive.conf
+
+# 4. start
+hive supervisor
+```
+
+That's it. `hive supervisor` installs missing tools, starts all agents, sets the kick cadence, and launches the supervisor. No tmux knowledge needed.
+
+---
+
+## Commands
+
+```bash
+hive supervisor             # start everything
+hive status                 # live terminal dashboard (cached repo data)
+hive status --repos         # refresh repo issue/PR counts from GitHub API
+hive status --json          # machine-readable JSON output
+hive status --json --repos  # JSON with fresh repo data (used by dashboard slow path)
+hive status --watch 5       # auto-refresh every 5 seconds (in-place overwrite)
+hive dashboard              # launch web dashboard (port 3001)
+hive attach supervisor      # watch the supervisor  (Ctrl+B D to leave)
+hive attach scanner         # watch any agent
+
+hive kick all               # immediate kick to all agents
+hive kick scanner           # kick one agent
+
+hive switch scanner claude  # switch CLI backend (pins it)
+hive switch reviewer copilot
+hive unpin scanner          # let governor manage CLI again
+
+hive logs governor          # tail governor decisions
+hive logs scanner           # tail any agent's service log
+
+hive stop all               # stop everything
+```
+
+---
+
+## Web Dashboard
+
+`hive dashboard` launches a real-time web dashboard on port 3001.
+
+- **Live updates** via SSE — agent states, governor mode, repo counts, and beads refresh every 5 seconds
+- **Sparkline history** — per-agent busy time and restart count sparklines with rolling history
+- **Restart tracking** — 24-hour restart count per agent with color-coded thresholds (yellow >0, red >5)
+- **Kick buttons** — one-click kick for any agent
+- **Switch dropdown** — switch agent CLI backend from the UI (auto-pins to prevent governor override)
+- **CLI pinning** — `hive switch` pins the backend so the governor won't override it; `hive unpin` releases it
+- **Intensity gauge** — half-circle speedometer comparing recent vs trailing token rates (cooling → steady → surging)
+- **Coverage tracking** — shows test coverage progress toward the configured target
+- **Übersicht widget** — download a macOS desktop widget from the button in the header
+- **Fast/slow refresh** — agent status refreshes every 5s; GitHub repo data refreshes every 60s to avoid API rate limits
+
+The dashboard runs as a systemd service (`hive-dashboard.service`) and auto-restarts on failure.
+
+```bash
+# Manual access
+open http://192.168.4.56:3001    # from LAN
+open http://localhost:3001       # from hive itself
+
+# Install Übersicht widget (macOS)
+curl -sf http://192.168.4.56:3001/api/widget | tar xzf - -C "$HOME/Library/Application Support/Übersicht/widgets/"
+```
+
+---
+
+## How it works
+
+The **kick-governor** measures issue and PR backlog across your repos every 5 minutes and picks a mode:
+
+| Mode | Trigger | Scanner | Reviewer | Architect | Outreach | Supervisor |
+|------|---------|---------|----------|-----------|----------|-----------|
+| SURGE | queue > 20 | 10 min | 10 min | **paused** | **paused** | 5 min |
+| BUSY  | queue > 10 | 15 min | 15 min | **paused** | **paused** | 5 min |
+| QUIET | queue > 2  | 15 min | 30 min | 1 h        | 2 h        | 5 min |
+| IDLE  | queue ≤ 2  | 30 min | 1 h    | 30 min     | 30 min     | 5 min |
+
+Architect and outreach are **opportunistic** — they fill idle cycles and pause entirely under load. Supervisor runs every 5 min regardless of mode.
+
+Cadences are tunable in `/etc/hive/governor.env` — no restart needed.
+
+### Restart tracking
+
+Each supervisor process tracks agent restarts in `/var/run/kick-governor/restarts_<session>`. The count is a rolling 24-hour window — old timestamps are pruned automatically. The dashboard and `hive status --json` both expose the `restarts` field per agent.
+
+---
+
+## Deterministic Pipeline
+
+Hive separates work into two layers:
+
+- **Deterministic layer** (shell scripts + JSON + config) — handles every decision where a human would give the same answer every time. Runs before agents wake up.
+- **Non-deterministic layer** (LLM agents) — receives pre-computed data and focuses on judgment calls: reading code, reasoning about fixes, writing PRs.
+
+The rule: **if a human would give the same answer every time, it belongs in infrastructure, not in a prompt.**
+
+LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliably prevents an agent from closing a hold-labeled issue or merging an untested PR. The deterministic pipeline removes those decisions from the agent entirely.
+
+### Pipeline stages
+
+Each stage runs as a shell script, declared in `hive-project.yaml`, with explicit dependencies:
+
+| Category | What it does | Example |
+|----------|-------------|---------|
+| **Enumerator** | Fetches and filters the canonical work list | `enumerate-actionable.sh` — queries GitHub, excludes hold/exempt labels, filters by author |
+| **Classifier** | Enriches items with deterministic metadata | `issue-classifier.sh` — complexity, model tier, lane assignment based on label/title patterns |
+| **Gate** | Pre-checks eligibility before action | `merge-gate.sh` — CI green? Author authorized? Required reviews in? |
+| **Monitor** | Detects state in external systems | `ga4-anomaly-detector.sh` — production error spikes; `copilot-comment-checker.sh` — unaddressed review comments |
+| **Enforcer** | Blocks agents from forbidden operations | `gh` wrapper — prevents merging to main, closing hold issues, pushing to protected branches |
+
+Stages declare their consumers and dependencies. The pipeline runner resolves the DAG and executes in parallel where possible.
+
+### Adding a pipeline stage
+
+1. Add an entry to `pipeline.stages[]` in `hive-project.yaml`
+2. Write the script in `bin/`
+3. Declare `output`, `consumers`, `phase`, and `depends`
+4. The pipeline runner picks it up on the next kick cycle
+
+### Config-driven rules
+
+Classification patterns, clustering signals, severity keywords, and exempt labels all live in `hive-project.yaml`. Scripts read rules from config — they don't contain project-specific logic. Change the config, change the behavior.
+
+---
+
+## Adapting for Your Project
+
+Hive is designed to be forked and configured, not hardcoded. All project-specific values live in `hive-project.yaml`.
+
+### Step by step
+
+1. **Copy the example config:**
+   ```bash
+   sudo cp examples/kubestellar/hive-project.yaml /etc/hive/hive-project.yaml
+   ```
+
+2. **Edit the `project` section** — your org, repos, AI author account:
+   ```yaml
+   project:
+     name: "My Project"
+     org: "my-org"
+     primary_repo: "my-org/my-repo"
+     repos:
+       - my-org/my-repo
+       - my-org/my-docs
+     ai_author: "my-bot-account"
+   ```
+
+3. **Edit `agents.enabled`** — pick which agents you need:
+   ```yaml
+   agents:
+     enabled:
+       - supervisor
+       - scanner
+       - reviewer
+       # - architect    # optional
+       # - outreach     # optional
+       # - docs-agent   # add your own
+   ```
+
+4. **Edit `classification`** — your labels, lane patterns, complexity rules:
+   ```yaml
+   classification:
+     complexity:
+       simple:
+         labels: ["typo", "docs"]
+         model: "haiku"
+       complex:
+         labels: ["architecture", "epic"]
+         model: "opus"
+       default_model: "sonnet"
+   ```
+
+5. **Copy and edit agent CLAUDE.md files** from `examples/kubestellar/agents/`. Template variables like `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, and `${PROJECT_AI_AUTHOR}` are substituted automatically at kick time — you don't need to hardcode your project values.
+
+6. **Set agent `.env` files** with your workdir and model preferences.
+
+7. **Start:**
+   ```bash
+   hive supervisor
+   ```
+
+### Template variables
+
+Agent policy files (CLAUDE.md) support these template variables, substituted by `kick-agents.sh` at kick time:
+
+| Variable | Source in config | Example value |
+|----------|-----------------|---------------|
+| `${PROJECT_ORG}` | `project.org` | `kubestellar` |
+| `${PROJECT_PRIMARY_REPO}` | `project.primary_repo` | `kubestellar/console` |
+| `${PROJECT_AI_AUTHOR}` | `project.ai_author` | `clubanderson` |
+| `${PROJECT_REPOS_LIST}` | `project.repos` | `kubestellar/console kubestellar/docs ...` |
+| `${HIVE_REPO}` | `project.hive_repo` | `kubestellar/hive` |
+| `${GA4_PROPERTY_ID}` | `outreach.ga4.property_id` | `525401563` |
+| `${AGENTS_WORKDIR}` | `agents.workdir` | `/home/dev/my-project` |
+| `${BEADS_BASE}` | `agents.beads_base` | `/home/dev` |
+
+---
+
+## Backends
+
+Set `HIVE_BACKENDS` in `hive.conf`. `HIVE_AUTO_INSTALL=true` installs missing backends on startup.
+
+| Backend | Type | Description |
+|---------|------|-------------|
+| `claude` | CLI | Anthropic's CLI — runs Claude models directly |
+| `gemini` | CLI | Google's CLI — runs Gemini models directly |
+| `copilot` | Aggregate | GitHub Copilot — routes to Claude, GPT, Gemini, and other vendor models |
+| `goose` | Aggregate | Block's Goose — routes to any model via config: qwen, deepseek, llama, and more (cloud or local) |
+
+**Native backends** (`claude`, `gemini`) are single-vendor tools that run their own models directly. **Aggregate backends** (`copilot`, `goose`) are multi-vendor routers — they can call models from different providers through a single interface.
+
+### Local models (optional)
+
+Set `HIVE_MODEL_SERVICES="ollama litellm"` to run models on-device with no API costs.
+
+```
+ollama        → runs local models (llama3, codestral, qwen2.5-coder, ...)
+    └── litellm proxy :4000  ← unified OpenAI-compatible endpoint
+            └── goose        ← points here when AGENT_BACKEND=goose
+```
+
+Ollama and litellm start as background services before any agent session launches.
+
+---
+
+## Notifications
+
+hive sends alerts to any combination of ntfy, Slack, and Discord. Set whichever you use in `hive.conf` — all three fire simultaneously if configured.
+
+| Channel | Config key | How to get it |
+|---------|-----------|---------------|
+| ntfy (phone push) | `NTFY_TOPIC` | Free at [ntfy.sh](https://ntfy.sh) — pick any topic string |
+| Slack | `SLACK_WEBHOOK` | api.slack.com/apps → Incoming Webhooks |
+| Discord | `DISCORD_WEBHOOK` | Channel Settings → Integrations → Webhooks |
+
+---
+
+## Config
+
+`/etc/hive/hive.conf` — the only file you need to edit:
+
+```bash
+# Repos to watch (space-separated)
+HIVE_REPOS="owner/repo1 owner/repo2"
+
+# Agent CLI backends to use (space-separated)
+HIVE_BACKENDS="copilot"          # copilot claude gemini goose
+
+# Local model services (optional — needs GPU or fast CPU)
+# HIVE_MODEL_SERVICES="ollama litellm"
+
+# Auto-install missing backends on hive supervisor start
+HIVE_AUTO_INSTALL=true
+
+# Notifications — set any combination
+NTFY_TOPIC=your-secret-topic     # free at ntfy.sh
+# SLACK_WEBHOOK=https://hooks.slack.com/services/...
+# DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
+```
+
+---
+
+## Troubleshooting
+
+```bash
+hive status                  # check what's running
+hive logs governor           # why did it kick / not kick?
+hive logs scanner            # what is scanner doing?
+hive attach supervisor       # watch supervisor live
+journalctl -u claude-scanner # raw service log
+```
+
+### Common issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| All agents idle, no ntfy | Governor crashing (check `hive logs governor`) | See below |
+| Governor: `Permission denied` on `/var/run/kick-governor/` | Root-owned files from `sudo` operations | `sudo chown -R dev:dev /var/run/kick-governor/` |
+| Governor: `Slack: command not found` | Broken comments in `notify.sh` | Reinstall: `sudo cp bin/notify.sh /usr/local/bin/notify.sh` |
+| Governor: `$2: unbound variable` | `set -u` + missing arg defaults | Use `${N:-}` syntax in all function params |
+| Dashboard: agents show `stopped` / CLI `?` | Service running as root (can't see dev's tmux) | Add `User=dev` to `hive-dashboard.service` |
+| Dashboard: widget download 404 | Stale node process on port 3001 | `ss -tlnp \| grep 3001` → `kill <PID>` → restart service |
+| `bd dolt push` fails | Root-owned `.beads/` files | `sudo chown -R dev:dev ~/.beads/ /home/dev/scanner-beads/.beads/` |
+| Beads: `?` in status | `bd list` blocked by stale lock | `sudo killall -9 bd && rm -f /home/dev/scanner-beads/.beads/embeddeddolt/.lock` |
+
+---
+
+Apache 2.0  ·  [Architecture](docs/architecture.md)  ·  [KubeStellar example](examples/kubestellar/)

--- a/docs/content/hive/troubleshooting.md
+++ b/docs/content/hive/troubleshooting.md
@@ -1,0 +1,164 @@
+# Troubleshooting
+
+## The `/loop` prompt never fires — the agent just sits at the prompt
+
+Cause: the supervisor's `AGENT_READY_MARKER` doesn't appear in the agent's TUI, so the supervisor gives up before sending `AGENT_LOOP_PROMPT`.
+
+Fix: attach to the session, look at the footer the agent shows when it's accepting input (for Claude Code v2.x it's "bypass permissions on"), and put that string in `AGENT_READY_MARKER` in `/etc/hive/agent.env`. Then:
+
+```sh
+sudo systemctl stop hive
+sudo -u "$AGENT_USER" tmux kill-session -t "$AGENT_SESSION_NAME"
+sudo systemctl start hive
+```
+
+## A permission prompt blocks every `/loop` iteration
+
+Cause: the agent is hitting an interactive prompt that needs a human to dismiss. For Claude Code writing to `memory/` triggers a "sensitive file" prompt even under `--dangerously-skip-permissions`.
+
+Fix: find the unique text of the "accept" option (e.g. `Yes, and always allow access to`) and put it in `AGENT_AUTO_APPROVE_PHRASE`. The supervisor will auto-send `Down Enter` the next time that phrase appears in the pane.
+
+If your agent needs multiple different approvals, extend `approve_prompt_if_present()` in `bin/supervisor.sh` to loop over a list of phrases.
+
+## `systemctl restart hive` didn't pick up my new `AGENT_LOOP_PROMPT`
+
+This is a footgun and it's worth repeating: **plain `systemctl restart` doesn't cause a session respawn.** tmux sessions survive supervisor exit, so when the new supervisor starts and sees a "healthy" old session with an "alive" agent, it does nothing. The old session is still running the old prompt.
+
+For a full reset you need:
+
+```sh
+sudo systemctl stop hive
+sudo -u "$AGENT_USER" tmux kill-session -t "$AGENT_SESSION_NAME"
+sudo systemctl start hive
+```
+
+Now the new supervisor finds no session, creates one, and sends the current `AGENT_LOOP_PROMPT`.
+
+## ntfy push never arrives
+
+Run in order:
+
+```sh
+# 1. Manual test — does ntfy work at all?
+curl -d "test" "$NTFY_SERVER/$NTFY_TOPIC"
+
+# 2. Is the healthcheck env correct?
+systemctl cat hive-healthcheck.service
+# Look for EnvironmentFile=/etc/hive/agent.env
+
+# 3. Run the healthcheck by hand to see any errors:
+sudo -u "$AGENT_USER" env $(cat /etc/hive/agent.env | xargs) /usr/local/bin/agent-healthcheck.sh
+
+# 4. Is the log actually stale?
+stat "$AGENT_LOG_FILE"
+```
+
+If step 1 works but the healthcheck doesn't push, the most common cause is `NTFY_TOPIC` being blank or misspelled in the env file.
+
+## Supervisor keeps respawning even though the agent looks healthy
+
+Check the `agent_alive()` heuristic in `bin/supervisor.sh`. It considers the agent dead if no non-shell process is running under the pane PID. If your launch command has an extra shell wrapper, the supervisor may mistake the wrapper for "dead." Remove the wrapper, or edit the heuristic.
+
+## Agent writes the heartbeat but scans are obviously broken
+
+The healthcheck only knows about file mtime. If the agent's iteration code is silently noop-ing but still remembers to append to the log, the healthcheck is happy. Two defensive patterns:
+
+1. **Put counts in the log.** If `Issues triaged: 0` for 8 firings in a row, something's wrong. You'll see it in `tail -f $AGENT_LOG_FILE`.
+2. **Add your own smoke-check** as a second systemd timer that hits an external endpoint (GitHub API, your app) and cross-checks the agent's reported state.
+
+## Where do I see what the agent is doing right now?
+
+```sh
+sudo -u "$AGENT_USER" tmux attach -t "$AGENT_SESSION_NAME"
+# Ctrl+B, D to detach — session keeps running.
+
+# Or just peek without attaching:
+sudo -u "$AGENT_USER" tmux capture-pane -t "$AGENT_SESSION_NAME" -p -S -50
+```
+
+## Switching Claude Code models via tmux
+
+The `/model` slash command inside Claude Code has a picker with only three choices: **Default** (Opus 4.7), **Sonnet** (Sonnet 4.6), and **Haiku** (Haiku 4.5). There is no picker entry for Opus 4.6.
+
+To select a model not shown in the picker, pass the **full model slug** to `/model`:
+
+```
+/model claude-opus-4-6
+```
+
+### Known model slugs
+
+| Alias in picker | Full slug | Notes |
+|----------------|-----------|-------|
+| Default (Opus 4.7) | `claude-opus-4-7` | Latest, highest capability |
+| — | `claude-opus-4-6` | Not in picker — must use full slug |
+| Sonnet | `claude-sonnet-4-6` | Best for everyday tasks |
+| Haiku | `claude-haiku-4-5` | Fastest |
+
+### What does NOT work
+
+| Command | Result |
+|---------|--------|
+| `/model opus 4` | `Model 'opus 4' not found` |
+| `/model claude-opus-4` | `Model 'claude-opus-4' not found` |
+| `/model --model claude-opus-4-6` | `Model '--model claude-opus-4-6' not found` (treats flag as model name) |
+| `/fast` | Toggles "Fast mode" billing tier for Opus 4.6 — does NOT switch the model itself |
+
+### Sending via tmux (supervisor)
+
+When switching an agent's model via `tmux send-keys`, the full sequence is:
+
+```sh
+tmux send-keys -t <session> '/model claude-opus-4-6'
+tmux send-keys -t <session> Enter
+```
+
+Confirm by reading the pane — the footer should show `Opus 4.6`:
+
+```sh
+tmux capture-pane -t <session> -p | grep -i opus
+```
+
+### Confirming with `claude -p`
+
+To verify a slug works before sending it to an agent session:
+
+```sh
+claude -p --model claude-opus-4-6 "say hello"
+```
+
+If the slug is valid, you'll get a response. If not, you'll get an error.
+
+## CI check rules for merging PRs
+
+All agents that merge PRs (scanner, reviewer, supervisor) MUST follow these rules:
+
+### Non-negotiable
+
+1. **ALL required CI checks must show SUCCESS before merging.** Run `gh pr checks <number> --required` and verify every line says `pass`. If any check is `pending` or `fail`, WAIT.
+2. **The ONLY exception is `tide`.** Prow's merge queue (`tide`) stays pending forever without `lgtm`/`approved` labels. If `tide` is the only non-passing check, treat CI as green and merge.
+3. **Never batch-merge.** After merging one PR, wait for the next PR's CI to re-run against the updated base. PRs green before a merge may conflict after.
+4. **Merge sequence:** merge one → wait for next PR's CI to re-trigger and pass → merge next.
+
+### Why `tide` is safe to ignore
+
+`tide` is Prow's automatic merge controller. It requires `lgtm` + `approved` labels to queue a PR. Since AI-authored PRs use `--admin --squash` merge (bypassing Prow), `tide` will never transition to `success`. It is not a CI quality gate — it is a merge queue status indicator.
+
+### Checking CI status
+
+```sh
+# Check all checks (filter out tide)
+gh pr checks <number> --required 2>&1 | grep -v tide
+
+# Quick pass/fail summary
+gh pr checks <number> --required 2>&1 | grep -v tide | grep -E "fail|pending"
+# If no output → safe to merge
+```
+
+## Clean reinstall
+
+```sh
+sudo ./uninstall.sh
+# (optionally remove /etc/hive/agent.env and the heartbeat log dir)
+sudo ./install.sh
+```

--- a/src/app/docs/[...slug]/layout.tsx
+++ b/src/app/docs/[...slug]/layout.tsx
@@ -15,6 +15,7 @@ function getProjectFromSlug(slug: string[]): ProjectId {
     if (slug[0] === 'multi-plugin') return 'multi-plugin'
     if (slug[0] === 'kubestellar-mcp') return 'kubestellar-mcp'
     if (slug[0] === 'console') return 'console'
+    if (slug[0] === 'hive') return 'hive'
   }
   return 'kubestellar'
 }

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -20,6 +20,8 @@ export function getContentPath(projectId: ProjectId): string {
       return path.join(process.cwd(), 'docs', 'content', 'kubestellar-mcp')
     case 'console':
       return path.join(process.cwd(), 'docs', 'content', 'console')
+    case 'hive':
+      return path.join(process.cwd(), 'docs', 'content', 'hive')
     default:
       return docsContentPath
   }
@@ -38,6 +40,8 @@ export function getBasePath(projectId: ProjectId): string {
       return 'docs/kubestellar-mcp'
     case 'console':
       return 'docs/console'
+    case 'hive':
+      return 'docs/hive'
     default:
       return 'docs'
   }
@@ -228,6 +232,30 @@ const NAV_STRUCTURE_CONSOLE: Array<{ title: string; items: NavItem[] }> = [
   }
 ]
 
+// Hive Navigation Structure
+const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
+  {
+    title: 'Overview',
+    items: [
+      { 'Introduction': 'readme.md' },
+      { 'Architecture': 'architecture.md' },
+    ]
+  },
+  {
+    title: 'Getting Started',
+    items: [
+      { 'macOS Setup': 'macos.md' },
+      { 'Troubleshooting': 'troubleshooting.md' },
+    ]
+  },
+  {
+    title: 'Reference',
+    items: [
+      { 'Outreach Anti-Spam': 'outreach-antispam.md' },
+    ]
+  }
+]
+
 // KubeStellar Navigation Structure
 const NAV_STRUCTURE_KUBESTELLAR: Array<{ title: string; items: NavItem[] }> = [
 
@@ -409,6 +437,9 @@ function getNavStructure(projectId: ProjectId): Array<{ title: string; items: Na
       break
     case 'console':
       baseStructure = NAV_STRUCTURE_CONSOLE
+      break
+    case 'hive':
+      baseStructure = NAV_STRUCTURE_HIVE
       break
     default:
       baseStructure = NAV_STRUCTURE_KUBESTELLAR

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -32,6 +32,7 @@ const GENERAL_SECTION_NAMES = GENERAL_SECTION_SLUGS.map(
 // Project display order and labels — each with a landing href for navigation links
 const PRIMARY_PROJECTS = [
   { id: 'console', label: 'KubeStellar Console', href: '/docs/console/overview/introduction' },
+  { id: 'hive', label: 'Hive', href: '/docs/hive/overview/introduction' },
   { id: 'kubestellar-mcp', label: 'KubeStellar MCP', href: '/docs/kubestellar-mcp/overview/introduction' },
 ] as const;
 

--- a/src/components/docs/DocsSourceActions.tsx
+++ b/src/components/docs/DocsSourceActions.tsx
@@ -13,6 +13,7 @@ const STATIC_EDIT_BASE_URLS: Record<ProjectId, string> = {
   "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
   "kubestellar-mcp": "https://github.com/kubestellar/kubectl-claude/edit/main/docs",
   console: 'https://github.com/kubestellar/console/edit/main/docs',
+  hive: 'https://github.com/kubestellar/hive/edit/main/docs',
 };
 
 // Prevent path traversal

--- a/src/components/docs/EditPageLink.tsx
+++ b/src/components/docs/EditPageLink.tsx
@@ -11,6 +11,7 @@ const STATIC_EDIT_BASE_URLS: Record<ProjectId, string> = {
   "multi-plugin": 'https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin',
   "kubestellar-mcp": 'https://github.com/kubestellar/kubectl-claude/edit/main/docs',
   console: 'https://github.com/kubestellar/console/edit/main/docs',
+  hive: 'https://github.com/kubestellar/hive/edit/main/docs',
 };
 
 interface EditPageLinkProps {

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -16,7 +16,7 @@ export const NETLIFY_SITE_NAME = "kubestellar-docs"
 export const PRODUCTION_URL = "https://kubestellar.io"
 
 // Project identifiers
-export type ProjectId = "kubestellar" | "a2a" | "kubeflex" | "multi-plugin" | "kubestellar-mcp" | "console"
+export type ProjectId = "kubestellar" | "a2a" | "kubeflex" | "multi-plugin" | "kubestellar-mcp" | "console" | "hive"
 
 // Version info structure
 export interface VersionInfo {
@@ -240,6 +240,15 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   },
 }
 
+// hive versions
+const HIVE_VERSIONS: Record<string, VersionInfo> = {
+  latest: {
+    label: "main (Latest)",
+    branch: "main",
+    isDefault: true,
+  },
+}
+
 // All projects configuration
 export const PROJECTS: Record<ProjectId, ProjectConfig> = {
   kubestellar: {
@@ -290,6 +299,14 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },
+  "hive": {
+    id: "hive",
+    name: "Hive",
+    basePath: "hive",
+    currentVersion: "main",
+    contentPath: "docs/content/hive",
+    versions: HIVE_VERSIONS,
+  },
 }
 
 // Get project from URL pathname
@@ -308,6 +325,9 @@ export function getProjectFromPath(pathname: string): ProjectConfig {
   }
   if (pathname.startsWith("/docs/console")) {
     return PROJECTS["console"]
+  }
+  if (pathname.startsWith("/docs/hive")) {
+    return PROJECTS["hive"]
   }
   return PROJECTS.kubestellar
 }


### PR DESCRIPTION
## Summary
- Adds **Hive** as a top-level project in the docs site left sidebar (between Console and KubeStellar MCP)
- Configures version routing, content path, nav structure, and slug detection
- Imports initial docs from `kubestellar/hive` repo: README, architecture, macOS setup, troubleshooting, outreach anti-spam

## Files changed
- `src/config/versions.ts` — add `hive` to `ProjectId`, `HIVE_VERSIONS`, `PROJECTS`, `getProjectFromPath()`
- `src/app/docs/page-map.ts` — add `NAV_STRUCTURE_HIVE`, hive cases in `getContentPath()`, `getBasePath()`, `getNavStructure()`
- `src/components/docs/DocsSidebar.tsx` — add hive to `PRIMARY_PROJECTS`
- `src/app/docs/[...slug]/layout.tsx` — add hive detection in `getProjectFromSlug()`
- `docs/content/hive/` — 5 markdown files imported from kubestellar/hive

## Test plan
- [ ] Verify `/docs/hive/overview/introduction` renders the hive README
- [ ] Verify hive appears in left sidebar between Console and KubeStellar MCP
- [ ] Verify navigation within hive docs works (architecture, macOS, troubleshooting)
- [ ] Verify other projects' routing is unaffected