### PR TITLE
feat: add read-only hive dashboard at /live/hive

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -97,6 +97,19 @@
   # Enable spam filtering
   spam_protection = true
 
+# Serve static hive dashboard snapshot (bypass Next.js middleware)
+[[redirects]]
+  from = "/live/hive"
+  to = "/live/hive/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/live/hive/"
+  to = "/live/hive/index.html"
+  status = 200
+  force = true
+
 # Redirects for short URLs
 
 # Redirect console-docs.kubestellar.io to kubestellar.io/docs/console

--- a/public/live/hive/index.html
+++ b/public/live/hive/index.html
@@ -1,0 +1,1894 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>🐝 KubeStellar Hive Dashboard for KubeStellar/Console</title>
+  <style>
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --green: #3fb950;
+      --yellow: #d29922; --red: #f85149; --blue: #58a6ff;
+      --cyan: #39d2c0; --purple: #bc8cff;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      background: var(--bg); color: var(--text);
+      padding: 24px; min-height: 100vh;
+    }
+    h1 { font-size: 1.4rem; margin-bottom: 20px; display: flex; align-items: center; }
+    h1 span.bee { font-size: 1.6rem; margin-right: 8px; }
+    .timestamp { color: var(--muted); font-size: 0.8rem; margin-left: 12px; }
+    .git-version { font-size: 0.65rem; color: var(--muted); margin-left: 10px; font-weight: 400; font-family: monospace; }
+    .git-version .git-behind { color: var(--yellow); font-weight: 600; }
+    .git-version .git-dirty { color: var(--yellow); }
+    .header-spacer { flex: 1; }
+    .widget-dl {
+      font-size: 0.75rem; color: var(--cyan); text-decoration: none;
+      border: 1px solid var(--cyan); border-radius: 6px; padding: 4px 10px;
+      transition: background 0.2s, color 0.2s; margin-left: auto; margin-right: auto;
+    }
+    .widget-dl:hover { background: var(--cyan); color: var(--bg); }
+
+    /* Agent cards */
+    .agents { display: grid; grid-template-columns: 1fr; gap: 12px; margin-bottom: 24px; }
+    .agent-card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 16px; transition: border-color 0.3s;
+      position: relative;
+    }
+    .agent-card.working { border-color: var(--green); }
+    .agent-card.idle { border-color: var(--border); }
+    .agent-card.stopped { border-color: var(--red); }
+    .agent-card.needs-login { border-color: #ef4444; }
+    .login-warning { background: rgba(239,68,68,0.15); color: #ef4444; font-size: 0.75rem; font-weight: 700; text-align: center; padding: 4px 8px; border-radius: 4px; margin-top: 6px; }
+    .agent-state { text-align: right; font-size: 0.75rem; font-weight: 600; margin-top: 6px; }
+    .agent-state.working { color: var(--green); }
+    .agent-state.idle { color: var(--muted); }
+    .agent-state.paused { color: #f85149; }
+    .status-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 2px 6px; border-radius: 4px; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .status-badge.blocked { background: rgba(248,81,73,0.2); color: #f85149; border: 1px solid rgba(248,81,73,0.4); }
+    .status-badge.needs-context { background: rgba(210,153,34,0.2); color: #d2992a; border: 1px solid rgba(210,153,34,0.4); }
+    .status-badge.done-concerns { background: rgba(227,139,44,0.2); color: #e38b2c; border: 1px solid rgba(227,139,44,0.4); }
+    .status-badge.done { background: rgba(63,185,80,0.15); color: #3fb950; border: 1px solid rgba(63,185,80,0.3); }
+    .agent-card.status-blocked { border-color: #f85149 !important; }
+    .agent-card.status-needs-context { border-color: #d2992a !important; }
+    @keyframes pulse-amber { 0%,100% { border-color: rgba(210,153,34,0.3); } 50% { border-color: rgba(210,153,34,0.8); } }
+    .agent-card.status-stale { animation: pulse-amber 2s ease-in-out infinite; }
+    .agent-name { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
+    .agent-name .dot {
+      display: inline-block; width: 8px; height: 8px;
+      border-radius: 50%; margin-right: 6px;
+    }
+    .dot.running { background: var(--green); }
+    .dot.stopped { background: var(--red); }
+    .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
+    .agent-field .label { color: var(--muted); }
+    .agent-field .value { text-align: right; }
+    .value.working { color: var(--green); }
+    .restart-label { font-size: 0.6rem; color: var(--muted); margin-left: 3px; }
+    .restart-warn { color: var(--yellow); }
+    .restart-high { color: var(--red); }
+    .restart-spark { display: inline-block; margin-left: 6px; vertical-align: middle; }
+    .restart-reset { cursor: pointer; font-size: 0.55rem; color: var(--muted); background: none; border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; margin-left: 4px; vertical-align: middle; transition: all 0.2s; }
+    .restart-reset:hover { color: var(--text); border-color: var(--text); }
+    .value.idle { color: var(--muted); }
+    .value.copilot { color: var(--cyan); }
+    .value.claude { color: var(--purple); }
+    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.5; min-height: 5.6em; width: 100%; }
+    .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
+    .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
+    .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
+    /* Agent metric gauges — removed, replaced by health panel */
+    .agent-actions { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+    .kick-prompt {
+      flex: 1 1 100%; background: var(--bg); border: 1px solid var(--border);
+      color: var(--text); padding: 4px 8px; border-radius: 4px; font-size: 0.75rem;
+      font-family: inherit; outline: none; min-width: 0;
+    }
+    .kick-prompt:focus { border-color: var(--accent); }
+    .kick-prompt::placeholder { color: var(--muted); }
+    .btn-toggle { cursor: pointer; font-size: 0.7rem; padding: 3px 8px; border-radius: 4px; border: 1px solid var(--border); background: var(--surface); color: var(--muted); transition: all 0.2s; }
+    .btn-toggle:hover { border-color: var(--accent); color: var(--text); }
+    .btn-toggle.paused { background: rgba(248,81,73,0.15); border-color: #f85149; color: #f85149; }
+    .btn-toggle.running { background: rgba(63,185,80,0.15); border-color: #3fb950; color: #3fb950; }
+    .agent-card.paused { border-color: #f85149; opacity: 0.7; }
+    .agent-card.paused .agent-state { color: #f85149; }
+    .pause-badge { display: inline-block; font-size: 0.6rem; background: rgba(248,81,73,0.15); color: #f85149; border: 1px solid rgba(248,81,73,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
+
+    /* Health status panel */
+    .health { margin-bottom: 24px; }
+    .health h2 { font-size: 0.95rem; margin-bottom: 8px; color: var(--muted); }
+    .health-grid { display: flex; flex-wrap: wrap; gap: 12px; }
+    .health-item {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 10px 16px; display: flex; align-items: center; gap: 8px;
+      font-size: 0.8rem;
+    }
+    .health-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+    .health-dot.ok { background: #3fb950; }
+    .health-dot.fail { background: #f85149; }
+    .health-dot.unknown { background: #8b949e; }
+    .health-label { color: var(--text); }
+    .health-ci { font-weight: 700; }
+    .health-ci.good { color: #3fb950; }
+    .health-ci.warn { color: #d29922; }
+    .health-ci.bad { color: #f85149; }
+    .btn {
+      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
+      border: 1px solid var(--border); background: var(--surface);
+      color: var(--muted); cursor: pointer; font-family: inherit;
+      transition: all 0.2s;
+    }
+    .btn:hover { background: var(--border); color: var(--text); }
+    .terminal-link {
+      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
+      border: 1px solid var(--cyan); background: transparent;
+      color: var(--cyan); cursor: pointer; font-family: inherit;
+      text-decoration: none; transition: all 0.2s; display: inline-block;
+    }
+    .terminal-link:hover { background: var(--cyan); color: var(--bg); }
+    .restart-btn {
+      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
+      border: 1px solid var(--yellow); background: transparent;
+      color: var(--yellow); cursor: pointer; font-family: inherit;
+      transition: all 0.2s; display: inline-block;
+    }
+    .restart-btn:hover { background: var(--yellow); color: var(--bg); }
+    .backend-select {
+      appearance: none; -webkit-appearance: none;
+      background: var(--surface); color: var(--muted);
+      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
+      border: 1px solid var(--border); cursor: pointer; font-family: inherit;
+    }
+    .backend-select:hover { background: var(--border); color: var(--text); }
+    .backend-select option { background: var(--surface); color: var(--text); }
+    .backend-select option:disabled { color: var(--muted); }
+
+    /* Governor */
+    .governor {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 16px; margin-bottom: 24px;
+    }
+    @media (max-width: 480px) {
+      .governor { padding: 10px; }
+      .pause-badge { font-size: 0.55rem; padding: 0px 3px; margin-left: 2px; }
+    }
+    .governor.dead { border-color: var(--red); }
+    .governor.active { border-color: var(--green); }
+    .gov-title { font-size: 1rem; font-weight: 700; margin-bottom: 8px; }
+    .gov-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; }
+    .gov-stat { font-size: 0.85rem; }
+    .gov-stat .label { color: var(--muted); font-size: 0.75rem; }
+    .gov-stat .val { font-size: 1.2rem; font-weight: 700; }
+    .gov-stat .val.active { color: var(--green); }
+    .gov-stat .val.dead { color: var(--red); }
+
+    /* Repos */
+    .repos { margin-bottom: 24px; }
+    .repos h2 { font-size: 0.95rem; margin-bottom: 8px; color: var(--muted); }
+    .repo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 8px; }
+    .repo-card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 12px; overflow: hidden;
+    }
+    .repo-name { font-size: 0.85rem; font-weight: 600; margin-bottom: 6px; }
+    .repo-name a:hover { text-decoration: underline !important; }
+    .repo-stats { display: flex; gap: 16px; font-size: 0.8rem; }
+    .repo-stat .num { font-weight: 700; font-size: 1rem; }
+    .repo-stat .label { color: var(--muted); font-size: 0.7rem; }
+    .repo-stat a:hover { text-decoration: underline !important; }
+    .repo-stat a:hover .label { color: var(--fg); }
+
+    /* Sparklines */
+    .sparkline { display: inline-block; vertical-align: middle; margin-left: 6px; flex-shrink: 0; }
+    .sparkline svg { display: block; }
+    .spark-row { display: flex; align-items: center; gap: 6px; overflow: hidden; }
+
+    /* Beads */
+    .beads { display: flex; gap: 24px; font-size: 0.85rem; }
+    .bead-stat .num { font-weight: 700; font-size: 1.1rem; }
+    .bead-stat .label { color: var(--muted); font-size: 0.75rem; }
+
+    /* Connection indicator */
+    .connection {
+      position: fixed; top: 8px; right: 12px;
+      font-size: 0.7rem; color: var(--muted);
+    }
+    .connection .dot-live { color: var(--green); }
+    .connection .dot-dead { color: var(--red); }
+
+    /* Slow blink for LIVE indicator */
+    @keyframes slow-blink { 0%,100% { opacity: 1; } 50% { opacity: 0.2; } }
+    .connection.live { animation: slow-blink 3s ease-in-out infinite; }
+
+    /* Pulse animation for working agents */
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.6; } }
+    .agent-card.working .agent-name { animation: pulse 2s ease-in-out infinite; }
+
+    /* Breathing green indicator for working agent cards — top right */
+    @keyframes breathe-green {
+      0%,100% { opacity: 1; box-shadow: 0 0 6px 2px rgba(63,185,80,0.5); }
+      50% { opacity: 0.25; box-shadow: 0 0 2px 0px rgba(63,185,80,0.1); }
+    }
+    .working-indicator {
+      position: absolute; top: 12px; right: 12px;
+      width: 8px; height: 8px; border-radius: 50%;
+      background: var(--green); display: none;
+    }
+    .agent-card.working .working-indicator {
+      display: block;
+      animation: breathe-green 4s ease-in-out infinite;
+    }
+
+    /* Green pulsing dot for active agents in cadence matrix */
+    @keyframes green-pulse { 0%,100% { opacity: 1; box-shadow: 0 0 4px var(--green); } 50% { opacity: 0.3; box-shadow: none; } }
+    .active-dot {
+      display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--green); margin-right: 6px; vertical-align: middle;
+      animation: green-pulse 6s ease-in-out infinite;
+    }
+
+    /* Temperature gauge */
+    .temp-gauge { margin: 12px 0 8px; }
+    .temp-gauge-label { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; display: flex; justify-content: space-between; }
+    .temp-gauge-track {
+      position: relative; height: 24px; border-radius: 12px; overflow: visible;
+      background: linear-gradient(to right, #238636 0%, #238636 7%, #1f6feb 7%, #1f6feb 33%, #d29922 33%, #d29922 67%, #f85149 67%, #f85149 100%);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .temp-gauge-glow {
+      position: absolute; top: 0; left: 0; height: 100%; border-radius: 12px;
+      background: linear-gradient(to right, rgba(35,134,54,0.25), rgba(248,81,73,0.25));
+      filter: blur(6px); pointer-events: none;
+    }
+    .temp-gauge-ticks {
+      position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 4px; font-size: 0.55rem; color: rgba(255,255,255,0.6); pointer-events: none;
+    }
+    .temp-gauge-needle {
+      position: absolute; top: -4px; width: 4px; height: 32px;
+      background: #fff; border-radius: 2px;
+      box-shadow: 0 0 8px rgba(255,255,255,0.8), 0 0 16px rgba(255,255,255,0.4);
+      transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+      z-index: 2;
+    }
+    .temp-gauge-needle::after {
+      content: attr(data-val); position: absolute; bottom: -16px; left: 50%;
+      transform: translateX(-50%); font-size: 0.75rem; font-weight: 700; color: #fff;
+      text-shadow: 0 1px 4px rgba(0,0,0,0.8);
+    }
+    .temp-gauge-labels {
+      position: relative; margin-top: 4px; height: 1em;
+      font-size: 0.6rem; color: var(--muted);
+    }
+    .temp-gauge-labels span { position: absolute; transform: translateX(-50%); text-align: center; }
+    .temp-gauge-labels .lbl-idle  { left: 3.5%; }
+    .temp-gauge-labels .lbl-quiet { left: 20%; }
+    .temp-gauge-labels .lbl-busy  { left: 50%; }
+    .temp-gauge-labels .lbl-surge { left: 83.5%; }
+    .tl-idle { color: #238636; }
+    .tl-quiet { color: #1f6feb; }
+    .tl-busy { color: #d29922; }
+    .tl-surge { color: #f85149; }
+
+    /* Governor cadence matrix table */
+    .gov-matrix { margin-top: 14px; width: 100%; border-collapse: collapse; font-size: 0.72rem; table-layout: fixed; }
+    .gov-matrix th { color: var(--muted); font-weight: 600; padding: 3px 8px; text-align: center; border-bottom: 1px solid var(--border); }
+    .gov-matrix th.mode-active { border-radius: 4px 4px 0 0; padding: 4px 10px; font-weight: 700; }
+    .gov-matrix th.mode-idle  { color: #238636; }
+    .gov-matrix th.mode-quiet { color: #1f6feb; }
+    .gov-matrix th.mode-busy  { color: #d29922; }
+    .gov-matrix th.mode-surge { color: #f85149; }
+    .gov-matrix th.mode-active.mode-idle  { background: rgba(35,134,54,0.15); }
+    .gov-matrix th.mode-active.mode-quiet { background: rgba(31,111,235,0.15); }
+    .gov-matrix th.mode-active.mode-busy  { background: rgba(210,153,34,0.15); }
+    .gov-matrix th.mode-active.mode-surge { background: rgba(248,81,73,0.15); }
+    .gov-matrix td { padding: 3px 8px; text-align: center; color: var(--muted); border-bottom: 1px solid rgba(48,54,61,0.5); }
+    .gov-matrix td:first-child { text-align: left; color: var(--text); font-weight: 600; min-width: 72px; }
+    @media (max-width: 480px) {
+      .gov-matrix { font-size: 0.65rem; }
+      .gov-matrix th { padding: 2px 4px; }
+      .gov-matrix th.mode-active { padding: 3px 6px; }
+      .gov-matrix td { padding: 2px 4px; }
+      .gov-matrix td:first-child { min-width: 56px; }
+    }
+    .gov-matrix td.col-active { font-weight: 700; color: var(--text); }
+    .gov-matrix td.col-active.mode-idle  { background: rgba(35,134,54,0.08); color: #3fb950; }
+    .gov-matrix td.col-active.mode-quiet { background: rgba(31,111,235,0.08); color: #58a6ff; }
+    .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: #d29922; }
+    .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: #f85149; }
+    .gov-matrix td.paused { color: #484f58; font-style: italic; }
+    .gov-matrix .agent-dot {
+      display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--green); margin-right: 4px; vertical-align: middle;
+      animation: green-pulse 6s ease-in-out infinite;
+    }
+
+    /* Timeline strip */
+    .gov-timeline { margin-top: 10px; }
+    .gov-timeline-label { display: flex; justify-content: space-between; font-size: 0.6rem; color: var(--muted); margin-bottom: 2px; }
+    .gov-timeline-strip { display: flex; height: 6px; border-radius: 3px; overflow: hidden; }
+    .gov-timeline-strip .tick { flex: 1; min-width: 1px; }
+    .tick-idle { background: #238636; }
+    .tick-quiet { background: #1f6feb; }
+    .tick-busy { background: #d29922; }
+    .tick-surge { background: #f85149; }
+    .tick-unknown { background: #484f58; }
+    .gov-timeline-legend { display: flex; gap: 12px; font-size: 0.6rem; margin-top: 3px; }
+
+    /* Agent indicators */
+    .agent-indicators { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border); font-size: 0.75rem; }
+    .ind-label { color: var(--muted); font-size: 0.65rem; }
+    .ind-empty { color: var(--muted); font-style: italic; font-size: 0.7rem; }
+    .ind-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
+    .ind-tag {
+      background: rgba(31,111,235,0.15); color: #58a6ff; border: 1px solid rgba(31,111,235,0.3);
+      border-radius: 4px; padding: 1px 6px; font-size: 0.65rem; text-decoration: none;
+    }
+    .ind-tag:hover { background: rgba(31,111,235,0.3); }
+    .ind-pair { display: flex; align-items: center; gap: 4px; margin-top: 3px; }
+    .ind-issue { background: rgba(35,134,54,0.15); color: #3fb950; border-color: rgba(35,134,54,0.3); }
+    .ind-issue:hover { background: rgba(35,134,54,0.3); }
+    .ind-pr { background: rgba(138,99,210,0.15); color: #bc8cff; border-color: rgba(138,99,210,0.3); }
+    .ind-pr:hover { background: rgba(138,99,210,0.3); }
+    .ind-merged { background: rgba(63,185,80,0.15); color: #3fb950; border-color: rgba(63,185,80,0.3); }
+    .ind-merged:hover { background: rgba(63,185,80,0.3); }
+    .ind-wip { background: rgba(210,153,34,0.15); color: #d29922; border-color: rgba(210,153,34,0.3); }
+    .ind-wip:hover { background: rgba(210,153,34,0.3); }
+    .ind-arrow { color: var(--muted); font-size: 0.7rem; }
+    .ind-dots { display: flex; flex-wrap: wrap; gap: 8px; }
+    .ind-dot-item { display: flex; align-items: center; gap: 3px; }
+    .ind-dlabel { font-size: 0.6rem; color: var(--muted); }
+    .ind-group { display: flex; align-items: center; gap: 6px; margin-bottom: 3px; }
+    .ind-group-label { font-size: 0.6rem; color: var(--muted); font-weight: 600; min-width: 52px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .ind-stat { display: inline-flex; align-items: baseline; gap: 3px; margin-right: 10px; }
+    .ind-num { font-weight: 700; font-size: 0.9rem; color: var(--text); }
+    .ind-err { color: #f85149; }
+    .ind-err .ind-num { color: #f85149; }
+    .ind-warn { color: #d29922; }
+    .ind-warn .ind-num { color: #d29922; }
+    .ind-ok { color: #3fb950; }
+    .ind-ok .ind-num { color: #3fb950; }
+    .ind-row { display: flex; flex-wrap: wrap; gap: 12px; }
+    .ind-summary { font-size: 0.7rem; color: var(--text); margin-bottom: 4px; line-height: 1.4; opacity: 0.85; }
+
+    /* Token usage panel */
+    .token-panel {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 16px;
+    }
+    .token-title { font-size: 1rem; font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+    .token-title .lookback { font-size: 0.7rem; color: var(--muted); font-weight: 400; }
+    .token-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; margin-bottom: 12px; }
+    .token-stat { text-align: left; }
+    .token-stat .tval { font-size: 1.3rem; font-weight: 700; }
+    .token-stat .tlabel { font-size: 0.65rem; color: var(--muted); }
+    .token-models { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
+    .token-model-chip {
+      background: rgba(188,140,255,0.1); border: 1px solid rgba(188,140,255,0.25);
+      border-radius: 6px; padding: 6px 10px; font-size: 0.72rem;
+    }
+    .token-model-chip .mname { color: var(--purple); font-weight: 600; }
+    .token-model-chip .mcount { color: var(--muted); margin-left: 6px; }
+    .token-sessions { font-size: 0.7rem; color: var(--muted); }
+    .token-sessions summary { cursor: pointer; font-weight: 600; color: var(--text); margin-bottom: 4px; }
+    .token-session-row { display: flex; gap: 8px; padding: 2px 0; align-items: baseline; }
+    .token-session-row .sid { color: var(--cyan); font-family: monospace; min-width: 90px; }
+    .token-session-row .sagent { font-weight: 600; min-width: 70px; font-size: 0.65rem; }
+    .token-session-row .sagent.a-scanner { color: #58a6ff; }
+    .token-session-row .sagent.a-reviewer { color: #3fb950; }
+    .token-session-row .sagent.a-architect { color: #bc8cff; }
+    .token-session-row .sagent.a-outreach { color: #39d2c0; }
+    .token-session-row .sagent.a-supervisor { color: #d29922; }
+    .token-session-row .sagent.a-unknown { color: var(--muted); font-style: italic; }
+    .token-session-row .smodel { color: var(--purple); min-width: 120px; }
+    .token-session-row .stokens { color: var(--text); font-weight: 600; min-width: 80px; text-align: right; }
+    .token-session-row .smsgs { color: var(--muted); min-width: 50px; }
+    .token-session-row .sproj { color: var(--muted); font-size: 0.65rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    /* Token burn rate chart */
+    .burn-chart-wrap { margin: 8px 0 12px; }
+    .burn-chart-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
+    .burn-context { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.7rem; font-family: monospace; }
+    .burn-context .bc-stat { display: flex; flex-direction: column; align-items: center; }
+    .burn-context .bc-val { font-weight: 700; font-size: 0.85rem; }
+    .burn-context .bc-label { color: var(--muted); font-size: 0.6rem; }
+    .burn-area-wrap { margin: 4px 0 12px; }
+    .burn-area-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
+
+    /* Cadence advisor */
+    .advisor-section { margin: 12px 0; padding: 12px; background: rgba(88,166,255,0.05); border: 1px solid rgba(88,166,255,0.15); border-radius: 6px; }
+    .advisor-title { font-size: 0.85rem; font-weight: 700; margin-bottom: 6px; }
+    .advisor-total { font-size: 0.8rem; margin-bottom: 10px; }
+    .advisor-bars { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+    .advisor-bar-row { display: flex; align-items: center; gap: 8px; font-size: 0.72rem; }
+    .advisor-agent { min-width: 70px; color: var(--text); font-weight: 600; }
+    .advisor-bar-track { flex: 1; height: 10px; background: var(--bg); border-radius: 4px; overflow: hidden; }
+    .advisor-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
+    .advisor-pct { min-width: 30px; text-align: right; color: var(--muted); }
+    .advisor-burn { min-width: 80px; text-align: right; color: var(--muted); font-size: 0.65rem; }
+    .advisor-tips { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
+    .advisor-tip { font-size: 0.72rem; color: var(--text); padding: 4px 8px; background: rgba(210,153,34,0.08); border-left: 2px solid var(--yellow); border-radius: 0 4px 4px 0; }
+    .advisor-tip b { color: var(--cyan); }
+
+    /* Budget bar */
+    .budget-bar { margin: 8px 0; }
+    .budget-bar-label { font-size: 0.72rem; color: var(--muted); margin-bottom: 3px; display: flex; justify-content: space-between; }
+    .budget-bar-track { height: 8px; background: var(--bg); border-radius: 4px; overflow: hidden; }
+    .budget-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
+    .budget-bar-fill.safe { background: var(--green); }
+    .budget-bar-fill.warning { background: var(--yellow); }
+    .budget-bar-fill.danger { background: var(--red); }
+
+    /* Model chip on agent cards */
+    .pin-toggle { cursor: pointer; background: none; border: none; font-size: 0.7rem; padding: 0 2px; opacity: 0.6; transition: opacity 0.2s; }
+    .pin-toggle:hover { opacity: 1; }
+    .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
+    .model-chip.free { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
+    .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
+    .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
+    .model-chip.opus { background: rgba(248,81,73,0.12); color: var(--red); }
+
+    /* Health dots (reused inside reviewer indicators) */
+    .health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
+    .health-dot.ok { background: #3fb950; }
+    .health-dot.fail { background: #f85149; }
+    .health-dot.unknown { background: #8b949e; }
+    .health-ci { font-weight: 700; font-size: 0.7rem; }
+    .health-ci.good { color: #3fb950; }
+    .health-ci.warn { color: #d29922; }
+    .health-ci.bad { color: #f85149; }
+
+    /* GitHub API rate limit alert bar */
+    .gh-auth-alert {
+      display: none; position: fixed; top: 0; left: 0; right: 0; z-index: 10000;
+      background: #8b1a1a; border-bottom: 2px solid #f85149; color: #e6edf3;
+      padding: 10px 20px; font-size: 0.85rem; text-align: center;
+    }
+    .gh-auth-alert.active { display: block; }
+    .gh-auth-alert a { color: #79c0ff; text-decoration: underline; }
+    .gh-rate-alert {
+      background: rgba(210,153,34,0.15); border: 1px solid rgba(210,153,34,0.4);
+      border-radius: 8px; padding: 10px 16px; margin-bottom: 16px;
+      display: none; /* hidden by default, shown via JS */
+    }
+    .gh-rate-alert.active { display: block; }
+    .gh-rate-alert-title {
+      font-size: 0.85rem; font-weight: 700; color: #d29922; margin-bottom: 6px;
+    }
+    .gh-rate-alert-item {
+      font-size: 0.75rem; color: var(--text); padding: 3px 0;
+      display: flex; align-items: baseline; gap: 8px;
+    }
+    .gh-rate-alert-agent {
+      font-weight: 700; color: #d29922; min-width: 70px;
+    }
+    .gh-rate-alert-age {
+      color: var(--muted); font-size: 0.65rem; white-space: nowrap;
+    }
+    .gh-rate-alert-msg {
+      color: var(--text); opacity: 0.85; overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; flex: 1;
+    }
+    #toast-container { position: fixed; top: 16px; right: 16px; z-index: 9999; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
+    .toast { pointer-events: auto; padding: 10px 16px; border-radius: 6px; font-size: 0.78rem; color: #e6edf3; box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: toast-in 0.25s ease-out; max-width: 360px; }
+    .toast.success { background: #1a7f37; border: 1px solid #238636; }
+    .toast.error { background: #8b1a1a; border: 1px solid #f85149; }
+    .toast.info { background: #1a3a5c; border: 1px solid #1f6feb; }
+    .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid rgba(255,255,255,0.3); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
+    @keyframes toast-out { from { opacity: 1; } to { opacity: 0; transform: translateY(-10px); } }
+  
+
+    /* Static snapshot overrides */
+    .connection { display: none !important; }
+    .agent-actions { display: none !important; }
+    .kick-row { display: none !important; }
+    .widget-dl { display: none !important; }
+    .snapshot-banner {
+      background: linear-gradient(135deg, #1a1f2e 0%, #161b22 100%);
+      border: 1px solid #30363d; border-radius: 8px;
+      padding: 12px 20px; margin-bottom: 16px;
+      display: flex; align-items: center; gap: 12px;
+      font-size: 0.8rem; color: #8b949e;
+    }
+    .snapshot-banner .snap-icon { font-size: 1.2rem; }
+    .snapshot-banner .snap-label { color: #58a6ff; font-weight: 600; }
+    .snapshot-banner .snap-time { color: #e6edf3; }
+  
+
+  </style>
+</head>
+<body>
+
+  <div class="snapshot-banner">
+    <span class="snap-icon">📸</span>
+    <span><span class="snap-label">Read-only snapshot</span> &mdash; captured <span class="snap-time" id="snap-time"></span></span>
+  </div>
+
+<div id="toast-container"></div>
+<div class="gh-auth-alert" id="gh-auth-alert">GitHub CLI authentication failed (401). Agents cannot use <code>gh</code> commands. Run <code>gh auth login</code> on the dev server to fix.</div>
+  <div class="gh-rate-alert" id="gh-rate-alert"></div>
+
+  <div class="connection live" id="conn">
+    <span class="dot-live">●</span> live
+  </div>
+
+  <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard&nbsp;<span id="project-name">for KubeStellar/Console</span> <span class="timestamp" id="ts"></span>
+    <span class="git-version" id="git-version"></span>
+    <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
+  </h1>
+
+  <div class="governor" id="governor"></div>
+
+  <div class="token-usage" id="token-panel" style="margin-bottom: 24px;"></div>
+
+  <div class="repos">
+    <h2>Repositories</h2>
+    <div class="repo-grid" id="repos"></div>
+  </div>
+
+  <div style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">Beads</h2>
+    <div class="beads" id="beads"></div>
+  </div>
+
+  <div class="agents" id="agents"></div>
+
+  
+  <script>
+
+    // ── Sparkline helper ──
+    let historyData = [];
+    const SPARK_W = 80, SPARK_H = 20;
+
+    function sparkSvg(rawValues, color) {
+      if (!rawValues || rawValues.length < 2) return '';
+      // Fill zero gaps: if a value is 0 but neighbors are non-zero, carry forward
+      const values = [...rawValues];
+      for (let i = 1; i < values.length; i++) {
+        if (values[i] === 0 && values[i - 1] > 0) {
+          values[i] = values[i - 1];
+        }
+      }
+      const min = Math.min(...values);
+      const max = Math.max(...values);
+      const range = max - min || 1;
+      const pts = values.map((v, i) => {
+        const x = (i / (values.length - 1)) * SPARK_W;
+        const y = SPARK_H - ((v - min) / range) * (SPARK_H - 2) - 1;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      });
+      return `<span class="sparkline"><svg width="${SPARK_W}" height="${SPARK_H}" viewBox="0 0 ${SPARK_W} ${SPARK_H}">` +
+        `<polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
+        `<circle cx="${pts[pts.length-1].split(',')[0]}" cy="${pts[pts.length-1].split(',')[1]}" r="2" fill="${color}"/>` +
+        `</svg></span>`;
+    }
+
+    function getHistorySeries(key) {
+      return historyData.map(s => {
+        const keys = key.split('.');
+        let v = s;
+        for (const k of keys) v = v?.[k];
+        return v ?? 0;
+      });
+    }
+
+    function restartSparkSvg(agentName) {
+      const series = historyData
+        .map(s => s.agents?.[agentName]?.restarts)
+        .filter(v => v != null);
+      if (series.length < 2 || Math.max(...series) === 0) return '';
+      return sparkSvg(series, '#f85149');
+    }
+
+    async function fetchHistory() {
+      try {
+        const r = await fetch('/api/history');
+        historyData = await r.json();
+      } catch (e) { /* ignore */ }
+    }
+    // Fetch history on load, then every 30s
+    fetchHistory();
+    setInterval(fetchHistory, 30000);
+
+    function formatAge(sec) {
+      if (sec < 0) return '—';
+      if (sec < 120) return sec + 's';
+      if (sec < 3600) return Math.floor(sec / 60) + 'm';
+      return Math.floor(sec / 3600) + 'h';
+    }
+
+    let currentAgentMetrics = {};
+    // Per-issue token cost data — keyed by issue number (string)
+    let issueCosts = {};
+
+    async function fetchIssueCosts() {
+      try {
+        const r = await fetch('/api/issue-costs');
+        const data = await r.json();
+        issueCosts = {};
+        for (const entry of (data || [])) {
+          if (entry.issue && entry.issue !== 'unknown') {
+            issueCosts[String(entry.issue)] = entry;
+          }
+        }
+      } catch (_) { /* non-fatal — cost display is optional */ }
+    }
+    // Fetch on load, then every 60s (matches token-collector cadence)
+    fetchIssueCosts();
+    const ISSUE_COSTS_REFRESH_MS = 60000;
+    setInterval(fetchIssueCosts, ISSUE_COSTS_REFRESH_MS);
+
+    function agentIndicators(name) {
+      const m = currentAgentMetrics[name];
+      if (!m) return '';
+
+      if (name === 'scanner') {
+        const pairs = m.pairs || [];
+        const inProgress = m.inProgress || [];
+        const openPairs = pairs.filter(p => p.state !== 'merged');
+        const mergedPairs = pairs.filter(p => p.state === 'merged');
+        const renderPair = (p) => {
+          const issueLabel = p.issueTitle ? `⊙ #${p.issue} — ${esc(p.issueTitle.length > 48 ? p.issueTitle.slice(0, 48) + '…' : p.issueTitle)}` : `⊙ #${p.issue}`;
+          const issueTip = p.issueTitle ? esc(p.issueTitle) : '';
+          const prIcon = p.state === 'merged' ? '✓' : '⎇';
+          const prCls = p.state === 'merged' ? 'ind-pr ind-merged' : 'ind-pr';
+          const prTip = p.prTitle ? esc(p.prTitle) : '';
+          // Show token cost annotation for merged issues when data is available
+          let costHtml = '';
+          if (p.state === 'merged') {
+            const cost = issueCosts[String(p.issue)];
+            if (cost) {
+              const tokVal = cost.tokens_exact != null ? cost.tokens_exact : cost.tokens_estimated;
+              if (tokVal > 0) {
+                const isExact = cost.tokens_exact != null;
+                const costTip = isExact ? 'exact token count (from session metadata)' : 'estimated (total ÷ issues)';
+                costHtml = ` <span class="ind-cost" title="${costTip}" style="color:var(--muted);font-size:0.65rem">${isExact ? '' : '~'}${fmtTokens(tokVal)} tok</span>`;
+              }
+            }
+          }
+          return `<div class="ind-pair">
+          <a class="ind-tag ind-issue" href="https://github.com/kubestellar/console/issues/${p.issue}" target="_blank" title="${issueTip}">${issueLabel}</a>
+          <span class="ind-arrow">→</span>
+          <a class="ind-tag ${prCls}" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${prTip}">${prIcon} #${p.pr}</a>${costHtml}
+        </div>`;
+        };
+        const renderWip = (ip) => {
+          const title = ip.title ? esc(ip.title.length > 48 ? ip.title.slice(0, 48) + '…' : ip.title) : '';
+          const label = title ? `⏳ #${ip.number} — ${title}` : `⏳ #${ip.number}`;
+          return `<div class="ind-pair">
+          <a class="ind-tag ind-wip" href="https://github.com/kubestellar/console/issues/${ip.number}" target="_blank" title="${ip.title ? esc(ip.title) : ''}">${label}</a>
+        </div>`;
+        };
+        let html = '';
+        if (inProgress.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Working on (${inProgress.length}):</span>${inProgress.map(renderWip).join('')}</div>`;
+        if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">PR open (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
+        if (mergedPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Merged today (${mergedPairs.length}):</span>${mergedPairs.map(renderPair).join('')}</div>`;
+        if (!html) html = '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
+        return html;
+      }
+
+      if (name === 'reviewer') {
+        const h = window._healthData || {};
+        const cov = m.coverage || 0;
+        const covTarget = m.coverageTarget || 91;
+        const covCls = cov >= covTarget ? 'ind-ok' : cov >= covTarget - 10 ? 'ind-warn' : 'ind-err';
+        const covBar = `<div class="agent-indicators"><div class="ind-group"><span class="ind-group-label">COVERAGE</span><div class="ind-dots">
+          <span class="ind-dot-item"><span class="ind-num ${covCls}">${cov}%</span><span class="ind-dlabel">current</span></span>
+          <span class="ind-dot-item"><span class="ind-dlabel">goal: ${covTarget}%</span></span>
+          <span class="ind-dot-item" style="flex:1;max-width:120px">
+            <div style="background:var(--border);border-radius:3px;height:6px;width:100%;position:relative">
+              <div style="background:${cov >= covTarget ? 'var(--green)' : cov >= covTarget - 10 ? 'var(--yellow)' : 'var(--red)'};height:100%;border-radius:3px;width:${Math.min(cov / covTarget * 100, 100)}%"></div>
+            </div>
+          </span>
+        </div></div></div>`;
+        const groups = [
+          { label: 'Artifacts', items: [
+            { key: 'brew', label: 'Brew' },
+            { key: 'helm', label: 'Helm' },
+          ]},
+          { label: 'Tests', items: [
+            { key: 'ci', label: 'CI', type: 'pct' },
+            { key: 'weekly', label: 'Weekly' },
+          ]},
+          { label: 'Nightly', items: [
+            { key: 'nightly', label: 'Tests' },
+            { key: 'nightlyCompliance', label: 'Compliance' },
+            { key: 'nightlyDashboard', label: 'Dashboard' },
+            { key: 'nightlyGhaw', label: 'gh-aw' },
+            { key: 'nightlyPlaywright', label: 'Playwright' },
+          ]},
+          { label: 'Releases', items: [
+            { key: 'nightlyRel', label: 'Nightly' },
+            { key: 'weeklyRel', label: 'Weekly' },
+          ]},
+          { label: 'Deploys', items: [
+            { key: 'vllm', label: 'vLLM-d' },
+            { key: 'pokprod', label: 'PokProd' },
+          ]},
+        ];
+        const renderItem = d => {
+          const v = h[d.key];
+          if (d.type === 'pct') {
+            const cls = v >= 90 ? 'good' : v >= 70 ? 'warn' : 'bad';
+            return `<span class="ind-dot-item"><span class="health-ci ${cls}">${v || 0}%</span><span class="ind-dlabel">${d.label}</span></span>`;
+          }
+          const dotCls = v === 1 ? 'ok' : v === 0 ? 'fail' : 'unknown';
+          return `<span class="ind-dot-item"><span class="health-dot ${dotCls}"></span><span class="ind-dlabel">${d.label}</span></span>`;
+        };
+        return `${covBar}<div class="agent-indicators">${groups.map(g =>
+          `<div class="ind-group"><span class="ind-group-label">${g.label}</span><div class="ind-dots">${g.items.map(renderItem).join('')}</div></div>`
+        ).join('')}</div>`;
+      }
+
+      if (name === 'outreach') {
+        const stars = m.stars || 0;
+        const forks = m.forks || 0;
+        const contribs = m.contributors || 0;
+        const adopters = m.adopters || 0;
+        const acmm = m.acmm || 0;
+        const orOpen = m.outreachOpen || 0;
+        const orMerged = m.outreachMerged || 0;
+        const starSpark = sparkSvg((window._trendData || []).map(s => s.stars || 0), '#e3b341');
+        const orOpenSpark = sparkSvg((window._trendData || []).map(s => s.outreachOpen || 0), '#58a6ff');
+        const orMergedSpark = sparkSvg((window._trendData || []).map(s => s.outreachMerged || 0), '#3fb950');
+        return `<div class="agent-indicators">
+          <div class="ind-group"><span class="ind-group-label">GROWTH</span><div class="ind-dots">
+            <span class="ind-dot-item"><span class="ind-num">⭐ ${stars}</span><span class="ind-dlabel">stars ${starSpark}</span></span>
+            <span class="ind-dot-item"><span class="ind-num">🍴 ${forks}</span><span class="ind-dlabel">forks</span></span>
+            <span class="ind-dot-item"><span class="ind-num">👥 ${contribs}</span><span class="ind-dlabel">contributors</span></span>
+          </div></div>
+          <div class="ind-group"><span class="ind-group-label">ADOPTION</span><div class="ind-dots">
+            <span class="ind-dot-item"><span class="ind-num">${adopters}</span><span class="ind-dlabel">adopters</span></span>
+            <span class="ind-dot-item"><span class="ind-num">${acmm}</span><span class="ind-dlabel">ACMM badges</span></span>
+          </div></div>
+          <div class="ind-group"><span class="ind-group-label">OUTREACH PRs</span><div class="ind-dots">
+            <span class="ind-dot-item"><span class="ind-num">${orOpen}</span><span class="ind-dlabel">open ${orOpenSpark}</span></span>
+            <span class="ind-dot-item"><span class="ind-num">${orMerged}</span><span class="ind-dlabel">merged ${orMergedSpark}</span></span>
+          </div></div>
+        </div>`;
+      }
+
+      if (name === 'architect') {
+        const prs = m.prs || 0;
+        const closed = m.closed || 0;
+        return `<div class="agent-indicators">
+          <div class="ind-row">
+            ${prs > 0 ? `<span class="ind-stat"><span class="ind-num">${prs}</span> PRs</span>` : ''}
+            ${closed > 0 ? `<span class="ind-stat"><span class="ind-num">${closed}</span> closed</span>` : ''}
+          </div>
+        </div>`;
+      }
+
+      return '';
+    }
+
+    function parseCadenceMinutes(cadence) {
+      if (!cadence || cadence === 'paused') return 0;
+      const m = cadence.match(/^(\d+)(m|h)$/);
+      if (!m) return 0;
+      const MINUTES_PER_HOUR = 60;
+      return m[2] === 'h' ? parseInt(m[1]) * MINUTES_PER_HOUR : parseInt(m[1]);
+    }
+
+    function getAgentIssueCount(name) {
+      const m = currentAgentMetrics[name];
+      if (!m) return 0;
+      if (name === 'scanner') {
+        const pairs = m.pairs || [];
+        return pairs.filter(p => p.state === 'merged').length;
+      }
+      if (name === 'outreach') return m.outreachMerged || 0;
+      if (name === 'architect') return m.prs || m.closed || 0;
+      return 0;
+    }
+
+    function agentTokenRow(name, cadence) {
+      const byAgent = window._tokensByAgent || {};
+      const t = byAgent[name];
+      if (!t || (t.messages === 0 && t.sessions === 0)) return '';
+      const total = (t.input || 0) + (t.output || 0) + (t.cacheRead || 0);
+      if (total === 0) {
+        return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--muted)">${t.sessions} sess · ${t.messages} msgs</span></div>`;
+      }
+      const avg = t.avgPerSession || (t.sessions > 0 ? Math.floor(total / t.sessions) : 0);
+      let rows = `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
+      rows += `<div class="agent-field"><span class="label">avg/pass</span><span class="value">${fmtTokens(avg)}</span></div>`;
+      const issueCount = getAgentIssueCount(name);
+      if (issueCount > 0) {
+        const tokensPerIssue = Math.floor(total / issueCount);
+        rows += `<div class="agent-field"><span class="label">avg/issue</span><span class="value" style="color:var(--green)">${fmtTokens(tokensPerIssue)} <span style="color:var(--muted);font-size:0.65rem">(${issueCount} today)</span></span></div>`;
+      }
+      const intervalMin = parseCadenceMinutes(cadence);
+      if (intervalMin > 0 && avg > 0) {
+        const MINUTES_PER_HOUR = 60;
+        const HOURS_PER_WEEK = 168;
+        const passesPerHour = MINUTES_PER_HOUR / intervalMin;
+        const tokensPerHour = avg * passesPerHour;
+        const tokensPerWeek = tokensPerHour * HOURS_PER_WEEK;
+        rows += `<div class="agent-field"><span class="label">burn rate</span><span class="value" style="color:var(--yellow)">${fmtTokens(tokensPerHour)}/hr · ${fmtTokens(tokensPerWeek)}/wk</span></div>`;
+      }
+      return rows;
+    }
+
+    const AGENT_TMUX_SESSION = {
+      supervisor: 'supervisor',
+      scanner: 'scanner',
+      reviewer: 'reviewer',
+      architect: 'architect',
+      outreach: 'outreach',
+    };
+    const TTYD_PORT = 7681;
+
+    function terminalUrl(agentName) {
+      const session = AGENT_TMUX_SESSION[agentName] || agentName;
+      const host = window.location.hostname;
+      return `http://${host}:${TTYD_PORT}/?arg=${encodeURIComponent(session)}`;
+    }
+
+    function renderAgents(agents) {
+      const el = document.getElementById('agents');
+      // Preserve custom prompt input values across re-renders
+      const savedInputs = {};
+      const focusedId = document.activeElement?.id;
+      el.querySelectorAll('.kick-prompt').forEach(inp => {
+        if (inp.value) savedInputs[inp.id] = inp.value;
+      });
+      const cards = agents.map(a => {
+        const needsLogin = a.needsLogin === true;
+        const isPaused = a.paused === true;
+        const isStopped = a.state === 'stopped' && !isPaused;
+        const STALE_MS = 1200000; // 20 minutes
+        const isStale = a.summaryUpdated && !isPaused && a.busy === 'working' && (Date.now() - new Date(a.summaryUpdated).getTime()) > STALE_MS;
+        let statusCls = '';
+        if (a.structuredStatus === 'BLOCKED') statusCls = 'status-blocked';
+        else if (a.structuredStatus === 'NEEDS_CONTEXT') statusCls = 'status-needs-context';
+        else if (isStale) statusCls = 'status-stale';
+        const cls = needsLogin ? 'needs-login' : isPaused ? 'paused' : isStopped ? 'stopped' : `${a.busy} ${statusCls}`.trim();
+        const dotCls = a.state === 'stopped' ? 'stopped' : 'running';
+        const canToggle = a.name !== 'supervisor';
+        const toggleBtn = canToggle ? `<button class="btn-toggle ${isPaused ? 'paused' : 'running'}" onclick="toggleAgent('${a.name}', ${isPaused})">${isPaused ? '▶ resume' : '⏸ pause'}</button>` : '';
+        // liveSummary is pushed via SSE every 5s — no separate fetch needed
+        let summaryEl = '';
+        if (a.liveSummary) {
+          let ageBadge = '';
+          if (!a.doing && a.summaryUpdated) {
+            const ageMs = Date.now() - new Date(a.summaryUpdated).getTime();
+            const ageMin = Math.floor(ageMs / 60000);
+            if (ageMin >= 5) {
+              const ageStr = ageMin >= 60 ? `${Math.floor(ageMin/60)}h ${ageMin%60}m ago` : `${ageMin}m ago`;
+              const ageCls = ageMin >= 120 ? 'age-stale' : 'age-recent';
+              ageBadge = `<span class="summary-age ${ageCls}">${ageStr}</span>`;
+            }
+          }
+          summaryEl = `<div class="doing">${ageBadge}${esc(a.liveSummary)}</div>`;
+        }
+        const indEl = agentIndicators(a.name);
+        return `<div class="agent-card ${cls}">
+          <span class="working-indicator"></span>
+          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" onclick="restartAgent('${a.name}')" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button></div>
+          <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'cli', false)" title="Pin CLI — lock current backend">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'model', false)" title="Pin model — lock current model">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label">interval</span><span class="value">${isPaused ? 'paused' : a.cadence}</span></div>
+          <div class="agent-field"><span class="label">last run</span><span class="value">${a.lastKick || '—'}</span></div>
+          <div class="agent-field"><span class="label">next run</span><span class="value">${isPaused ? 'paused' : (a.nextKick || '—')}</span></div>
+          ${agentTokenRow(a.name, a.cadence)}
+          <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? `<button class="restart-reset" onclick="resetRestarts('${a.name}')" title="Reset restart counter">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
+          <div class="agent-state ${isPaused ? 'paused' : a.busy}">${isPaused ? 'paused' : a.busy}${(() => {
+            if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
+            if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
+            if (a.structuredStatus === 'DONE_WITH_CONCERNS') return '<span class="status-badge done-concerns" title="' + esc(a.statusEvidence) + '">concerns</span>';
+            if (a.structuredStatus === 'DONE') return '<span class="status-badge done">done</span>';
+            if (isStale) return '<span class="status-badge needs-context">stale</span>';
+            return '';
+          })()}</div>
+          ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
+          ${summaryEl}${indEl}
+          <div class="agent-actions">
+            <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" onkeydown="if(event.key==='Enter'){kick('${a.name}')}" />
+            <button class="btn" onclick="kick('${a.name}')" title="Send custom prompt to agent">send</button>
+            <button class="btn" onclick="document.getElementById('kick-prompt-${a.name}').value='';kick('${a.name}')">kick</button>
+            <select class="btn backend-select" onchange="switchCli('${a.name}', this.value); this.selectedIndex=0">
+              <option value="" disabled selected>cli ▾</option>
+              ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${b}</option>`).join('')}
+            </select>
+            <select class="btn backend-select" onchange="switchModel('${a.name}', this.value); this.selectedIndex=0">
+              <option value="" disabled selected>model ▾</option>
+              ${KNOWN_MODELS.map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
+            </select>
+          </div>
+        </div>`;
+      });
+      el.innerHTML = cards.join('');
+      // Restore saved input values and focus
+      for (const [id, val] of Object.entries(savedInputs)) {
+        const inp = document.getElementById(id);
+        if (inp) inp.value = val;
+      }
+      if (focusedId) {
+        const prev = document.getElementById(focusedId);
+        if (prev) prev.focus();
+      }
+    }
+
+    function renderHealth(health) {
+      const el = document.getElementById('health');
+      if (!health || Object.keys(health).length === 0) { el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">Loading…</span>'; return; }
+      const items = [
+        { key: 'ci', label: 'CI Pass Rate', type: 'pct' },
+        { key: 'brew', label: 'Brew Formula' },
+        { key: 'helm', label: 'Helm Chart' },
+        { key: 'nightly', label: 'Nightly Tests' },
+        { key: 'nightlyRel', label: 'Nightly Release' },
+        { key: 'weekly', label: 'Weekly Tests' },
+        { key: 'weeklyRel', label: 'Weekly Rel' },
+        { key: 'vllm', label: 'vLLM-d Deploy' },
+        { key: 'pokprod', label: 'PokProd Deploy' },
+      ];
+      el.innerHTML = items.map(it => {
+        const v = health[it.key];
+        if (it.type === 'pct') {
+          const cls = v >= 90 ? 'good' : v >= 70 ? 'warn' : 'bad';
+          return `<div class="health-item"><span class="health-ci ${cls}">${v}%</span><span class="health-label">${it.label}</span></div>`;
+        }
+        const dotCls = v === 1 ? 'ok' : v === 0 ? 'fail' : 'unknown';
+        return `<div class="health-item"><span class="health-dot ${dotCls}"></span><span class="health-label">${it.label}</span></div>`;
+      }).join('');
+    }
+
+    function formatFixTime(minutes) {
+      if (!minutes || minutes <= 0) return '—';
+      return `${minutes}m`;
+    }
+
+    function renderGovernor(gov, cadenceMatrix, data) {
+      const el = document.getElementById('governor');
+      const cls = gov.active ? 'active' : 'dead';
+      el.className = `governor ${cls}`;
+      const issuesSpark = sparkSvg(getHistorySeries('govIssues'), '#58a6ff');
+      const prsSpark = sparkSvg(getHistorySeries('govPrs'), '#bc8cff');
+      const totalSpark = sparkSvg(getHistorySeries('govTotal'), '#3fb950');
+      const issueCount = gov.issues || 0;
+      const currentMode = gov.mode || 'idle';
+      const modes = ['idle', 'quiet', 'busy', 'surge'];
+
+      // Gauge bar — thresholds driven by issue count only (PRs don't affect mode)
+      const maxQ = 30;
+      const pct = Math.min(issueCount / maxQ * 100, 100);
+      const modeColors = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };
+      const modeColor = modeColors[gov.mode] || '#8b949e';
+
+      // Timeline strip from 24h persistent timeline data
+      const tlData = window._timelineData || [];
+      const tlModes = tlData.map(s => s.mode || 'unknown');
+      const ticks = tlModes.map(m => `<div class="tick tick-${m}"></div>`).join('');
+      const firstTime = tlData.length > 0 ? new Date(tlData[0].t).toLocaleDateString([], {month:'numeric',day:'numeric'}) + ' ' + new Date(tlData[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+      const lastTime = tlData.length > 0 ? new Date(tlData[tlData.length-1].t).toLocaleDateString([], {month:'numeric',day:'numeric'}) + ' ' + new Date(tlData[tlData.length-1].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+
+      const itm = data.issueToMerge || {};
+      const itmAvg = itm.avg_minutes || 0;
+      const itmMedian = itm.median_minutes || 0;
+      const itmCount = itm.count || 0;
+      const FIX_TIME_SPARK_COLOR = '#d2a8ff';
+      const itmHistory = (itm.history || []).map(h => h.median || h.avg);
+      const itmSpark = sparkSvg(itmHistory, FIX_TIME_SPARK_COLOR);
+      const itmTitle = itmCount > 0 ? `MTTR (Mean Time to Resolution) — median: ${formatFixTime(itmMedian)} | avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes in last 30d` : 'MTTR — no data yet';
+
+      el.innerHTML = `
+        <div class="gov-title">Governor</div>
+        <div class="gov-grid">
+          <div class="gov-stat"><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : '⚠ DEAD'}</div></div>
+          <div class="gov-stat"><div class="label">mode</div><div class="val" style="color:${modeColor}">${gov.mode}</div></div>
+          <div class="gov-stat"><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
+          <div class="gov-stat"><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
+          <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
+          <div class="gov-stat"><div class="label">next run</div><div class="val">${gov.nextKick || '—'}</div></div>
+        </div>
+        <div class="temp-gauge">
+          <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>
+          <div class="temp-gauge-track">
+            <div class="temp-gauge-glow" style="width:100%"></div>
+            <div class="temp-gauge-ticks"><span>0</span><span>2</span><span>10</span><span>20</span><span>${maxQ}</span></div>
+            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${issueCount}"></div>
+          </div>
+          <div class="temp-gauge-labels">
+            <span class="tl-idle lbl-idle">idle</span>
+            <span class="tl-quiet lbl-quiet">quiet</span>
+            <span class="tl-busy lbl-busy">busy</span>
+            <span class="tl-surge lbl-surge">surge</span>
+          </div>
+        </div>
+        <div class="gov-timeline">
+          <div class="gov-timeline-label"><span>${firstTime}</span><span>Mode Timeline</span><span>${lastTime}</span></div>
+          <div class="gov-timeline-strip">${ticks || '<div class="tick tick-unknown" style="flex:1"></div>'}</div>
+          <div class="gov-timeline-legend">
+            <span class="tl-idle">idle</span>
+            <span class="tl-quiet">quiet</span>
+            <span class="tl-busy">busy</span>
+            <span class="tl-surge">surge</span>
+          </div>
+        </div>
+        ${renderBudgetBar(data.budget || {})}
+        ${renderCadenceMatrix(cadenceMatrix, currentMode, modes)}`;
+    }
+
+    function renderCadenceMatrix(matrix, currentMode, modes) {
+      if (!matrix || !matrix.length) return '';
+      const agents = window._lastAgents || [];
+      const agentOrder = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
+      const rows = agentOrder.map(aname => {
+        const row = matrix.find(r => r.agent === aname);
+        if (!row) return '';
+        const agentData = agents.find(a => a.name === aname);
+        const isWorking = agentData && agentData.busy === 'working';
+        const agentPaused = agentData && agentData.paused === true;
+        const cells = modes.map(m => {
+          const val = row[m] || '?';
+          const isActive = m === currentMode;
+          const isPaused = val === 'paused';
+          const showPaused = isPaused || agentPaused;
+          const colCls = isActive ? `col-active mode-${m}` : '';
+          const pausedCls = showPaused ? ' paused' : '';
+          const dot = (isActive && isWorking && !agentPaused) ? '<span class="active-dot"></span>' : '';
+          return `<td class="${colCls}${pausedCls}">${dot}${showPaused ? '<span class="pause-badge">paused</span>' : val}</td>`;
+        }).join('');
+        const nameDot = isWorking ? '<span class="agent-dot"></span>' : '';
+        const pauseBadge = agentPaused ? '<span class="pause-badge">paused</span>' : '';
+        const cliPinned = agentData && (agentData.pinnedBoth || agentData.pinnedCli);
+        const modelPinned = agentData && (agentData.pinnedBoth || agentData.pinnedModel);
+        const cChip = agentData && agentData.cli ? cliChip(agentData.cli, cliPinned, aname) : '?';
+        const mChip = agentData && agentData.model ? modelChip(agentData.model, agentData.govReason, modelPinned, aname) : '';
+        return `<tr><td>${nameDot}${aname}${pauseBadge}</td>${cells}<td>${cChip}</td><td>${mChip}</td></tr>`;
+      }).join('');
+      const headers = modes.map(m => {
+        const isActive = m === currentMode;
+        const cls = `mode-${m}${isActive ? ' mode-active' : ''}`;
+        return `<th class="${cls}">${m}${isActive ? ' ◀' : ''}</th>`;
+      }).join('');
+      return `<table class="gov-matrix">
+        <thead><tr><th></th>${headers}<th>cli</th><th>model</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+    }
+
+    function renderRepos(repos) {
+      const el = document.getElementById('repos');
+      el.innerHTML = repos.map(r => {
+        const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
+        const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
+        const repoUrl = 'https://github.com/' + (r.full || r.name);
+        return `
+        <div class="repo-card">
+          <div class="repo-name"><a href="${repoUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${r.full || r.name}</a></div>
+          <div class="repo-stats">
+            <div class="repo-stat"><a href="${repoUrl}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
+            <div class="repo-stat"><a href="${repoUrl}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
+          </div>
+        </div>`;
+      }).join('');
+    }
+
+    function renderBeads(beads) {
+      const el = document.getElementById('beads');
+      const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), '#39d2c0');
+      const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), '#d29922');
+      el.innerHTML = `
+        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.workers >= 0 ? beads.workers : 0}</span>${wSpark}</div><div class="label">workers</div></div>
+        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : 0}</span>${sSpark}</div><div class="label">supervisor</div></div>`;
+    }
+
+    function fmtTokens(n) {
+      if (n === 0) return '0';
+      const b = n / 1e9;
+      if (b >= 100) return b.toFixed(0) + 'B';
+      if (b >= 10) return b.toFixed(1) + 'B';
+      if (b >= 1) return b.toFixed(2) + 'B';
+      if (b >= 0.1) return b.toFixed(2) + 'B';
+      if (b >= 0.01) return b.toFixed(3) + 'B';
+      return b.toFixed(3) + 'B';
+    }
+
+    let budgetIgnored = false;
+    fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {});
+
+    function toggleBudgetIgnore() {
+      budgetIgnored = !budgetIgnored;
+      fetch('/api/budget-ignore', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ignored: budgetIgnored }) })
+        .then(r => r.json()).then(d => { budgetIgnored = d.ignored; renderAll(); });
+    }
+
+    function renderBudgetBar(budget) {
+      if (!budget || !budget.BUDGET_WEEKLY) return '';
+      const PCT_SAFE = 50;
+      const PCT_WARN = 85;
+      const used = budget.BUDGET_USED || 0;
+      const weekly = budget.BUDGET_WEEKLY;
+      const pctUsed = budget.BUDGET_PCT_USED || 0;
+      const projPct = budget.PROJECTED_PCT || 0;
+      const burnRate = budget.BURN_RATE_HOURLY || 0;
+      const hoursLeft = budget.HOURS_REMAINING || 0;
+      const HOURS_PER_DAY = 24;
+      const dailyRate = burnRate * HOURS_PER_DAY;
+      const usedFillCls = budgetIgnored ? 'safe' : pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
+
+      let govAction = '';
+      if (budgetIgnored) {
+        govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
+      } else if (projPct > PCT_WARN) {
+        govAction = '<span style="color:var(--red)">Governor downgrading models to stay within budget</span>';
+      } else if (projPct > PCT_SAFE) {
+        govAction = '<span style="color:var(--yellow)">Governor may downgrade non-priority agents if burn increases</span>';
+      } else {
+        govAction = '<span style="color:var(--green)">Budget healthy — governor using preferred models</span>';
+      }
+
+      const ignoreCheck = `<label style="font-size:0.68rem;color:var(--muted);cursor:pointer;margin-left:12px">
+        <input type="checkbox" ${budgetIgnored ? 'checked' : ''} onchange="toggleBudgetIgnore()" style="cursor:pointer;vertical-align:middle"> ignore budget
+      </label>`;
+
+      return `<div class="budget-bar">
+        <div class="budget-bar-label">
+          <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)${ignoreCheck}</span>
+          <span>${hoursLeft}h until reset</span>
+        </div>
+        <div class="budget-bar-track"><div class="budget-bar-fill ${usedFillCls}" style="width:${Math.min(pctUsed, 100)}%"></div></div>
+        <div style="display:flex;justify-content:space-between;font-size:0.68rem;color:var(--muted);margin-top:4px">
+          <span>Burn: ${fmtTokens(burnRate)}/hr · ${fmtTokens(dailyRate)}/day</span>
+          <span>Projected: ${fmtTokens(used + burnRate * hoursLeft)} (${projPct}%)</span>
+        </div>
+        <div style="font-size:0.68rem;margin-top:3px">${govAction}</div>
+      </div>`;
+    }
+
+    // ── Centralized backend/model config (mirrors backends.conf) ──────────
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'gemini', 'codex', 'amazonq', 'goose', 'aider'];
+    const FREE_BACKENDS = ['copilot', 'goose'];
+    const KNOWN_MODELS = [
+      { value: 'claude-opus-4-6', label: 'Opus 4.6' },
+      { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { value: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
+      { value: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+      { value: 'gpt-5.4', label: 'GPT-5.4' },
+      { value: 'gpt-5.2', label: 'GPT-5.2' },
+    ];
+
+    function _modelTier(model) {
+      const m = (model || '').toLowerCase();
+      if (m.includes('haiku')) return 'haiku';
+      if (m.includes('opus')) return 'opus';
+      if (m.includes('sonnet')) return 'sonnet';
+      if (m.startsWith('gpt-')) return 'gpt';
+      if (m.startsWith('gemini-')) return 'gemini';
+      return 'unknown';
+    }
+
+    function cliChip(cli, pinned, agent) {
+      if (!cli || cli === '?') return '?';
+      const tier = FREE_BACKENDS.includes(cli) ? 'free' : 'paid';
+      const pin = pinned ? ' \u{1F4CC}' : '';
+      const pinTitle = pinned ? ' (pinned — click to unpin)' : '';
+      const click = pinned && agent ? ` onclick="togglePin('${agent}', 'cli', true)" style="cursor:pointer"` : '';
+      return `<span class="model-chip ${tier}" title="cli: ${cli}${pinTitle}"${click}>${cli}${pin}</span>`;
+    }
+
+    function backendChip(backend) {
+      if (!backend || backend === 'unknown') return '';
+      const tier = FREE_BACKENDS.includes(backend) ? 'free' : 'paid';
+      return ` <span class="model-chip ${tier}" title="billing: ${backend}">${backend}</span>`;
+    }
+
+    function modelChip(model, reason, pinned, agent) {
+      if (!model || model === '?' || model === 'unknown') return '?';
+      const normalized = model.toLowerCase().replace(/\s+/g, '-');
+      const shortModel = normalized.replace(/^claude-/, '').replace(/-(\d[\d-]*\d)$/, (_, v) => '-' + v.replace(/-/g, '.'));
+      const tier = _modelTier(normalized);
+      const chipCls = tier === 'unknown' ? 'sonnet' : tier;
+      const isBudgetOverride = reason && (reason.includes('budget_downgrade') || reason.includes('budget_critical'));
+      const overrideIcon = isBudgetOverride ? ' ⬇' : '';
+      const overrideTitle = isBudgetOverride ? ` (${reason})` : '';
+      const pin = pinned ? ' \u{1F4CC}' : '';
+      const pinTitle = pinned ? ' (pinned — click to unpin)' : '';
+      const click = pinned && agent ? ` onclick="togglePin('${agent}', 'model', true)" style="cursor:pointer"` : '';
+      return `<span class="model-chip ${chipCls}" title="${model}${overrideTitle}${pinTitle}"${click}>${shortModel}${overrideIcon}${pin}</span>`;
+    }
+
+    function buildCadenceAdvisor(byAgent) {
+      const agents = window._lastAgents || [];
+      if (!agents.length || !byAgent) return '';
+
+      const MINUTES_PER_HOUR = 60;
+      const HOURS_PER_WEEK = 168;
+      const AGENT_ORDER = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+      const rows = [];
+      let totalWeeklyBurn = 0;
+
+      for (const name of AGENT_ORDER) {
+        const agentData = agents.find(a => a.name === name);
+        const tokenData = byAgent[name];
+        if (!agentData || !tokenData) continue;
+
+        const avg = tokenData.avgPerSession || 0;
+        const cadenceMin = parseCadenceMinutes(agentData.cadence);
+        const isPaused = !cadenceMin;
+        const passesPerHour = isPaused ? 0 : MINUTES_PER_HOUR / cadenceMin;
+        const weeklyBurn = avg * passesPerHour * HOURS_PER_WEEK;
+        totalWeeklyBurn += weeklyBurn;
+
+        rows.push({ name, avg, cadenceMin, isPaused, passesPerHour, weeklyBurn, cli: agentData.cli });
+      }
+
+      if (totalWeeklyBurn === 0) return '';
+
+      const tips = [];
+      const sorted = [...rows].filter(r => r.weeklyBurn > 0).sort((a, b) => b.weeklyBurn - a.weeklyBurn);
+
+      if (sorted.length > 0) {
+        const top = sorted[0];
+        const topPct = Math.round((top.weeklyBurn / totalWeeklyBurn) * 100);
+        if (topPct > 60) {
+          const DOUBLE_CADENCE = 2;
+          tips.push(`<b>${top.name}</b> uses ${topPct}% of weekly tokens. Doubling interval to ${top.cadenceMin * DOUBLE_CADENCE}m would halve its burn.`);
+        }
+      }
+
+      const architect = rows.find(r => r.name === 'architect');
+      if (architect) {
+        if (architect.isPaused) {
+          tips.push(`<b>architect</b> is paused — no architect work happening. Consider enabling at 1h cadence.`);
+        } else if (architect.weeklyBurn > 0) {
+          const architectPct = Math.round((architect.weeklyBurn / totalWeeklyBurn) * 100);
+          if (architectPct < 15 && architect.cadenceMin > 15) {
+            const HALVE_CADENCE = 2;
+            tips.push(`<b>architect</b> is only ${architectPct}% of burn. Could increase to ${Math.max(15, Math.floor(architect.cadenceMin / HALVE_CADENCE))}m for more architect work.`);
+          }
+        }
+      }
+
+      for (const r of rows) {
+        if (r.cli === 'copilot' && r.avg === 0 && !r.isPaused) {
+          tips.push(`<b>${r.name}</b> runs on copilot (unlimited tokens, no metering). Token burn unknown — consider switching to claude CLI for visibility.`);
+        }
+      }
+
+      // Model-aware tips from governor assignments
+      const OPUS_COST = 15;
+      const SONNET_COST = 3;
+      for (const r of rows) {
+        const agentData = agents.find(a => a.name === r.name);
+        if (!agentData) continue;
+        const gb = agentData.govBackend;
+        const gm = agentData.govModel || '';
+        if (gb === 'copilot' || gb === 'goose') {
+          if (r.weeklyBurn > 0) {
+            tips.push(`<b>${r.name}</b> assigned to ${gb} (free) — ${fmtTokens(r.weeklyBurn)}/wk savings vs metered CLI.`);
+          }
+        } else if (gm.includes('opus') && r.weeklyBurn > 0) {
+          const sonnetBurn = Math.round(r.weeklyBurn * SONNET_COST / OPUS_COST);
+          tips.push(`<b>${r.name}</b> on Opus (${OPUS_COST}x) — switching to Sonnet would save ~${fmtTokens(r.weeklyBurn - sonnetBurn)}/wk in cost-adjusted tokens.`);
+        }
+      }
+
+      const budget = window._lastBudget || {};
+      if (budget.PROJECTED_PCT) {
+        const SAFE_THRESHOLD = 50;
+        const WARN_THRESHOLD = 85;
+        if (budget.PROJECTED_PCT > WARN_THRESHOLD) {
+          tips.push(`Budget projected at <b>${budget.PROJECTED_PCT}%</b> — governor is auto-downgrading models to stay within budget.`);
+        } else if (budget.PROJECTED_PCT < SAFE_THRESHOLD) {
+          const paused = rows.filter(r => r.isPaused);
+          if (paused.length > 0) {
+            tips.push(`Budget at ${budget.PROJECTED_PCT}% — headroom to enable paused agents: ${paused.map(r => `<b>${r.name}</b>`).join(', ')}.`);
+          }
+        }
+      }
+
+      const barRows = rows.filter(r => r.weeklyBurn > 0 || !r.isPaused).map(r => {
+        const pct = totalWeeklyBurn > 0 ? Math.round((r.weeklyBurn / totalWeeklyBurn) * 100) : 0;
+        const barColor = r.name === 'scanner' ? 'var(--blue)' : r.name === 'reviewer' ? 'var(--green)' : r.name === 'architect' ? 'var(--purple)' : r.name === 'outreach' ? 'var(--cyan)' : 'var(--yellow)';
+        const label = r.isPaused ? 'paused' : `${fmtTokens(r.weeklyBurn)}/wk`;
+        return `<div class="advisor-bar-row">
+          <span class="advisor-agent">${r.name}</span>
+          <div class="advisor-bar-track"><div class="advisor-bar-fill" style="width:${Math.max(pct, 2)}%;background:${barColor}"></div></div>
+          <span class="advisor-pct">${r.isPaused ? '—' : pct + '%'}</span>
+          <span class="advisor-burn">${label}</span>
+        </div>`;
+      }).join('');
+
+      const tipsHtml = tips.length > 0 ? `<div class="advisor-tips">${tips.map(t => `<div class="advisor-tip">💡 ${t}</div>`).join('')}</div>` : '';
+
+      return `<div class="advisor-section">
+        <div class="advisor-title">Cadence Advisor <span style="color:var(--muted);font-size:0.7rem">weekly projection at current cadence</span></div>
+        <div class="advisor-total">Projected: <b style="color:var(--cyan)">${fmtTokens(totalWeeklyBurn)}</b> tokens/week</div>
+        <div class="advisor-bars">${barRows}</div>
+        ${tipsHtml}
+      </div>`;
+    }
+
+// Intensity gauge: compares recent vs trailing token rate
+// Returns SVG string for a half-circle speedometer
+function computeHourlyBurnRates() {
+  const MIN_POINTS = 6;
+  if (historyData.length < MIN_POINTS) return null;
+
+  // Collect points where tokenTotal actually changed (skip stale repeats)
+  const changePoints = [];
+  let lastVal = -1;
+  for (const s of historyData) {
+    const v = s.tokenTotal || 0;
+    if (v !== lastVal) {
+      changePoints.push({ t: s.t, v });
+      lastVal = v;
+    }
+  }
+  if (changePoints.length < 3) return null;
+
+  // Compute rate between consecutive change points
+  const rawRates = [];
+  for (let i = 1; i < changePoints.length; i++) {
+    const dt = (changePoints[i].t - changePoints[i - 1].t) / 1000;
+    if (dt <= 0) continue;
+    const delta = changePoints[i].v - changePoints[i - 1].v;
+    if (delta <= 0) continue;
+    rawRates.push({ t: changePoints[i].t, rate: (delta / dt) * 3600 });
+  }
+  if (rawRates.length < 3) return null;
+
+  // Cap outliers at p95 to remove collector-reset spikes
+  const sorted = rawRates.map(r => r.rate).sort((a, b) => a - b);
+  const P95_IDX = Math.floor(sorted.length * 0.95);
+  const cap = sorted[Math.min(P95_IDX, sorted.length - 1)] * 1.5;
+  for (const r of rawRates) { if (r.rate > cap) r.rate = cap; }
+
+  // Bucket into 5-minute windows
+  const BUCKET_MS = 300000;
+  const rates = [];
+  let i = 0;
+  while (i < rawRates.length) {
+    const bucketEnd = rawRates[i].t + BUCKET_MS;
+    let sum = 0, count = 0;
+    const bt = rawRates[i].t;
+    while (i < rawRates.length && rawRates[i].t < bucketEnd) {
+      sum += rawRates[i].rate;
+      count++;
+      i++;
+    }
+    if (count > 0) rates.push({ t: bt, rate: sum / count });
+  }
+  return rates.length >= 3 ? rates : null;
+}
+
+function intensityGauge() {
+  const rates = computeHourlyBurnRates();
+  if (!rates) return '';
+
+  const rateVals = rates.map(r => r.rate);
+  const now = rateVals[rateVals.length - 1];
+  const peak = Math.max(...rateVals);
+  const low = Math.min(...rateVals);
+  const avg = rateVals.reduce((a, b) => a + b, 0) / rateVals.length;
+
+  let color;
+  if (peak === 0) color = '#8b949e';
+  else if (now / peak > 0.8) color = '#f85149';
+  else if (now / peak > 0.5) color = '#d29922';
+  else if (now / peak > 0.2) color = '#3fb950';
+  else color = '#58a6ff';
+
+  let label;
+  if (peak === 0) label = 'idle';
+  else if (now / peak > 0.8) label = 'surging';
+  else if (now / peak > 0.5) label = 'ramping';
+  else if (now / peak > 0.2) label = 'steady';
+  else label = 'cooling';
+
+  const W = 240, H = 50, PAD = 2;
+  const range = peak - low || 1;
+  const pts = rateVals.map((v, i) => {
+    const x = PAD + (i / (rateVals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - low) / range) * (H - PAD * 2);
+    return [x.toFixed(1), y.toFixed(1)];
+  });
+
+  const yAvg = (PAD + (1 - (avg - low) / range) * (H - PAD * 2)).toFixed(1);
+  const yPeak = (PAD + (1 - (peak - low) / range) * (H - PAD * 2)).toFixed(1);
+  const yLow = (PAD + (1 - (low - low) / range) * (H - PAD * 2)).toFixed(1);
+  const lastPt = pts[pts.length - 1];
+
+  const polyline = pts.map(p => p.join(',')).join(' ');
+
+  const tStart = new Date(rates[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}).toLowerCase();
+  const tEnd = new Date(rates[rates.length - 1].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}).toLowerCase();
+
+  const dotLeftPct = (parseFloat(lastPt[0]) / W * 100).toFixed(1);
+  const dotTopPct = (parseFloat(lastPt[1]) / H * 100).toFixed(1);
+
+  return `<div class="burn-chart-wrap">
+    <div class="burn-chart-title">burn rate (tok/hr)</div>
+    <div style="position:relative">
+      <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="width:100%;height:${H}px;display:block">
+        <line x1="${PAD}" y1="${yPeak}" x2="${W - PAD}" y2="${yPeak}" stroke="#f85149" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yAvg}" x2="${W - PAD}" y2="${yAvg}" stroke="#d29922" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yLow}" x2="${W - PAD}" y2="${yLow}" stroke="#58a6ff" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+      </svg>
+      <div style="position:absolute;left:${dotLeftPct}%;top:${dotTopPct}%;width:6px;height:6px;border-radius:50%;background:${color};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
+    </div>
+    <div style="display:flex;justify-content:space-between;font-size:0.6rem;color:var(--muted);margin-top:1px;font-family:monospace">
+      <span>${tStart}</span><span>${tEnd}</span>
+    </div>
+    <div class="burn-context">
+      <div class="bc-stat"><span class="bc-val" style="color:#58a6ff">${fmtTokens(low)}</span><span class="bc-label">low/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:#d29922">${fmtTokens(avg)}</span><span class="bc-label">avg/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:#f85149">${fmtTokens(peak)}</span><span class="bc-label">peak/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:${color}">${fmtTokens(now)}</span><span class="bc-label">current/hr</span></div>
+    </div>
+    <div style="color:${color};font-size:11px;font-family:monospace;margin-top:2px">${label}</div>
+  </div>`;
+}
+
+function burnAreaChart() {
+  const rates = computeHourlyBurnRates();
+  if (!rates || rates.length < 4) return '';
+
+  const rateVals = rates.map(r => r.rate);
+  const BUCKET_COUNT = 8;
+  const bucketSize = Math.max(1, Math.floor(rateVals.length / BUCKET_COUNT));
+  const buckets = [];
+  for (let i = 0; i < rateVals.length; i += bucketSize) {
+    const slice = rateVals.slice(i, i + bucketSize).sort((a, b) => a - b);
+    if (slice.length === 0) continue;
+    const p25Idx = Math.floor(slice.length * 0.25);
+    const p75Idx = Math.min(Math.floor(slice.length * 0.75), slice.length - 1);
+    const median = slice[Math.floor(slice.length * 0.5)];
+    buckets.push({ p25: slice[p25Idx], p75: slice[p75Idx], median, t: rates[Math.min(i, rates.length - 1)].t });
+  }
+
+  if (buckets.length < 2) return '';
+
+  const allVals = rateVals;
+  const peak = Math.max(...allVals);
+  const low = Math.min(...allVals);
+  const range = peak - low || 1;
+
+  const W = 400, H = 60, PAD = 2;
+  const xStep = (W - PAD * 2) / (buckets.length - 1);
+
+  const bandTop = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.p75 - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const bandBot = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.p25 - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).reverse();
+
+  const medianPts = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.median - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  const nowPts = rateVals.map((v, i) => {
+    const x = PAD + (i / (rateVals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const lastNow = nowPts[nowPts.length - 1];
+  const nowVal = rateVals[rateVals.length - 1];
+  const aboveBand = nowVal > buckets[buckets.length - 1].p75;
+  const belowBand = nowVal < buckets[buckets.length - 1].p25;
+  const dotColor = aboveBand ? '#f85149' : belowBand ? '#58a6ff' : '#3fb950';
+
+  const areaDotLeftPct = (parseFloat(lastNow.split(',')[0]) / W * 100).toFixed(1);
+  const areaDotTopPct = (parseFloat(lastNow.split(',')[1]) / H * 100).toFixed(1);
+
+  return `<div class="burn-area-wrap">
+    <div class="burn-area-title" style="text-align:left">burn rate distribution · <span style="color:rgba(57,210,192,0.6)">p25–p75 band</span> · <span style="color:#39d2c0">actual</span></div>
+    <div style="position:relative">
+      <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="width:100%;height:${H}px;display:block">
+        <polygon points="${bandTop.join(' ')} ${bandBot.join(' ')}" fill="rgba(57,210,192,0.12)" stroke="none"/>
+        <polyline points="${medianPts.join(' ')}" fill="none" stroke="rgba(57,210,192,0.3)" stroke-width="1" stroke-dasharray="2,2" vector-effect="non-scaling-stroke"/>
+        <polyline points="${nowPts.join(' ')}" fill="none" stroke="#39d2c0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+      </svg>
+      <div style="position:absolute;left:${areaDotLeftPct}%;top:${areaDotTopPct}%;width:6px;height:6px;border-radius:50%;background:${dotColor};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
+    </div>
+  </div>`;
+}
+
+
+    function renderTokens(tokens) {
+      const el = document.getElementById('token-panel');
+
+      if (!tokens || !tokens.totals || tokens.totals.sessions === 0) {
+        el.innerHTML = '';
+        return;
+      }
+
+      const sessionsEl = el.querySelector('.token-sessions');
+      const sessionsOpen = sessionsEl ? sessionsEl.open : true;
+
+      const t = tokens.totals;
+      const totalTokens = t.input + t.output + t.cacheRead;
+      const models = Object.entries(tokens.byModel || {}).sort((a, b) =>
+        (b[1].input + b[1].output + b[1].cacheRead) - (a[1].input + a[1].output + a[1].cacheRead)
+      );
+      const sessions = tokens.sessions || [];
+
+      const modelChips = models.map(([name, m]) => {
+        const mTotal = m.input + m.output + m.cacheRead;
+        const mSpark = sparkSvg(historyData.map(s => s.tokenModels?.[name] ?? 0), '#bc8cff');
+        return `<div class="token-model-chip">
+          <span class="mname">${esc(name)}</span>
+          <span class="mcount">${fmtTokens(mTotal)} tokens · ${m.messages} msgs</span>
+          ${mSpark}
+        </div>`;
+      }).join('');
+
+      const HIVE_AGENTS = new Set(['scanner', 'reviewer', 'architect', 'outreach', 'supervisor']);
+      const agentSessions = sessions.filter(s => HIVE_AGENTS.has(s.agent));
+      const grouped = {};
+      for (const s of agentSessions) {
+        if (!grouped[s.agent]) grouped[s.agent] = [];
+        grouped[s.agent].push(s);
+      }
+      const AGENT_ORDER = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
+      const sortedGroups = AGENT_ORDER.filter(a => grouped[a]).map(a => [a, grouped[a]]);
+      const sessionRows = sortedGroups.map(([agent, grp]) => {
+        const agentCls = `a-${agent}`;
+        const rows = grp.map(s => {
+          const age = s.lastActive ? new Date(s.lastActive).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+          const act = s.activity || [];
+          const MINI_W = 60, MINI_H = 14;
+          let miniSpark = '';
+          if (act.length >= 2) {
+            const mx = Math.max(...act, 1);
+            const pts = act.map((v, i) => `${(i / (act.length - 1)) * MINI_W},${MINI_H - (v / mx) * (MINI_H - 2) - 1}`).join(' ');
+            const aClrs = { scanner: '#58a6ff', reviewer: '#3fb950', architect: '#bc8cff', outreach: '#39d2c0', supervisor: '#d29922' };
+            const clr = aClrs[s.agent] || '#8b949e';
+            miniSpark = `<span class="sparkline" style="margin-left:4px"><svg width="${MINI_W}" height="${MINI_H}" viewBox="0 0 ${MINI_W} ${MINI_H}"><polyline points="${pts}" fill="none" stroke="${clr}" stroke-width="1.2" opacity="0.7"/></svg></span>`;
+          }
+          return `<div class="token-session-row" style="padding-left:12px">
+            <span class="sid">${esc(s.id)}</span>
+            <span class="smodel">${esc(s.model)}</span>
+            <span class="stokens" ${s.estimated ? 'title="estimated from avg tokens/msg"' : ''}>${s.total > 0 ? (s.estimated ? '~' : '') + fmtTokens(s.total) : '—'}</span>
+            <span class="smsgs">${s.messages} msgs</span>${miniSpark}
+            <span class="sproj">${age}</span>
+          </div>`;
+        }).join('');
+        const totalMsgs = grp.reduce((a, s) => a + s.messages, 0);
+        const totalTokens = grp.reduce((a, s) => a + s.total, 0);
+        const hasEstimates = grp.some(s => s.estimated && s.total > 0);
+        return `<div style="margin-bottom:6px">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:2px">
+            <span class="sagent ${agentCls}" style="font-weight:700">${agent}</span>
+            <span style="color:var(--muted);font-size:0.65rem">${grp.length} session${grp.length > 1 ? 's' : ''} · ${totalMsgs} msgs${totalTokens > 0 ? ' · ' + (hasEstimates ? '~' : '') + fmtTokens(totalTokens) : ''}</span>
+          </div>
+          ${rows}
+        </div>`;
+      }).join('');
+
+      const advisorHtml = buildCadenceAdvisor(tokens.byAgent || {});
+
+      const totalSpark = sparkSvg(getHistorySeries('tokenTotal'), '#39d2c0');
+      const agentNames = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
+      const agentColors = { scanner: '#58a6ff', reviewer: '#3fb950', architect: '#bc8cff', outreach: '#39d2c0', supervisor: '#d29922' };
+      const agentSparkRows = agentNames.map(name => {
+        const ba = tokens.byAgent || {};
+        const aData = ba[name];
+        const aTotal = aData ? (aData.input || 0) + (aData.output || 0) + (aData.cacheRead || 0) : 0;
+        const aSpark = sparkSvg(historyData.map(s => s.tokens?.[name] ?? 0), agentColors[name] || '#8b949e');
+        return `<div class="token-stat"><div class="spark-row"><span class="tval" style="color:${agentColors[name]}">${fmtTokens(aTotal)}</span>${aSpark}</div><div class="tlabel">${name}</div></div>`;
+      }).join('');
+
+      el.innerHTML = `<div class="token-panel">
+        <div class="token-title">Token Usage <span class="lookback">${tokens.lookbackHours || 24}h window · ${t.sessions} sessions</span></div>
+        <div style="display:flex;gap:16px;margin-bottom:24px;padding-bottom:16px;border-bottom:1px solid var(--border)">
+          <div style="flex:1;min-width:0">${intensityGauge()}</div>
+          <div style="flex:1;min-width:0">${burnAreaChart()}</div>
+        </div>
+        <div class="token-grid">
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--cyan)">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), '#58a6ff')}</div><div class="tlabel">input</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--purple)">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), '#bc8cff')}</div><div class="tlabel">output</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--green)">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), '#3fb950')}</div><div class="tlabel">cache read</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--yellow)">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), '#d29922')}</div><div class="tlabel">cache create</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), '#8b949e')}</div><div class="tlabel">messages</div></div>
+        </div>
+        ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
+        ${advisorHtml}
+        <div class="token-models">${modelChips}</div>
+        ${agentSessions.length > 0 ? `<details class="token-sessions"${sessionsOpen ? ' open' : ''}><summary>Active Sessions (${agentSessions.length})</summary>${sessionRows}</details>` : ''}
+      </div>`;
+    }
+
+    // GitHub auth health — sticky banner when 401
+    const GH_AUTH_POLL_MS = 30000;
+    async function checkGhAuth() {
+      try {
+        const res = await fetch('/api/gh-auth');
+        const data = await res.json();
+        const el = document.getElementById('gh-auth-alert');
+        if (data.ok) {
+          el.className = 'gh-auth-alert';
+        } else {
+          el.className = 'gh-auth-alert active';
+        }
+      } catch (_) { /* dashboard unreachable — different problem */ }
+    }
+    checkGhAuth();
+    setInterval(checkGhAuth, GH_AUTH_POLL_MS);
+
+    function renderGhRateLimits(ghRateLimits) {
+      const el = document.getElementById('gh-rate-alert');
+      const alerts = (ghRateLimits && ghRateLimits.alerts) || [];
+      const pullbacks = (ghRateLimits && ghRateLimits.pullbacks) || [];
+      const now = Math.floor(Date.now() / 1000);
+      const GH_RATE_DEFAULT_TTL = 3600;
+      const SECONDS_PER_MINUTE = 60;
+      const MINUTES_PER_HOUR = 60;
+      const active = alerts.filter(a => {
+        if (a.api_reset_epoch && a.api_reset_epoch > 0) return now < a.api_reset_epoch;
+        const ttl = a.ttl_seconds || GH_RATE_DEFAULT_TTL;
+        return now - (a.detected_epoch || 0) < ttl;
+      });
+      const activePullbacks = pullbacks.filter(p => now < (p.expiry_epoch || 0));
+      if (active.length === 0 && activePullbacks.length === 0) {
+        el.className = 'gh-rate-alert';
+        el.innerHTML = '';
+        return;
+      }
+      el.className = 'gh-rate-alert active';
+      const items = active.map(a => {
+        const ageSec = now - (a.detected_epoch || now);
+        let ageStr;
+        if (ageSec < SECONDS_PER_MINUTE) ageStr = ageSec + 's ago';
+        else if (ageSec < SECONDS_PER_MINUTE * MINUTES_PER_HOUR) ageStr = Math.floor(ageSec / SECONDS_PER_MINUTE) + 'm ago';
+        else ageStr = Math.floor(ageSec / (SECONDS_PER_MINUTE * MINUTES_PER_HOUR)) + 'h ago';
+        const cliTag = a.cli ? ` <span style="opacity:0.6;font-size:0.65rem">(${esc(a.cli)})</span>` : '';
+        return `<div class="gh-rate-alert-item">
+          <span class="gh-rate-alert-agent">${esc(a.agent)}${cliTag}</span>
+          <span class="gh-rate-alert-age">${ageStr}</span>
+          <span class="gh-rate-alert-msg">${esc(a.message || 'GitHub API rate limited')}</span>
+        </div>`;
+      }).join('');
+      const pullbackHtml = activePullbacks.map(p => {
+        const remainSec = (p.expiry_epoch || 0) - now;
+        const remainMin = Math.max(0, Math.ceil(remainSec / SECONDS_PER_MINUTE));
+        const paused = (p.paused_agents || []).join(', ') || 'none';
+        let resetStr = '';
+        if (p.api_reset_epoch && p.api_reset_epoch > now) {
+          const resetDate = new Date(p.api_reset_epoch * 1000);
+          resetStr = ` · API quota resets ${resetDate.toLocaleTimeString([], {hour:'numeric',minute:'2-digit'})}`;
+        } else if (p.api_reset_epoch && p.api_reset_epoch <= now) {
+          resetStr = ' · API quota restored';
+        }
+        return `<div style="font-size:0.72rem;color:#d29922;margin-top:6px;padding-top:6px;border-top:1px solid rgba(210,153,34,0.25)">
+          ⏸ Pullback (${esc(p.cli || '?')}): paused <strong>${esc(paused)}</strong> — resumes in ${remainMin}m${resetStr}
+        </div>`;
+      }).join('');
+      el.innerHTML = `<div class="gh-rate-alert-title">GitHub API Rate Limit (${active.length} agent${active.length > 1 ? 's' : ''})</div>${items}${pullbackHtml}`;
+    }
+
+    // Guard: skip agent re-render while a dropdown is focused/open
+    let _dropdownOpen = false;
+    document.addEventListener('focusin', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = true; });
+    document.addEventListener('focusout', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = false; });
+    document.addEventListener('change', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = false; });
+
+    function render(data) {
+      if (!data || data.error) return;
+      const scrollY = window.scrollY;
+      document.getElementById('ts').textContent = new Date(data.timestamp).toLocaleDateString([], {month:'numeric',day:'numeric'}) + ' ' + new Date(data.timestamp).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
+      currentAgentMetrics = data.agentMetrics || {};
+      window._healthData = data.health || {};
+      window._tokensByAgent = (data.tokens || {}).byAgent || {};
+      window._lastAgents = data.agents || [];
+      window._lastBudget = data.budget || {};
+      renderGhRateLimits(data.ghRateLimits || {});
+      if (!_dropdownOpen) {
+        applyPinOverrides(data.agents || []);
+        renderAgents(data.agents || []);
+        renderGovernor(data.governor || {}, data.cadenceMatrix || [], data);
+      }
+      renderTokens(data.tokens || {});
+      renderRepos(data.repos || []);
+      renderBeads(data.beads || {});
+      requestAnimationFrame(() => window.scrollTo(0, scrollY));
+    }
+
+    function esc(s) {
+      const d = document.createElement('div');
+      d.textContent = s;
+      return d.innerHTML;
+    }
+
+    const TOAST_DURATION_MS = 3000;
+    const TOAST_PROGRESS_MAX_MS = 60000;
+    function showToast(msg, type = 'info', persistent = false) {
+      const container = document.getElementById('toast-container');
+      const el = document.createElement('div');
+      el.className = `toast ${type}`;
+      el.textContent = msg;
+      container.appendChild(el);
+      if (persistent) {
+        const spinner = document.createElement('span');
+        spinner.className = 'toast-spinner';
+        el.prepend(spinner);
+        el._persistent = true;
+        setTimeout(() => { if (el.parentNode) dismissToast(el); }, TOAST_PROGRESS_MAX_MS);
+        return el;
+      }
+      setTimeout(() => dismissToast(el), TOAST_DURATION_MS);
+      return el;
+    }
+    function dismissToast(el, newMsg, newType) {
+      if (!el || !el.parentNode) return;
+      if (newMsg) {
+        el.textContent = newMsg;
+        el.className = `toast ${newType || 'success'}`;
+        setTimeout(() => { el.style.animation = 'toast-out 0.3s ease-in forwards'; setTimeout(() => el.remove(), 300); }, TOAST_DURATION_MS);
+      } else {
+        el.style.animation = 'toast-out 0.3s ease-in forwards';
+        setTimeout(() => el.remove(), 300);
+      }
+    }
+
+    async function kick(agent) {
+      const input = document.getElementById(`kick-prompt-${agent}`);
+      const prompt = input ? input.value.trim() : '';
+
+      const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
+      if (prompt) opts.body = JSON.stringify({ prompt });
+      const res = await fetch(`/api/kick/${agent}`, opts);
+      const data = await res.json();
+      if (!data.ok) { showToast('Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
+      showToast(`Kicked ${agent}`, 'success');
+      if (input) input.value = '';
+    }
+
+    async function toggleAgent(agent, currentlyPaused) {
+      const action = currentlyPaused ? 'resume' : 'pause';
+      const label = currentlyPaused ? 'Resuming' : 'Pausing';
+      const toast = showToast(`${label} ${agent}...`, 'info', true);
+      const res = await fetch(`/api/${action}/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `${action} failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} ${action}d`, 'success');
+    }
+
+    async function restartAgent(agent) {
+      if (!confirm(`Restart ${agent}? This will kill the current session and start fresh.`)) return;
+      const toast = showToast(`Restarting ${agent}...`, 'info', true);
+      const res = await fetch(`/api/restart/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `Restart failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} restarted — supervisor will respawn`, 'success');
+    }
+
+    async function resetRestarts(agent) {
+      const toast = showToast(`Resetting ${agent} restart counter...`, 'info', true);
+      const res = await fetch(`/api/reset-restarts/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `Reset failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} restart counter reset`, 'success');
+    }
+
+    async function switchCli(agent, backend) {
+      if (!backend) return;
+      const toast = showToast(`Switching ${agent} → ${backend}...`, 'info', true);
+      const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} CLI → ${backend}`, 'success');
+    }
+
+    async function switchModel(agent, model) {
+      if (!model) return;
+      const toast = showToast(`Switching ${agent} model → ${model}...`, 'info', true);
+      const res = await fetch(`/api/model/${agent}/${encodeURIComponent(model)}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `Model switch failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} model → ${model}`, 'success');
+    }
+
+    const PIN_OVERRIDE_TTL_MS = 8000;
+    const _pinOverrides = {};
+    async function togglePin(agent, dimension, currentlyPinned) {
+      const action = currentlyPinned ? 'unpin' : 'pin';
+      const res = await fetch(`/api/${action}/${agent}/${dimension}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { showToast(`${action} failed: ` + (data.error || 'unknown'), 'error'); return; }
+      showToast(`${agent} ${dimension} ${action}ned`, 'success');
+      const nowPinned = !currentlyPinned;
+      const key = `${agent}:${dimension}`;
+      _pinOverrides[key] = { value: nowPinned, expires: Date.now() + PIN_OVERRIDE_TTL_MS };
+      const agents = window._lastAgents || [];
+      applyPinOverrides(agents);
+      renderAgents(agents);
+    }
+    function applyPinOverrides(agents) {
+      const now = Date.now();
+      for (const key of Object.keys(_pinOverrides)) {
+        if (_pinOverrides[key].expires < now) { delete _pinOverrides[key]; continue; }
+        const [agent, dimension] = key.split(':');
+        const a = (agents || []).find(x => x.name === agent);
+        if (!a) continue;
+        const v = _pinOverrides[key].value;
+        if (dimension === 'cli') { a.pinnedCli = v; if (!v && a.pinnedBoth) { a.pinnedBoth = false; a.pinnedModel = true; } }
+        else if (dimension === 'model') { a.pinnedModel = v; if (!v && a.pinnedBoth) { a.pinnedBoth = false; a.pinnedCli = true; } }
+        else { a.pinnedBoth = v; a.pinnedCli = v; a.pinnedModel = v; }
+      }
+    }
+
+    // Git version indicator
+    const GIT_VERSION_POLL_MS = 300000;
+    async function fetchGitVersion() {
+      try {
+        const res = await fetch('/api/version');
+        const v = await res.json();
+        const el = document.getElementById('git-version');
+        let html = `<a href="https://github.com/kubestellar/hive/commit/${v.hash}" target="_blank" style="color:inherit;text-decoration:none" title="${v.hash}">${v.short}</a>`;
+        if (v.dirty) html += ' <span class="git-dirty">*</span>';
+        if (v.behind > 0) html += ` <span class="git-behind">${v.behind} behind</span>`;
+        el.innerHTML = html;
+      } catch (_) {}
+    }
+    fetchGitVersion();
+    setInterval(fetchGitVersion, GIT_VERSION_POLL_MS);
+
+    // SSE connection
+    
+
+    // ── Static snapshot initialization ──
+    historyData = [{"t":1777645480911,"govIssues":14,"govPrs":19,"govTotal":33,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":18,"prs":19},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":1,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19725178,"unknown":4928018062,"dog-alpha":44748820,"scanner":606653765,"supervisor":214502016,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6142616187,"tokenInput":586509709,"tokenOutput":18845305,"tokenCacheRead":5537261173,"tokenCacheCreate":103847385,"tokenMessages":59913,"tokenModels":{"claude-opus-4-6":4947743240,"claude-haiku-4-5-20251001":44748820,"claude-opus-4.6":607359722,"claude-sonnet-4.6":465332490,"auto":5841464,"claude-haiku-4.5":71590451}},{"t":1777645844106,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":18,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19670478,"unknown":4929821640,"dog-alpha":43750735,"scanner":606653765,"supervisor":216851141,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6145716105,"tokenInput":587703533,"tokenOutput":18854521,"tokenCacheRead":5539158051,"tokenCacheCreate":103816798,"tokenMessages":60063,"tokenModels":{"claude-opus-4-6":4949492118,"claude-haiku-4-5-20251001":43750735,"claude-opus-4.6":607359722,"claude-sonnet-4.6":467681615,"auto":5841464,"claude-haiku-4.5":71590451}},{"t":1777646200766,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":18,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19725491,"unknown":4934780099,"dog-alpha":43750735,"scanner":598283477,"supervisor":218374802,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6143882950,"tokenInput":584052835,"tokenOutput":18829310,"tokenCacheRead":5541000805,"tokenCacheCreate":103431814,"tokenMessages":60005,"tokenModels":{"claude-opus-4-6":4954505590,"claude-haiku-4-5-20251001":43750735,"claude-opus-4.6":607359722,"claude-sonnet-4.6":469813347,"auto":5233393,"claude-haiku-4.5":63220163}},{"t":1777646568249,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":18,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":1,"restarts":2},"architect":{"busy":1,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19670790,"unknown":4939592173,"dog-alpha":43750735,"scanner":617365232,"supervisor":217316182,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6166663458,"tokenInput":593264279,"tokenOutput":18918673,"tokenCacheRead":5554480506,"tokenCacheCreate":103928722,"tokenMessages":60103,"tokenModels":{"claude-opus-4-6":4959262963,"claude-haiku-4-5-20251001":43750735,"claude-opus-4.6":626441477,"claude-sonnet-4.6":468754727,"auto":5233393,"claude-haiku-4.5":63220163}},{"t":1777646925597,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19616098,"unknown":4944439728,"dog-alpha":43843763,"scanner":617365232,"supervisor":219933467,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6174166634,"tokenInput":594601392,"tokenOutput":18942499,"tokenCacheRead":5560622743,"tokenCacheCreate":104032093,"tokenMessages":60217,"tokenModels":{"claude-opus-4-6":4964055826,"claude-haiku-4-5-20251001":43843763,"claude-opus-4.6":626441477,"claude-sonnet-4.6":471372012,"auto":5233393,"claude-haiku-4.5":63220163}},{"t":1777647286792,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":1,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19615944,"unknown":4950248556,"dog-alpha":44622954,"scanner":607584926,"supervisor":219852120,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6170892846,"tokenInput":589429853,"tokenOutput":18916671,"tokenCacheRead":5562546322,"tokenCacheCreate":103629788,"tokenMessages":60228,"tokenModels":{"claude-opus-4-6":4969864500,"claude-haiku-4-5-20251001":44622954,"claude-opus-4.6":626441477,"claude-sonnet-4.6":471372012,"auto":5152046,"claude-haiku-4.5":53439857}},{"t":1777647656532,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19583347,"unknown":4954635859,"dog-alpha":43749868,"scanner":607584926,"supervisor":221400721,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6175923067,"tokenInput":590220783,"tokenOutput":18929347,"tokenCacheRead":5566772937,"tokenCacheCreate":103597697,"tokenMessages":60290,"tokenModels":{"claude-opus-4-6":4974219206,"claude-haiku-4-5-20251001":43749868,"claude-opus-4.6":626441477,"claude-sonnet-4.6":472920613,"auto":5152046,"claude-haiku-4.5":53439857}},{"t":1777648008418,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19638376,"unknown":4957294108,"dog-alpha":43749868,"scanner":607584926,"supervisor":221195378,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6178431002,"tokenInput":590103438,"tokenOutput":18933414,"tokenCacheRead":5569394150,"tokenCacheCreate":103611280,"tokenMessages":60358,"tokenModels":{"claude-opus-4-6":4976932484,"claude-haiku-4-5-20251001":43749868,"claude-opus-4.6":626441477,"claude-sonnet-4.6":472920613,"auto":4946703,"claude-haiku-4.5":53439857}},{"t":1777648377215,"govIssues":14,"govPrs":20,"govTotal":34,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":20},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19583661,"unknown":4962708389,"dog-alpha":43749868,"scanner":597491470,"supervisor":223661601,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6176163335,"tokenInput":586061907,"tokenOutput":18918190,"tokenCacheRead":5571183238,"tokenCacheCreate":103137343,"tokenMessages":60290,"tokenModels":{"claude-opus-4-6":4982292050,"claude-haiku-4-5-20251001":43749868,"claude-opus-4.6":626410895,"claude-sonnet-4.6":475386836,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777648741583,"govIssues":14,"govPrs":23,"govTotal":37,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":22},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":1,"restarts":2},"architect":{"busy":1,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19528663,"unknown":4969448820,"dog-alpha":44584162,"scanner":597491470,"supervisor":225421891,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6185443352,"tokenInput":586949434,"tokenOutput":18938161,"tokenCacheRead":5579555757,"tokenCacheCreate":103283603,"tokenMessages":60419,"tokenModels":{"claude-opus-4-6":4988977483,"claude-haiku-4-5-20251001":44584162,"claude-opus-4.6":626410895,"claude-sonnet-4.6":477147126,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777649101239,"govIssues":14,"govPrs":21,"govTotal":35,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":21},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":1,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19528872,"unknown":4972777461,"dog-alpha":44947050,"scanner":600853233,"supervisor":222009254,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6189084216,"tokenInput":586966671,"tokenOutput":18948050,"tokenCacheRead":5583169495,"tokenCacheCreate":103385925,"tokenMessages":60492,"tokenModels":{"claude-opus-4-6":4992306333,"claude-haiku-4-5-20251001":44947050,"claude-opus-4.6":629772658,"claude-sonnet-4.6":473734489,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777649457408,"govIssues":14,"govPrs":19,"govTotal":33,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":19,"prs":19},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":1,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19528976,"unknown":4979650021,"dog-alpha":44136113,"scanner":600853233,"supervisor":222009254,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6195145943,"tokenInput":586966602,"tokenOutput":18954804,"tokenCacheRead":5589224537,"tokenCacheCreate":103344074,"tokenMessages":60545,"tokenModels":{"claude-opus-4-6":4999178997,"claude-haiku-4-5-20251001":44136113,"claude-opus-4.6":629772658,"claude-sonnet-4.6":473734489,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777649823416,"govIssues":14,"govPrs":19,"govTotal":33,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19529178,"unknown":4985431195,"dog-alpha":44136113,"scanner":600853233,"supervisor":222289588,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6201207653,"tokenInput":587111814,"tokenOutput":18966957,"tokenCacheRead":5595128882,"tokenCacheCreate":103493500,"tokenMessages":60610,"tokenModels":{"claude-opus-4-6":5004960373,"claude-haiku-4-5-20251001":44136113,"claude-opus-4.6":629772658,"claude-sonnet-4.6":474014823,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777650183556,"govIssues":0,"govPrs":3,"govTotal":3,"govActive":1,"govMode":"busy","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19529080,"unknown":4988470267,"dog-alpha":44136113,"scanner":600853233,"supervisor":226390218,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6208347257,"tokenInput":589171694,"tokenOutput":18994422,"tokenCacheRead":5600181141,"tokenCacheCreate":103736333,"tokenMessages":60664,"tokenModels":{"claude-opus-4-6":5007999347,"claude-haiku-4-5-20251001":44136113,"claude-opus-4.6":629772658,"claude-sonnet-4.6":478115453,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777650545972,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19529184,"unknown":4990455068,"dog-alpha":45258044,"scanner":581188201,"supervisor":223795651,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6189194494,"tokenInput":577898455,"tokenOutput":18959359,"tokenCacheRead":5592336680,"tokenCacheCreate":103497115,"tokenMessages":60582,"tokenModels":{"claude-opus-4-6":5009984252,"claude-haiku-4-5-20251001":45258044,"claude-opus-4.6":610107626,"claude-sonnet-4.6":475520886,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777650904763,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19529259,"unknown":4992819181,"dog-alpha":45258044,"scanner":581188201,"supervisor":225321303,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6193084334,"tokenInput":578680325,"tokenOutput":18972659,"tokenCacheRead":5595431350,"tokenCacheCreate":103554408,"tokenMessages":60666,"tokenModels":{"claude-opus-4-6":5012348440,"claude-haiku-4-5-20251001":45258044,"claude-opus-4.6":610107626,"claude-sonnet-4.6":477046538,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777651271835,"govIssues":0,"govPrs":2,"govTotal":2,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19584294,"unknown":4994459526,"dog-alpha":44403408,"scanner":581188201,"supervisor":223428661,"reviewer":284067612,"outreach":19232083,"architect":25668651},"tokenTotal":6192032436,"tokenInput":577715193,"tokenOutput":18968529,"tokenCacheRead":5595348714,"tokenCacheCreate":103508751,"tokenMessages":60671,"tokenModels":{"claude-opus-4-6":5014043820,"claude-haiku-4-5-20251001":44403408,"claude-opus-4.6":608214984,"claude-sonnet-4.6":477046538,"auto":4946703,"claude-haiku-4.5":43376983}},{"t":1777651639538,"govIssues":0,"govPrs":2,"govTotal":2,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":1,"restarts":2},"architect":{"busy":1,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19584501,"unknown":4995134194,"dog-alpha":44403408,"scanner":566220645,"supervisor":228943545,"reviewer":328798877,"outreach":87121926,"architect":183261184},"tokenTotal":6453468280,"tokenInput":710155230,"tokenOutput":19625901,"tokenCacheRead":5723687149,"tokenCacheCreate":108157750,"tokenMessages":60659,"tokenModels":{"claude-opus-4-6":5014718695,"claude-haiku-4-5-20251001":44403408,"claude-opus-4.6":593247428,"claude-sonnet-4.6":482561422,"auto":49677968,"claude-haiku-4.5":268859359}},{"t":1777651993206,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":0,"restarts":2},"architect":{"busy":0,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19584593,"unknown":4997778987,"dog-alpha":44403408,"scanner":566665585,"supervisor":228290348,"reviewer":328798877,"outreach":87121926,"architect":183261184},"tokenTotal":6455904908,"tokenInput":710050102,"tokenOutput":19637132,"tokenCacheRead":5726217674,"tokenCacheCreate":108193858,"tokenMessages":60781,"tokenModels":{"claude-opus-4-6":5017363580,"claude-haiku-4-5-20251001":44403408,"claude-opus-4.6":593039171,"claude-sonnet-4.6":482561422,"auto":49677968,"claude-haiku-4.5":268859359}},{"t":1777652365421,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":1,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19584808,"unknown":4998741878,"dog-alpha":45254016,"scanner":566940036,"supervisor":227890686,"reviewer":335228673,"outreach":87121926,"architect":190495556},"tokenTotal":6471257579,"tokenInput":716984473,"tokenOutput":19710760,"tokenCacheRead":5734562346,"tokenCacheCreate":108622008,"tokenMessages":60886,"tokenModels":{"claude-opus-4-6":5018326686,"claude-haiku-4-5-20251001":45254016,"claude-opus-4.6":600148332,"claude-sonnet-4.6":488991218,"auto":49677968,"claude-haiku-4.5":268859359}},{"t":1777652732292,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":1,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19584907,"unknown":5001742810,"dog-alpha":45254016,"scanner":566940036,"supervisor":232823482,"reviewer":335228673,"outreach":98677729,"architect":190495556},"tokenTotal":6490747209,"tokenInput":725289486,"tokenOutput":19756786,"tokenCacheRead":5745700937,"tokenCacheCreate":108766664,"tokenMessages":61036,"tokenModels":{"claude-opus-4-6":5021327717,"claude-haiku-4-5-20251001":45254016,"claude-opus-4.6":600148332,"claude-sonnet-4.6":488991218,"auto":66166567,"claude-haiku-4.5":268859359}},{"t":1777653094815,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19639921,"unknown":5005593220,"dog-alpha":45254016,"scanner":541710230,"supervisor":231273056,"reviewer":335228673,"outreach":98677729,"architect":190495556},"tokenTotal":6467872401,"tokenInput":711744005,"tokenOutput":19672814,"tokenCacheRead":5736455582,"tokenCacheCreate":108489781,"tokenMessages":60905,"tokenModels":{"claude-opus-4-6":5025233141,"claude-haiku-4-5-20251001":45254016,"claude-opus-4.6":573368100,"claude-sonnet-4.6":488991218,"auto":66166567,"claude-haiku-4.5":268859359}},{"t":1777653469300,"govIssues":5,"govPrs":0,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":10,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19684867,"unknown":5011721908,"dog-alpha":44237039,"scanner":542915340,"supervisor":229655856,"reviewer":335228673,"outreach":101209123,"architect":199683155},"tokenTotal":6484335961,"tokenInput":717608394,"tokenOutput":19766494,"tokenCacheRead":5746961073,"tokenCacheCreate":108960673,"tokenMessages":60915,"tokenModels":{"claude-opus-4-6":5031406775,"claude-haiku-4-5-20251001":44237039,"claude-opus-4.6":572956010,"claude-sonnet-4.6":491522612,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777653840685,"govIssues":5,"govPrs":0,"govTotal":5,"govActive":1,"govMode":"quiet","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":10,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":2},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":1,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19684964,"unknown":5015549321,"dog-alpha":44237039,"scanner":542915340,"supervisor":229655856,"reviewer":335228673,"outreach":101209123,"architect":199683155},"tokenTotal":6488163471,"tokenInput":717608455,"tokenOutput":19781994,"tokenCacheRead":5750773022,"tokenCacheCreate":109174988,"tokenMessages":60979,"tokenModels":{"claude-opus-4-6":5035234285,"claude-haiku-4-5-20251001":44237039,"claude-opus-4.6":572956010,"claude-sonnet-4.6":491522612,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777654221476,"govIssues":5,"govPrs":0,"govTotal":5,"govActive":1,"govMode":"quiet","beadsWorkers":25,"beadsSupervisor":50,"repos":{"console":{"issues":10,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":2},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":1,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19630256,"unknown":5020564170,"dog-alpha":44694787,"scanner":531935521,"supervisor":229187802,"reviewer":335228673,"outreach":103095226,"architect":199683155},"tokenTotal":6484019590,"tokenInput":712650670,"tokenOutput":19741442,"tokenCacheRead":5751627478,"tokenCacheCreate":108845618,"tokenMessages":61061,"tokenModels":{"claude-opus-4-6":5040194426,"claude-haiku-4-5-20251001":44694787,"claude-opus-4.6":561508137,"claude-sonnet-4.6":493408715,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777654592078,"govIssues":6,"govPrs":3,"govTotal":9,"govActive":1,"govMode":"quiet","beadsWorkers":30,"beadsSupervisor":50,"repos":{"console":{"issues":11,"prs":7},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":1,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19608341,"unknown":5026110687,"dog-alpha":45188291,"scanner":536589854,"supervisor":233036202,"reviewer":335228673,"outreach":103095226,"architect":199683155},"tokenTotal":6498540429,"tokenInput":717034555,"tokenOutput":19807868,"tokenCacheRead":5761698006,"tokenCacheCreate":109211347,"tokenMessages":61306,"tokenModels":{"claude-opus-4-6":5045719028,"claude-haiku-4-5-20251001":45188291,"claude-opus-4.6":566162470,"claude-sonnet-4.6":497257115,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777654951160,"govIssues":6,"govPrs":8,"govTotal":14,"govActive":1,"govMode":"quiet","beadsWorkers":30,"beadsSupervisor":50,"repos":{"console":{"issues":11,"prs":8},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19630468,"unknown":5030978889,"dog-alpha":44253691,"scanner":536589854,"supervisor":233036202,"reviewer":335228673,"outreach":103095226,"architect":199683155},"tokenTotal":6502496158,"tokenInput":717034530,"tokenOutput":19815491,"tokenCacheRead":5765646137,"tokenCacheCreate":109190366,"tokenMessages":61352,"tokenModels":{"claude-opus-4-6":5050609357,"claude-haiku-4-5-20251001":44253691,"claude-opus-4.6":566162470,"claude-sonnet-4.6":497257115,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777655321639,"govIssues":6,"govPrs":8,"govTotal":14,"govActive":1,"govMode":"quiet","beadsWorkers":30,"beadsSupervisor":50,"repos":{"console":{"issues":11,"prs":8},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19575760,"unknown":5038256329,"dog-alpha":44253691,"scanner":536589854,"supervisor":233036202,"reviewer":335228673,"outreach":103095226,"architect":199683155},"tokenTotal":6509718890,"tokenInput":717034633,"tokenOutput":19833193,"tokenCacheRead":5772851064,"tokenCacheCreate":109206664,"tokenMessages":61456,"tokenModels":{"claude-opus-4-6":5057832089,"claude-haiku-4-5-20251001":44253691,"claude-opus-4.6":566162470,"claude-sonnet-4.6":497257115,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777655679918,"govIssues":6,"govPrs":8,"govTotal":14,"govActive":1,"govMode":"quiet","beadsWorkers":27,"beadsSupervisor":50,"repos":{"console":{"issues":11,"prs":8},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19608765,"unknown":5043963472,"dog-alpha":44253691,"scanner":538761515,"supervisor":232486729,"reviewer":335228673,"outreach":103095226,"architect":199683155},"tokenTotal":6517081226,"tokenInput":717846685,"tokenOutput":19850962,"tokenCacheRead":5779383579,"tokenCacheCreate":109279477,"tokenMessages":61540,"tokenModels":{"claude-opus-4-6":5063572237,"claude-haiku-4-5-20251001":44253691,"claude-opus-4.6":567784658,"claude-sonnet-4.6":497257115,"auto":66166567,"claude-haiku-4.5":278046958}},{"t":1777656076932,"govIssues":3,"govPrs":4,"govTotal":7,"govActive":1,"govMode":"quiet","beadsWorkers":27,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19554057,"unknown":5050832149,"dog-alpha":45376989,"scanner":538872510,"supervisor":234759499,"reviewer":336812765,"outreach":109871364,"architect":211831443},"tokenTotal":6547910776,"tokenInput":729464040,"tokenOutput":19953859,"tokenCacheRead":5798492877,"tokenCacheCreate":109753878,"tokenMessages":61676,"tokenModels":{"claude-opus-4-6":5070386206,"claude-haiku-4-5-20251001":45376989,"claude-opus-4.6":569479745,"claude-sonnet-4.6":511678173,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777656436907,"govIssues":3,"govPrs":4,"govTotal":7,"govActive":1,"govMode":"normal","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19576194,"unknown":5056312695,"dog-alpha":45376989,"scanner":538872510,"supervisor":234288446,"reviewer":336812765,"outreach":109871364,"architect":211831443},"tokenTotal":6552942406,"tokenInput":729213068,"tokenOutput":19960753,"tokenCacheRead":5803768585,"tokenCacheCreate":109742001,"tokenMessages":61775,"tokenModels":{"claude-opus-4-6":5075888889,"claude-haiku-4-5-20251001":45376989,"claude-opus-4.6":569008692,"claude-sonnet-4.6":511678173,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777656797786,"govIssues":1,"govPrs":3,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19576304,"unknown":5062476761,"dog-alpha":44503633,"scanner":472405401,"supervisor":235713236,"reviewer":344398656,"outreach":109871364,"architect":211831443},"tokenTotal":6500776798,"tokenInput":700273592,"tokenOutput":19846745,"tokenCacheRead":5780656461,"tokenCacheCreate":109214137,"tokenMessages":61371,"tokenModels":{"claude-opus-4-6":5082053065,"claude-haiku-4-5-20251001":44503633,"claude-opus-4.6":502541583,"claude-sonnet-4.6":520688854,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777657167482,"govIssues":1,"govPrs":3,"govTotal":4,"govActive":1,"govMode":"normal","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19576405,"unknown":5067281138,"dog-alpha":44503633,"scanner":472933011,"supervisor":234806361,"reviewer":344398656,"outreach":109871364,"architect":211831443},"tokenTotal":6505202011,"tokenInput":700074918,"tokenOutput":19859031,"tokenCacheRead":5785268062,"tokenCacheCreate":109291888,"tokenMessages":61445,"tokenModels":{"claude-opus-4-6":5086857543,"claude-haiku-4-5-20251001":44503633,"claude-opus-4.6":502162318,"claude-sonnet-4.6":520688854,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777657527458,"govIssues":1,"govPrs":3,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19576606,"unknown":5069760398,"dog-alpha":44743281,"scanner":470961006,"supervisor":235923807,"reviewer":344398656,"outreach":109871364,"architect":211831443},"tokenTotal":6507066561,"tokenInput":699686418,"tokenOutput":19870987,"tokenCacheRead":5787509156,"tokenCacheCreate":109443527,"tokenMessages":61492,"tokenModels":{"claude-opus-4-6":5089337004,"claude-haiku-4-5-20251001":44743281,"claude-opus-4.6":498516948,"claude-sonnet-4.6":523479665,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777657887290,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19576716,"unknown":5073282884,"dog-alpha":45548482,"scanner":470961006,"supervisor":239178833,"reviewer":354330362,"outreach":109871364,"architect":211831443},"tokenTotal":6524581090,"tokenInput":706326476,"tokenOutput":19923755,"tokenCacheRead":5798330859,"tokenCacheCreate":109601873,"tokenMessages":61601,"tokenModels":{"claude-opus-4-6":5092859600,"claude-haiku-4-5-20251001":45548482,"claude-opus-4.6":498516948,"claude-sonnet-4.6":536666397,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777658242779,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":1,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19576833,"unknown":5078580991,"dog-alpha":45548482,"scanner":468970230,"supervisor":237968939,"reviewer":354330362,"outreach":109871364,"architect":211831443},"tokenTotal":6526678644,"tokenInput":704693252,"tokenOutput":19928050,"tokenCacheRead":5802057342,"tokenCacheCreate":109565174,"tokenMessages":61674,"tokenModels":{"claude-opus-4-6":5098157824,"claude-haiku-4-5-20251001":45548482,"claude-opus-4.6":495316278,"claude-sonnet-4.6":536666397,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777658607344,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19631861,"unknown":5082388587,"dog-alpha":44776752,"scanner":468970230,"supervisor":240339184,"reviewer":354330362,"outreach":109871364,"architect":211831443},"tokenTotal":6532139783,"tokenInput":705879161,"tokenOutput":19939658,"tokenCacheRead":5806320964,"tokenCacheCreate":109575711,"tokenMessages":61765,"tokenModels":{"claude-opus-4-6":5102020448,"claude-haiku-4-5-20251001":44776752,"claude-opus-4.6":493871664,"claude-sonnet-4.6":540481256,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777658972123,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19631953,"unknown":5084556935,"dog-alpha":44776752,"scanner":469446430,"supervisor":240339184,"reviewer":359606567,"outreach":109871364,"architect":211831443},"tokenTotal":6540060628,"tokenInput":708793526,"tokenOutput":19967070,"tokenCacheRead":5811300032,"tokenCacheCreate":109678771,"tokenMessages":61828,"tokenModels":{"claude-opus-4-6":5104188888,"claude-haiku-4-5-20251001":44776752,"claude-opus-4.6":494347864,"claude-sonnet-4.6":545757461,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777659333180,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632176,"unknown":5088859029,"dog-alpha":45493288,"scanner":445319805,"supervisor":239137177,"reviewer":360954441,"outreach":109871364,"architect":211831443},"tokenTotal":6521098723,"tokenInput":696712165,"tokenOutput":19927872,"tokenCacheRead":5804458686,"tokenCacheCreate":109511065,"tokenMessages":61757,"tokenModels":{"claude-opus-4-6":5108491205,"claude-haiku-4-5-20251001":45493288,"claude-opus-4.6":469019232,"claude-sonnet-4.6":547105335,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777659696732,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19577469,"unknown":5090450920,"dog-alpha":45944524,"scanner":445319805,"supervisor":240893786,"reviewer":360954441,"outreach":109871364,"architect":211831443},"tokenTotal":6524843752,"tokenInput":697613037,"tokenOutput":19939328,"tokenCacheRead":5807291387,"tokenCacheCreate":109553603,"tokenMessages":61859,"tokenModels":{"claude-opus-4-6":5110028389,"claude-haiku-4-5-20251001":45944524,"claude-opus-4.6":469019232,"claude-sonnet-4.6":548861944,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777660056559,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632482,"unknown":5091987119,"dog-alpha":45091152,"scanner":445319805,"supervisor":240347674,"reviewer":360954441,"outreach":109871364,"architect":211831443},"tokenTotal":6525035480,"tokenInput":697323502,"tokenOutput":19940641,"tokenCacheRead":5807771337,"tokenCacheCreate":109520890,"tokenMessages":61861,"tokenModels":{"claude-opus-4-6":5111619601,"claude-haiku-4-5-20251001":45091152,"claude-opus-4.6":468473120,"claude-sonnet-4.6":548861944,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777660420187,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632396,"unknown":5096284641,"dog-alpha":45091152,"scanner":438886542,"supervisor":242737019,"reviewer":366298594,"outreach":109871364,"architect":211831443},"tokenTotal":6530633151,"tokenInput":697914468,"tokenOutput":19959717,"tokenCacheRead":5812758966,"tokenCacheCreate":109465463,"tokenMessages":61875,"tokenModels":{"claude-opus-4-6":5115917037,"claude-haiku-4-5-20251001":45091152,"claude-opus-4.6":462039857,"claude-sonnet-4.6":556595442,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777660772280,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632481,"unknown":5100251015,"dog-alpha":45091152,"scanner":439930749,"supervisor":241948257,"reviewer":366298594,"outreach":109871364,"architect":211831443},"tokenTotal":6534855055,"tokenInput":698052451,"tokenOutput":19966697,"tokenCacheRead":5816835907,"tokenCacheCreate":109501862,"tokenMessages":61925,"tokenModels":{"claude-opus-4-6":5119883496,"claude-haiku-4-5-20251001":45091152,"claude-opus-4.6":462295302,"claude-sonnet-4.6":556595442,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777661135000,"govIssues":2,"govPrs":2,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632710,"unknown":5104134939,"dog-alpha":45454658,"scanner":439930749,"supervisor":242771022,"reviewer":366298594,"outreach":109871364,"architect":211831443},"tokenTotal":6539925479,"tokenInput":698468015,"tokenOutput":19976595,"tokenCacheRead":5821480869,"tokenCacheCreate":109637513,"tokenMessages":61963,"tokenModels":{"claude-opus-4-6":5123767649,"claude-haiku-4-5-20251001":45454658,"claude-opus-4.6":461463445,"claude-sonnet-4.6":558250064,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777661497241,"govIssues":3,"govPrs":2,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19577899,"unknown":5105436190,"dog-alpha":45991494,"scanner":439930749,"supervisor":242771022,"reviewer":370112993,"outreach":109871364,"architect":211831443},"tokenTotal":6545523154,"tokenInput":700438764,"tokenOutput":20002319,"tokenCacheRead":5825082071,"tokenCacheCreate":109898640,"tokenMessages":62086,"tokenModels":{"claude-opus-4-6":5125014089,"claude-haiku-4-5-20251001":45991494,"claude-opus-4.6":461463445,"claude-sonnet-4.6":562064463,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777661858728,"govIssues":3,"govPrs":3,"govTotal":6,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632812,"unknown":5107842030,"dog-alpha":45991494,"scanner":438599510,"supervisor":242579210,"reviewer":370112993,"outreach":109871364,"architect":211831443},"tokenTotal":6546460856,"tokenInput":699640113,"tokenOutput":20011655,"tokenCacheRead":5826809088,"tokenCacheCreate":109926304,"tokenMessages":62105,"tokenModels":{"claude-opus-4-6":5127474842,"claude-haiku-4-5-20251001":45991494,"claude-opus-4.6":458503476,"claude-sonnet-4.6":563501381,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777662220097,"govIssues":3,"govPrs":3,"govTotal":6,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19577888,"unknown":5114614222,"dog-alpha":45013299,"scanner":438599510,"supervisor":242561910,"reviewer":370112993,"outreach":109871364,"architect":211831443},"tokenTotal":6552182629,"tokenInput":699636648,"tokenOutput":20026291,"tokenCacheRead":5832519690,"tokenCacheCreate":109857671,"tokenMessages":62174,"tokenModels":{"claude-opus-4-6":5134192110,"claude-haiku-4-5-20251001":45013299,"claude-opus-4.6":456615297,"claude-sonnet-4.6":565372260,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777662584927,"govIssues":3,"govPrs":4,"govTotal":7,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19522984,"unknown":5121870211,"dog-alpha":45013299,"scanner":443678796,"supervisor":242561910,"reviewer":370112993,"outreach":109871364,"architect":211831443},"tokenTotal":6564463000,"tokenInput":702217113,"tokenOutput":20061686,"tokenCacheRead":5842184201,"tokenCacheCreate":109977912,"tokenMessages":62275,"tokenModels":{"claude-opus-4-6":5141393195,"claude-haiku-4-5-20251001":45013299,"claude-opus-4.6":461694583,"claude-sonnet-4.6":565372260,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777662951761,"govIssues":2,"govPrs":3,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19577898,"unknown":5128427625,"dog-alpha":45357903,"scanner":438636971,"supervisor":244133440,"reviewer":378474083,"outreach":109871364,"architect":211831443},"tokenTotal":6576310727,"tokenInput":704601919,"tokenOutput":20086890,"tokenCacheRead":5851621918,"tokenCacheCreate":110022196,"tokenMessages":62387,"tokenModels":{"claude-opus-4-6":5148005523,"claude-haiku-4-5-20251001":45357903,"claude-opus-4.6":455885780,"claude-sonnet-4.6":576071858,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777663317101,"govIssues":3,"govPrs":5,"govTotal":8,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":5},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19545335,"unknown":5135437451,"dog-alpha":45839937,"scanner":444310156,"supervisor":243799615,"reviewer":389240510,"outreach":109871364,"architect":211831443},"tokenTotal":6599875811,"tokenInput":712714640,"tokenOutput":20153920,"tokenCacheRead":5867007251,"tokenCacheCreate":110198801,"tokenMessages":62503,"tokenModels":{"claude-opus-4-6":5154982786,"claude-haiku-4-5-20251001":45839937,"claude-opus-4.6":461225140,"claude-sonnet-4.6":586838285,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777663675099,"govIssues":3,"govPrs":6,"govTotal":9,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":6},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19545334,"unknown":5142188685,"dog-alpha":45839937,"scanner":438228916,"supervisor":243799615,"reviewer":389240510,"outreach":109871364,"architect":211831443},"tokenTotal":6600545804,"tokenInput":709571538,"tokenOutput":20154266,"tokenCacheRead":5870820000,"tokenCacheCreate":110069887,"tokenMessages":62563,"tokenModels":{"claude-opus-4-6":5161734019,"claude-haiku-4-5-20251001":45839937,"claude-opus-4.6":455143900,"claude-sonnet-4.6":586838285,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777664033969,"govIssues":3,"govPrs":6,"govTotal":9,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19490181,"unknown":5147061581,"dog-alpha":44684695,"scanner":438126048,"supervisor":241545556,"reviewer":389240510,"outreach":109871364,"architect":211831443},"tokenTotal":6601851378,"tokenInput":708365822,"tokenOutput":20156963,"tokenCacheRead":5873328593,"tokenCacheCreate":109949050,"tokenMessages":62641,"tokenModels":{"claude-opus-4-6":5166551762,"claude-haiku-4-5-20251001":44684695,"claude-opus-4.6":455041032,"claude-sonnet-4.6":584584226,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777664400802,"govIssues":4,"govPrs":6,"govTotal":10,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":9,"prs":6},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19490191,"unknown":5152321365,"dog-alpha":44684695,"scanner":439608060,"supervisor":241545556,"reviewer":389240510,"outreach":109871364,"architect":211831443},"tokenTotal":6608593184,"tokenInput":709136036,"tokenOutput":20181921,"tokenCacheRead":5879275227,"tokenCacheCreate":110049983,"tokenMessages":62733,"tokenModels":{"claude-opus-4-6":5171811556,"claude-haiku-4-5-20251001":44684695,"claude-opus-4.6":456523044,"claude-sonnet-4.6":584584226,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777664757891,"govIssues":4,"govPrs":5,"govTotal":9,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":9,"prs":6},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19435252,"unknown":5157812434,"dog-alpha":44684695,"scanner":441922232,"supervisor":242639342,"reviewer":389240510,"outreach":109871364,"architect":211831443},"tokenTotal":6617437272,"tokenInput":710869367,"tokenOutput":20217072,"tokenCacheRead":5886350833,"tokenCacheCreate":110320277,"tokenMessages":62831,"tokenModels":{"claude-opus-4-6":5177247686,"claude-haiku-4-5-20251001":44684695,"claude-opus-4.6":458837216,"claude-sonnet-4.6":585678012,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777665118267,"govIssues":2,"govPrs":4,"govTotal":6,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19380332,"unknown":5162950283,"dog-alpha":45488549,"scanner":441922232,"supervisor":241955145,"reviewer":399976185,"outreach":109871364,"architect":211831443},"tokenTotal":6633375533,"tokenInput":715909277,"tokenOutput":20276421,"tokenCacheRead":5897189835,"tokenCacheCreate":110529132,"tokenMessages":62957,"tokenModels":{"claude-opus-4-6":5182330615,"claude-haiku-4-5-20251001":45488549,"claude-opus-4.6":458837216,"claude-sonnet-4.6":595729490,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777665480763,"govIssues":2,"govPrs":4,"govTotal":6,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19357700,"unknown":5170205772,"dog-alpha":45719103,"scanner":441922232,"supervisor":243608364,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6644316609,"tokenInput":717694423,"tokenOutput":20319998,"tokenCacheRead":5906302188,"tokenCacheCreate":110692852,"tokenMessages":63099,"tokenModels":{"claude-opus-4-6":5189563472,"claude-haiku-4-5-20251001":45719103,"claude-opus-4.6":458837216,"claude-sonnet-4.6":599207155,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777665846151,"govIssues":1,"govPrs":4,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":4},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19390603,"unknown":5175774143,"dog-alpha":44478707,"scanner":430856642,"supervisor":242346413,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6636349946,"tokenInput":711458432,"tokenOutput":20282531,"tokenCacheRead":5904608983,"tokenCacheCreate":110691607,"tokenMessages":63142,"tokenModels":{"claude-opus-4-6":5195164746,"claude-haiku-4-5-20251001":44478707,"claude-opus-4.6":447771626,"claude-sonnet-4.6":597945204,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777666215994,"govIssues":4,"govPrs":7,"govTotal":11,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":9,"prs":8},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19357706,"unknown":5179057724,"dog-alpha":44478707,"scanner":430856642,"supervisor":245139886,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6642394103,"tokenInput":712879469,"tokenOutput":20297373,"tokenCacheRead":5909217261,"tokenCacheCreate":110727410,"tokenMessages":63241,"tokenModels":{"claude-opus-4-6":5198415430,"claude-haiku-4-5-20251001":44478707,"claude-opus-4.6":447771626,"claude-sonnet-4.6":600738677,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777666579891,"govIssues":5,"govPrs":6,"govTotal":11,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":10,"prs":6},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19357713,"unknown":5183400372,"dog-alpha":44524993,"scanner":435429825,"supervisor":242369008,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6648585349,"tokenInput":713817996,"tokenOutput":20326556,"tokenCacheRead":5914440797,"tokenCacheCreate":110955923,"tokenMessages":63298,"tokenModels":{"claude-opus-4-6":5202758085,"claude-haiku-4-5-20251001":44524993,"claude-opus-4.6":452344809,"claude-sonnet-4.6":597967799,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777666936408,"govIssues":5,"govPrs":4,"govTotal":9,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":10,"prs":7},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19357715,"unknown":5187110961,"dog-alpha":45448002,"scanner":413504259,"supervisor":244369045,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6633293420,"tokenInput":703755217,"tokenOutput":20260324,"tokenCacheRead":5909277879,"tokenCacheCreate":110740654,"tokenMessages":63307,"tokenModels":{"claude-opus-4-6":5206468676,"claude-haiku-4-5-20251001":45448002,"claude-opus-4.6":430419243,"claude-sonnet-4.6":599967836,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777667296490,"govIssues":4,"govPrs":7,"govTotal":11,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":9,"prs":7},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19412629,"unknown":5190056677,"dog-alpha":45448002,"scanner":425315605,"supervisor":246884372,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6650620723,"tokenInput":711029483,"tokenOutput":20333968,"tokenCacheRead":5919257272,"tokenCacheCreate":111121870,"tokenMessages":63390,"tokenModels":{"claude-opus-4-6":5209469306,"claude-haiku-4-5-20251001":45448002,"claude-opus-4.6":442230589,"claude-sonnet-4.6":602483163,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777667662979,"govIssues":4,"govPrs":7,"govTotal":11,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19412623,"unknown":5191390312,"dog-alpha":45448002,"scanner":425881026,"supervisor":246170875,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6651806276,"tokenInput":710951488,"tokenOutput":20333918,"tokenCacheRead":5920520870,"tokenCacheCreate":111116128,"tokenMessages":63436,"tokenModels":{"claude-opus-4-6":5210802935,"claude-haiku-4-5-20251001":45448002,"claude-opus-4.6":442796010,"claude-sonnet-4.6":601769666,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777668025144,"govIssues":3,"govPrs":3,"govTotal":6,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":3},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19467547,"unknown":5195743255,"dog-alpha":44189372,"scanner":425881026,"supervisor":248480122,"reviewer":401800631,"outreach":109871364,"architect":211831443},"tokenTotal":6657264760,"tokenInput":712125621,"tokenOutput":20348648,"tokenCacheRead":5924790491,"tokenCacheCreate":111193199,"tokenMessages":63518,"tokenModels":{"claude-opus-4-6":5215210802,"claude-haiku-4-5-20251001":44189372,"claude-opus-4.6":442796010,"claude-sonnet-4.6":604078913,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777668395763,"govIssues":2,"govPrs":0,"govTotal":2,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19412642,"unknown":5201589703,"dog-alpha":44297186,"scanner":400209368,"supervisor":245800840,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6670007365,"tokenInput":715527446,"tokenOutput":20368178,"tokenCacheRead":5934111741,"tokenCacheCreate":111322625,"tokenMessages":63410,"tokenModels":{"claude-opus-4-6":5221002345,"claude-haiku-4-5-20251001":44297186,"claude-opus-4.6":417124352,"claude-sonnet-4.6":636593819,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777668758269,"govIssues":3,"govPrs":1,"govTotal":4,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19412633,"unknown":5205563888,"dog-alpha":45094504,"scanner":400209368,"supervisor":247160457,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6676138476,"tokenInput":716209517,"tokenOutput":20392195,"tokenCacheRead":5939536764,"tokenCacheCreate":111364672,"tokenMessages":63537,"tokenModels":{"claude-opus-4-6":5224976521,"claude-haiku-4-5-20251001":45094504,"claude-opus-4.6":417124352,"claude-sonnet-4.6":637953436,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777669130619,"govIssues":3,"govPrs":1,"govTotal":4,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19357727,"unknown":5209482860,"dog-alpha":44110188,"scanner":407057379,"supervisor":247160457,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6685866237,"tokenInput":719690870,"tokenOutput":20413728,"tokenCacheRead":5945761639,"tokenCacheCreate":111512831,"tokenMessages":63676,"tokenModels":{"claude-opus-4-6":5228840587,"claude-haiku-4-5-20251001":44110188,"claude-opus-4.6":423972363,"claude-sonnet-4.6":637953436,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777669493309,"govIssues":3,"govPrs":3,"govTotal":6,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19467559,"unknown":5214216754,"dog-alpha":44110188,"scanner":386986298,"supervisor":246621516,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6670099941,"tokenInput":709313558,"tokenOutput":20369821,"tokenCacheRead":5940416562,"tokenCacheCreate":111400915,"tokenMessages":63714,"tokenModels":{"claude-opus-4-6":5233684313,"claude-haiku-4-5-20251001":44110188,"claude-opus-4.6":403901282,"claude-sonnet-4.6":637414495,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777669865641,"govIssues":3,"govPrs":3,"govTotal":6,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":6},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19522473,"unknown":5219521506,"dog-alpha":44110188,"scanner":386986298,"supervisor":246621516,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6675459607,"tokenInput":709313643,"tokenOutput":20380836,"tokenCacheRead":5945765128,"tokenCacheCreate":111489218,"tokenMessages":63850,"tokenModels":{"claude-opus-4-6":5239043979,"claude-haiku-4-5-20251001":44110188,"claude-opus-4.6":403901282,"claude-sonnet-4.6":637414495,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777670222766,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19577386,"unknown":5226037607,"dog-alpha":44912472,"scanner":386986298,"supervisor":246236119,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6682447508,"tokenInput":709122160,"tokenOutput":20396151,"tokenCacheRead":5952929197,"tokenCacheCreate":111613667,"tokenMessages":63974,"tokenModels":{"claude-opus-4-6":5245614993,"claude-haiku-4-5-20251001":44912472,"claude-opus-4.6":403901282,"claude-sonnet-4.6":637029098,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777670601695,"govIssues":1,"govPrs":3,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":4},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19686980,"unknown":5231423016,"dog-alpha":44912472,"scanner":398375103,"supervisor":247920042,"reviewer":436994819,"outreach":109871364,"architect":211831443},"tokenTotal":6701015239,"tokenInput":715715472,"tokenOutput":20453688,"tokenCacheRead":5964846079,"tokenCacheCreate":111860322,"tokenMessages":64043,"tokenModels":{"claude-opus-4-6":5251109996,"claude-haiku-4-5-20251001":44912472,"claude-opus-4.6":415290087,"claude-sonnet-4.6":638713021,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777670967864,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19686976,"unknown":5234045693,"dog-alpha":44912472,"scanner":396559421,"supervisor":246520407,"reviewer":471403110,"outreach":109871364,"architect":211831443},"tokenTotal":6734830886,"tokenInput":731378449,"tokenOutput":20531670,"tokenCacheRead":5982920767,"tokenCacheCreate":112066923,"tokenMessages":64099,"tokenModels":{"claude-opus-4-6":5253732669,"claude-haiku-4-5-20251001":44912472,"claude-opus-4.6":413474405,"claude-sonnet-4.6":671721677,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777671335923,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19686963,"unknown":5239779055,"dog-alpha":44912472,"scanner":396559421,"supervisor":245886229,"reviewer":471403110,"outreach":109871364,"architect":211831443},"tokenTotal":6739930057,"tokenInput":731061402,"tokenOutput":20539094,"tokenCacheRead":5988329561,"tokenCacheCreate":112100889,"tokenMessages":64184,"tokenModels":{"claude-opus-4-6":5259466018,"claude-haiku-4-5-20251001":44912472,"claude-opus-4.6":413474405,"claude-sonnet-4.6":671087499,"auto":72942705,"claude-haiku-4.5":278046958}},{"t":1777671701160,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19686974,"unknown":5244478718,"dog-alpha":44912472,"scanner":410455232,"supervisor":247418461,"reviewer":476463779,"outreach":109871364,"architect":211831443},"tokenTotal":6765118443,"tokenInput":741459926,"tokenOutput":20619517,"tokenCacheRead":6003039000,"tokenCacheCreate":112583868,"tokenMessages":64290,"tokenModels":{"claude-opus-4-6":5264165692,"claude-haiku-4-5-20251001":44912472,"claude-opus-4.6":427370216,"claude-sonnet-4.6":672619731,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777672066157,"govIssues":1,"govPrs":3,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632066,"unknown":5247087642,"dog-alpha":45766851,"scanner":406135494,"supervisor":247418461,"reviewer":480382527,"outreach":109871364,"architect":211831443},"tokenTotal":6768125848,"tokenInput":741243975,"tokenOutput":20639511,"tokenCacheRead":6006242362,"tokenCacheCreate":112599187,"tokenMessages":64378,"tokenModels":{"claude-opus-4-6":5266719708,"claude-haiku-4-5-20251001":45766851,"claude-opus-4.6":423050478,"claude-sonnet-4.6":676538479,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777672425330,"govIssues":1,"govPrs":5,"govTotal":6,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":5},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19632081,"unknown":5249581389,"dog-alpha":44815161,"scanner":406135494,"supervisor":247841822,"reviewer":480382527,"outreach":109871364,"architect":211831443},"tokenTotal":6770091281,"tokenInput":741454248,"tokenOutput":20639532,"tokenCacheRead":6007997501,"tokenCacheCreate":112540451,"tokenMessages":64394,"tokenModels":{"claude-opus-4-6":5269213470,"claude-haiku-4-5-20251001":44815161,"claude-opus-4.6":423050478,"claude-sonnet-4.6":676961840,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777672789738,"govIssues":1,"govPrs":5,"govTotal":6,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":5},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19687000,"unknown":5253121831,"dog-alpha":44815161,"scanner":411677666,"supervisor":247841822,"reviewer":480382527,"outreach":109871364,"architect":211831443},"tokenTotal":6779228814,"tokenInput":744287413,"tokenOutput":20667752,"tokenCacheRead":6014273649,"tokenCacheCreate":112735823,"tokenMessages":64505,"tokenModels":{"claude-opus-4-6":5272808831,"claude-haiku-4-5-20251001":44815161,"claude-opus-4.6":428592650,"claude-sonnet-4.6":676961840,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777673151024,"govIssues":1,"govPrs":3,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19609539,"unknown":5256058853,"dog-alpha":44815161,"scanner":388581694,"supervisor":248026079,"reviewer":492054412,"outreach":109871364,"architect":211831443},"tokenTotal":6770848545,"tokenInput":738652703,"tokenOutput":20670774,"tokenCacheRead":6011525068,"tokenCacheCreate":112608407,"tokenMessages":64393,"tokenModels":{"claude-opus-4-6":5275668392,"claude-haiku-4-5-20251001":44815161,"claude-opus-4.6":405496678,"claude-sonnet-4.6":688817982,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777673514250,"govIssues":2,"govPrs":2,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19664436,"unknown":5259700954,"dog-alpha":44815161,"scanner":388581694,"supervisor":247178651,"reviewer":492054412,"outreach":109871364,"architect":211831443},"tokenTotal":6773698115,"tokenInput":738210136,"tokenOutput":20677167,"tokenCacheRead":6014810812,"tokenCacheCreate":112624314,"tokenMessages":64463,"tokenModels":{"claude-opus-4-6":5279365390,"claude-haiku-4-5-20251001":44815161,"claude-opus-4.6":405496678,"claude-sonnet-4.6":687970554,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777673868980,"govIssues":2,"govPrs":2,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19642424,"unknown":5263204342,"dog-alpha":45978814,"scanner":381185183,"supervisor":248496424,"reviewer":492054412,"outreach":109871364,"architect":211831443},"tokenTotal":6772264406,"tokenInput":735131825,"tokenOutput":20671566,"tokenCacheRead":6016461015,"tokenCacheCreate":112611257,"tokenMessages":64491,"tokenModels":{"claude-opus-4-6":5282846766,"claude-haiku-4-5-20251001":45978814,"claude-opus-4.6":398100167,"claude-sonnet-4.6":689288327,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777674240308,"govIssues":2,"govPrs":2,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19609510,"unknown":5266415090,"dog-alpha":45126228,"scanner":381077407,"supervisor":246789824,"reviewer":501555290,"outreach":109871364,"architect":211831443},"tokenTotal":6782276156,"tokenInput":738985579,"tokenOutput":20692050,"tokenCacheRead":6022598527,"tokenCacheCreate":112570200,"tokenMessages":64512,"tokenModels":{"claude-opus-4-6":5286024600,"claude-haiku-4-5-20251001":45126228,"claude-opus-4.6":397992391,"claude-sonnet-4.6":697082605,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777674602510,"govIssues":2,"govPrs":3,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19698022,"unknown":5268318375,"dog-alpha":45126228,"scanner":383648879,"supervisor":246789824,"reviewer":501555290,"outreach":109871364,"architect":211831443},"tokenTotal":6786839425,"tokenInput":740289602,"tokenOutput":20703788,"tokenCacheRead":6025846035,"tokenCacheCreate":112619553,"tokenMessages":64634,"tokenModels":{"claude-opus-4-6":5288016397,"claude-haiku-4-5-20251001":45126228,"claude-opus-4.6":400563863,"claude-sonnet-4.6":697082605,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777674962534,"govIssues":3,"govPrs":3,"govTotal":6,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643110,"unknown":5269405438,"dog-alpha":45126228,"scanner":383550165,"supervisor":247765638,"reviewer":501555290,"outreach":109871364,"architect":211831443},"tokenTotal":6788748676,"tokenInput":740710246,"tokenOutput":20705359,"tokenCacheRead":6027333071,"tokenCacheCreate":112554279,"tokenMessages":64638,"tokenModels":{"claude-opus-4-6":5289048548,"claude-haiku-4-5-20251001":45126228,"claude-opus-4.6":400465149,"claude-sonnet-4.6":698058419,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777675322552,"govIssues":2,"govPrs":3,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643108,"unknown":5270505446,"dog-alpha":45126228,"scanner":381021138,"supervisor":247765638,"reviewer":501555290,"outreach":109871364,"architect":211831443},"tokenTotal":6787319655,"tokenInput":739415167,"tokenOutput":20699756,"tokenCacheRead":6027204732,"tokenCacheCreate":112489282,"tokenMessages":64679,"tokenModels":{"claude-opus-4-6":5290148554,"claude-haiku-4-5-20251001":45126228,"claude-opus-4.6":397936122,"claude-sonnet-4.6":698058419,"auto":72942705,"claude-haiku-4.5":283107627}},{"t":1777675687972,"govIssues":2,"govPrs":3,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643107,"unknown":5271618084,"dog-alpha":46127040,"scanner":381021138,"supervisor":250417685,"reviewer":508876800,"outreach":109871364,"architect":211831443},"tokenTotal":6799406661,"tokenInput":744470301,"tokenOutput":20740214,"tokenCacheRead":6034196146,"tokenCacheCreate":112720898,"tokenMessages":64745,"tokenModels":{"claude-opus-4-6":5291261191,"claude-haiku-4-5-20251001":46127040,"claude-opus-4.6":397936122,"claude-sonnet-4.6":700710466,"auto":72942705,"claude-haiku-4.5":290429137}},{"t":1777676039910,"govIssues":2,"govPrs":3,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19698004,"unknown":5272884771,"dog-alpha":45182463,"scanner":387540926,"supervisor":248271800,"reviewer":508876800,"outreach":109871364,"architect":211831443},"tokenTotal":6804157571,"tokenInput":746726856,"tokenOutput":20746750,"tokenCacheRead":6036683965,"tokenCacheCreate":112855027,"tokenMessages":64757,"tokenModels":{"claude-opus-4-6":5292582775,"claude-haiku-4-5-20251001":45182463,"claude-opus-4.6":404455910,"claude-sonnet-4.6":698564581,"auto":72942705,"claude-haiku-4.5":290429137}},{"t":1777676411109,"govIssues":3,"govPrs":0,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643088,"unknown":5274166096,"dog-alpha":45182463,"scanner":387540926,"supervisor":250074378,"reviewer":508876800,"outreach":109871364,"architect":211831443},"tokenTotal":6807186558,"tokenInput":747651929,"tokenOutput":20754787,"tokenCacheRead":6038779842,"tokenCacheCreate":112877943,"tokenMessages":64809,"tokenModels":{"claude-opus-4-6":5293809184,"claude-haiku-4-5-20251001":45182463,"claude-opus-4.6":404455910,"claude-sonnet-4.6":700367159,"auto":72942705,"claude-haiku-4.5":290429137}},{"t":1777676765109,"govIssues":3,"govPrs":0,"govTotal":3,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643098,"unknown":5275594540,"dog-alpha":45182463,"scanner":377389036,"supervisor":248880510,"reviewer":508876800,"outreach":109871364,"architect":211831443},"tokenTotal":6797269254,"tokenInput":741898814,"tokenOutput":20715312,"tokenCacheRead":6034655128,"tokenCacheCreate":112852610,"tokenMessages":64860,"tokenModels":{"claude-opus-4-6":5295237638,"claude-haiku-4-5-20251001":45182463,"claude-opus-4.6":394304020,"claude-sonnet-4.6":699173291,"auto":72942705,"claude-haiku-4.5":290429137}},{"t":1777677123530,"govIssues":3,"govPrs":2,"govTotal":5,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643106,"unknown":5276469728,"dog-alpha":45182463,"scanner":386015749,"supervisor":248946869,"reviewer":508876800,"outreach":109871364,"architect":211831443},"tokenTotal":6806837522,"tokenInput":746363342,"tokenOutput":20754536,"tokenCacheRead":6039719644,"tokenCacheCreate":113124332,"tokenMessages":64932,"tokenModels":{"claude-opus-4-6":5296112834,"claude-haiku-4-5-20251001":45182463,"claude-opus-4.6":402930733,"claude-sonnet-4.6":699239650,"auto":72942705,"claude-haiku-4.5":290429137}},{"t":1777677486386,"govIssues":3,"govPrs":1,"govTotal":4,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19643087,"unknown":5277255626,"dog-alpha":45810949,"scanner":386015749,"supervisor":248946869,"reviewer":487000256,"outreach":109871364,"architect":211831443},"tokenTotal":6786375343,"tokenInput":734836402,"tokenOutput":20673013,"tokenCacheRead":6030865928,"tokenCacheCreate":111926043,"tokenMessages":64904,"tokenModels":{"claude-opus-4-6":5296898713,"claude-haiku-4-5-20251001":45810949,"claude-opus-4.6":402930733,"claude-sonnet-4.6":699239650,"auto":72942705,"claude-haiku-4.5":268552593,"claude-sonnet-4.5":0}},{"t":1777677847903,"govIssues":3,"govPrs":2,"govTotal":5,"govActive":1,"govMode":"quiet","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":8,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19697988,"unknown":5278070026,"dog-alpha":44803864,"scanner":386015749,"supervisor":244567470,"reviewer":487000256,"outreach":95282599,"architect":196469959},"tokenTotal":6751907911,"tokenInput":717189325,"tokenOutput":20544076,"tokenCacheRead":6014174510,"tokenCacheCreate":110874022,"tokenMessages":64635,"tokenModels":{"claude-opus-4-6":5297768014,"claude-haiku-4-5-20251001":44803864,"claude-opus-4.6":402930733,"claude-sonnet-4.6":680271486,"auto":72942705,"claude-haiku-4.5":253191109}},{"t":1777678216290,"govIssues":2,"govPrs":2,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":5},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19697992,"unknown":5278912856,"dog-alpha":44803864,"scanner":365623290,"supervisor":244567470,"reviewer":482552729,"outreach":95282599,"architect":196469959},"tokenTotal":6727910759,"tokenInput":704449252,"tokenOutput":20452593,"tokenCacheRead":6003008914,"tokenCacheCreate":110164885,"tokenMessages":64498,"tokenModels":{"claude-opus-4-6":5298610848,"claude-haiku-4-5-20251001":44803864,"claude-opus-4.6":382538274,"claude-sonnet-4.6":675823959,"auto":72942705,"claude-haiku-4.5":253191109}},{"t":1777678581999,"govIssues":2,"govPrs":3,"govTotal":5,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":7,"prs":3},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19697986,"unknown":5279784593,"dog-alpha":44803864,"scanner":365623290,"supervisor":244159243,"reviewer":509733086,"outreach":95282599,"architect":196469959},"tokenTotal":6755554620,"tokenInput":717947131,"tokenOutput":20531932,"tokenCacheRead":6017075557,"tokenCacheCreate":110468418,"tokenMessages":64565,"tokenModels":{"claude-opus-4-6":5299482579,"claude-haiku-4-5-20251001":44803864,"claude-opus-4.6":382538274,"claude-sonnet-4.6":675415732,"auto":72942705,"claude-haiku-4.5":280371466,"claude-sonnet-4.5":0}},{"t":1777678938010,"govIssues":2,"govPrs":2,"govTotal":4,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19752891,"unknown":5280687174,"dog-alpha":44803864,"scanner":364881040,"supervisor":244159243,"reviewer":509733086,"outreach":95282599,"architect":196469959},"tokenTotal":6755769856,"tokenInput":717788017,"tokenOutput":20580271,"tokenCacheRead":6017401568,"tokenCacheCreate":110960375,"tokenMessages":64334,"tokenModels":{"claude-opus-4-6":5300440065,"claude-haiku-4-5-20251001":44803864,"claude-opus-4.6":381796024,"claude-sonnet-4.6":675415732,"auto":72942705,"claude-haiku-4.5":280371466}},{"t":1777679297275,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":2},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19752888,"unknown":5281776563,"dog-alpha":45796537,"scanner":364881040,"supervisor":243141138,"reviewer":504544889,"outreach":95282599,"architect":196469959},"tokenTotal":6751645613,"tokenInput":714664547,"tokenOutput":20564843,"tokenCacheRead":6016416223,"tokenCacheCreate":110972781,"tokenMessages":64364,"tokenModels":{"claude-opus-4-6":5301529451,"claude-haiku-4-5-20251001":45796537,"claude-opus-4.6":381796024,"claude-sonnet-4.6":669209430,"auto":72942705,"claude-haiku-4.5":280371466}},{"t":1777679656663,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19752906,"unknown":5282822653,"dog-alpha":44978905,"scanner":359452240,"supervisor":243141138,"reviewer":504544889,"outreach":95282599,"architect":196469959},"tokenTotal":6746445289,"tokenInput":711845410,"tokenOutput":20544970,"tokenCacheRead":6014054909,"tokenCacheCreate":110695547,"tokenMessages":64336,"tokenModels":{"claude-opus-4-6":5302575559,"claude-haiku-4-5-20251001":44978905,"claude-opus-4.6":376367224,"claude-sonnet-4.6":669209430,"auto":72942705,"claude-haiku-4.5":280371466}},{"t":1777680022980,"govIssues":1,"govPrs":0,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19807829,"unknown":5284152886,"dog-alpha":44978905,"scanner":359452240,"supervisor":242960617,"reviewer":504544889,"outreach":95282599,"architect":191593656},"tokenTotal":6742773621,"tokenInput":709214605,"tokenOutput":20511017,"tokenCacheRead":6013047999,"tokenCacheCreate":110525845,"tokenMessages":64296,"tokenModels":{"claude-opus-4-6":5303960715,"claude-haiku-4-5-20251001":44978905,"claude-opus-4.6":371490921,"claude-sonnet-4.6":669028909,"auto":72942705,"claude-haiku-4.5":280371466}},{"t":1777680384850,"govIssues":1,"govPrs":0,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19862756,"unknown":5285176689,"dog-alpha":44978905,"scanner":359452240,"supervisor":242960617,"reviewer":504544889,"outreach":95282599,"architect":191593656},"tokenTotal":6743852351,"tokenInput":709214639,"tokenOutput":20514978,"tokenCacheRead":6014122734,"tokenCacheCreate":110563199,"tokenMessages":64352,"tokenModels":{"claude-opus-4-6":5305039445,"claude-haiku-4-5-20251001":44978905,"claude-opus-4.6":371490921,"claude-sonnet-4.6":669028909,"auto":72942705,"claude-haiku-4.5":280371466}},{"t":1777680745564,"govIssues":1,"govPrs":0,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19917662,"unknown":5286222716,"dog-alpha":44978905,"scanner":359452240,"supervisor":244929203,"reviewer":504544889,"outreach":95282599,"architect":191593656},"tokenTotal":6746921870,"tokenInput":710239547,"tokenOutput":20526432,"tokenCacheRead":6016155891,"tokenCacheCreate":110688576,"tokenMessages":64405,"tokenModels":{"claude-opus-4-6":5306140378,"claude-haiku-4-5-20251001":44978905,"claude-opus-4.6":371490921,"claude-sonnet-4.6":670997495,"auto":72942705,"claude-haiku-4.5":280371466}},{"t":1777681110351,"govIssues":1,"govPrs":0,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19862756,"unknown":5287289448,"dog-alpha":45607073,"scanner":359452240,"supervisor":247616908,"reviewer":509084803,"outreach":95282599,"architect":191593656},"tokenTotal":6755789483,"tokenInput":714005311,"tokenOutput":20564175,"tokenCacheRead":6021219997,"tokenCacheCreate":111025341,"tokenMessages":64533,"tokenModels":{"claude-opus-4-6":5307152204,"claude-haiku-4-5-20251001":45607073,"claude-opus-4.6":371490921,"claude-sonnet-4.6":673685200,"auto":72942705,"claude-haiku-4.5":284911380}},{"t":1777681468102,"govIssues":1,"govPrs":1,"govTotal":2,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19917669,"unknown":5288376233,"dog-alpha":45607073,"scanner":380296497,"supervisor":247616908,"reviewer":509084803,"outreach":95282599,"architect":191593656},"tokenTotal":6777775438,"tokenInput":724743946,"tokenOutput":20658558,"tokenCacheRead":6032372934,"tokenCacheCreate":111760069,"tokenMessages":64641,"tokenModels":{"claude-opus-4-6":5308293902,"claude-haiku-4-5-20251001":45607073,"claude-opus-4.6":392335178,"claude-sonnet-4.6":673685200,"auto":72942705,"claude-haiku-4.5":284911380}},{"t":1777681829524,"govIssues":1,"govPrs":2,"govTotal":3,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":1,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972571,"unknown":5289767344,"dog-alpha":44347470,"scanner":380296497,"supervisor":248944707,"reviewer":509084803,"outreach":95282599,"architect":191593656},"tokenTotal":6779289647,"tokenInput":725423506,"tokenOutput":20662422,"tokenCacheRead":6033203719,"tokenCacheCreate":111768577,"tokenMessages":64679,"tokenModels":{"claude-opus-4-6":5309739915,"claude-haiku-4-5-20251001":44347470,"claude-opus-4.6":392335178,"claude-sonnet-4.6":675012999,"auto":72942705,"claude-haiku-4.5":284911380}},{"t":1777682196111,"govIssues":0,"govPrs":2,"govTotal":2,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19917649,"unknown":5291001628,"dog-alpha":44347470,"scanner":380296497,"supervisor":249223718,"reviewer":519202695,"outreach":95282599,"architect":191593656},"tokenTotal":6790865912,"tokenInput":730673630,"tokenOutput":20693892,"tokenCacheRead":6039498390,"tokenCacheCreate":111866618,"tokenMessages":64736,"tokenModels":{"claude-opus-4-6":5310919277,"claude-haiku-4-5-20251001":44347470,"claude-opus-4.6":392335178,"claude-sonnet-4.6":685130891,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777682553340,"govIssues":0,"govPrs":2,"govTotal":2,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972571,"unknown":5292165904,"dog-alpha":44347470,"scanner":392859447,"supervisor":249223718,"reviewer":519202695,"outreach":95282599,"architect":191593656},"tokenTotal":6804648060,"tokenInput":737106399,"tokenOutput":20724043,"tokenCacheRead":6046817618,"tokenCacheCreate":112229338,"tokenMessages":64797,"tokenModels":{"claude-opus-4-6":5312138475,"claude-haiku-4-5-20251001":44347470,"claude-opus-4.6":404898128,"claude-sonnet-4.6":685130891,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777682913474,"govIssues":0,"govPrs":2,"govTotal":2,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":1}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19917670,"unknown":5293548490,"dog-alpha":45251634,"scanner":392859447,"supervisor":250096613,"reviewer":519202695,"outreach":95282599,"architect":191593656},"tokenTotal":6807752804,"tokenInput":737562328,"tokenOutput":20734784,"tokenCacheRead":6049455692,"tokenCacheCreate":112288378,"tokenMessages":64834,"tokenModels":{"claude-opus-4-6":5313466160,"claude-haiku-4-5-20251001":45251634,"claude-opus-4.6":404898128,"claude-sonnet-4.6":686003786,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777683283736,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972590,"unknown":5294957760,"dog-alpha":44400650,"scanner":392859447,"supervisor":250096613,"reviewer":524989874,"outreach":95282599,"architect":191593656},"tokenTotal":6814153189,"tokenInput":740485059,"tokenOutput":20756390,"tokenCacheRead":6052911740,"tokenCacheCreate":112338564,"tokenMessages":64859,"tokenModels":{"claude-opus-4-6":5314930350,"claude-haiku-4-5-20251001":44400650,"claude-opus-4.6":404898128,"claude-sonnet-4.6":691790965,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777683634847,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972603,"unknown":5296186782,"dog-alpha":44400650,"scanner":393975276,"supervisor":252440437,"reviewer":524989874,"outreach":95282599,"architect":191593656},"tokenTotal":6818841877,"tokenInput":742264980,"tokenOutput":20771512,"tokenCacheRead":6055805385,"tokenCacheCreate":112451215,"tokenMessages":64954,"tokenModels":{"claude-opus-4-6":5316159385,"claude-haiku-4-5-20251001":44400650,"claude-opus-4.6":406013957,"claude-sonnet-4.6":694134789,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777683995807,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":20027526,"unknown":5297434881,"dog-alpha":44400650,"scanner":393975276,"supervisor":252440437,"reviewer":524989874,"outreach":95282599,"architect":191593656},"tokenTotal":6820144899,"tokenInput":742265014,"tokenOutput":20775291,"tokenCacheRead":6057104594,"tokenCacheCreate":112488059,"tokenMessages":65014,"tokenModels":{"claude-opus-4-6":5317462407,"claude-haiku-4-5-20251001":44400650,"claude-opus-4.6":406013957,"claude-sonnet-4.6":694134789,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777684359301,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972616,"unknown":5298701267,"dog-alpha":44400650,"scanner":393975276,"supervisor":253756878,"reviewer":535553788,"outreach":95282599,"architect":191593656},"tokenTotal":6833236730,"tokenInput":748257748,"tokenOutput":20819243,"tokenCacheRead":6064159739,"tokenCacheCreate":112599324,"tokenMessages":65046,"tokenModels":{"claude-opus-4-6":5318673883,"claude-haiku-4-5-20251001":44400650,"claude-opus-4.6":406013957,"claude-sonnet-4.6":706015144,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777684713598,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972581,"unknown":5299985517,"dog-alpha":45573564,"scanner":395484122,"supervisor":255201143,"reviewer":536095263,"outreach":95282599,"architect":191593656},"tokenTotal":6839188445,"tokenInput":750081642,"tokenOutput":20839014,"tokenCacheRead":6068267789,"tokenCacheCreate":112826359,"tokenMessages":65129,"tokenModels":{"claude-opus-4-6":5319958098,"claude-haiku-4-5-20251001":45573564,"claude-opus-4.6":407522803,"claude-sonnet-4.6":708000884,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777685073368,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":20005476,"unknown":5301287575,"dog-alpha":44862304,"scanner":395484122,"supervisor":255201143,"reviewer":536095263,"outreach":95282599,"architect":191593656},"tokenTotal":6839812138,"tokenInput":750081609,"tokenOutput":20840111,"tokenCacheRead":6068890418,"tokenCacheCreate":112819478,"tokenMessages":65130,"tokenModels":{"claude-opus-4-6":5321293051,"claude-haiku-4-5-20251001":44862304,"claude-opus-4.6":407522803,"claude-sonnet-4.6":708000884,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777685434064,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":19972605,"unknown":5302713015,"dog-alpha":44862304,"scanner":395484122,"supervisor":255942126,"reviewer":536095263,"outreach":95282599,"architect":191593656},"tokenTotal":6841945690,"tokenInput":750467037,"tokenOutput":20845619,"tokenCacheRead":6070633034,"tokenCacheCreate":112905498,"tokenMessages":65162,"tokenModels":{"claude-opus-4-6":5322685620,"claude-haiku-4-5-20251001":44862304,"claude-opus-4.6":407522803,"claude-sonnet-4.6":708741867,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777685803777,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":20027511,"unknown":5304337592,"dog-alpha":44862304,"scanner":395484122,"supervisor":257409802,"reviewer":538670733,"outreach":95282599,"architect":191593656},"tokenTotal":6847668319,"tokenInput":752527375,"tokenOutput":20866071,"tokenCacheRead":6074274873,"tokenCacheCreate":113033588,"tokenMessages":65233,"tokenModels":{"claude-opus-4-6":5324365103,"claude-haiku-4-5-20251001":44862304,"claude-opus-4.6":407522803,"claude-sonnet-4.6":712785013,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777686168533,"govIssues":1,"govPrs":0,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":6,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":1,"restarts":0}},"ga4Errors":0,"adopters":0,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"tokens":{"boot":20027502,"unknown":5310269809,"dog-alpha":44862304,"scanner":395695407,"supervisor":257409802,"reviewer":538670733,"outreach":95282599,"architect":191593656},"tokenTotal":6853811812,"tokenInput":752648104,"tokenOutput":20877969,"tokenCacheRead":6080285739,"tokenCacheCreate":113100956,"tokenMessages":65326,"tokenModels":{"claude-opus-4-6":5330297311,"claude-haiku-4-5-20251001":44862304,"claude-opus-4.6":407734088,"claude-sonnet-4.6":712785013,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777686555074,"govIssues":1,"govPrs":0,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":20027242,"unknown":5318599343,"dog-alpha":45718284,"scanner":395695407,"supervisor":261990517,"reviewer":538670733,"outreach":95282599,"architect":191593656},"tokenTotal":6867577781,"tokenInput":754963946,"tokenOutput":20918738,"tokenCacheRead":6091695097,"tokenCacheCreate":113256505,"tokenMessages":65477,"tokenModels":{"claude-opus-4-6":5338626585,"claude-haiku-4-5-20251001":45718284,"claude-opus-4.6":407734088,"claude-sonnet-4.6":717365728,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777686922374,"govIssues":0,"govPrs":1,"govTotal":1,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":20027241,"unknown":5324271164,"dog-alpha":44819306,"scanner":395695407,"supervisor":261990517,"reviewer":544412946,"outreach":95282599,"architect":191593656},"tokenTotal":6878092836,"tokenInput":757894643,"tokenOutput":20942709,"tokenCacheRead":6099255484,"tokenCacheCreate":113362130,"tokenMessages":65523,"tokenModels":{"claude-opus-4-6":5344298405,"claude-haiku-4-5-20251001":44819306,"claude-opus-4.6":407734088,"claude-sonnet-4.6":723107941,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777687279553,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":1,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":19972343,"unknown":5329115892,"dog-alpha":44819306,"scanner":395906715,"supervisor":263423356,"reviewer":544412946,"outreach":95282599,"architect":191593656},"tokenTotal":6884526813,"tokenInput":758744799,"tokenOutput":20961067,"tokenCacheRead":6104820947,"tokenCacheCreate":113543793,"tokenMessages":65624,"tokenModels":{"claude-opus-4-6":5349088235,"claude-haiku-4-5-20251001":44819306,"claude-opus-4.6":407945396,"claude-sonnet-4.6":724540780,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777687643146,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":1},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":0,"awesomeMerged":0,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":19950317,"unknown":5334878395,"dog-alpha":44819306,"scanner":395906715,"supervisor":263423356,"reviewer":544412946,"outreach":95282599,"architect":191593656},"tokenTotal":6890267290,"tokenInput":758744870,"tokenOutput":20976913,"tokenCacheRead":6110545507,"tokenCacheCreate":113575449,"tokenMessages":65748,"tokenModels":{"claude-opus-4-6":5354828712,"claude-haiku-4-5-20251001":44819306,"claude-opus-4.6":407945396,"claude-sonnet-4.6":724540780,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777688082984,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":5,"prs":1},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":1},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":254,"awesomeMerged":90,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":19972322,"unknown":5339014909,"dog-alpha":44819306,"scanner":395906715,"reviewer":559505190,"supervisor":263423356,"outreach":95282599,"architect":191593656},"tokenTotal":6909518053,"tokenInput":766394455,"tokenOutput":21020273,"tokenCacheRead":6122103325,"tokenCacheCreate":113835754,"tokenMessages":65818,"tokenModels":{"claude-opus-4-6":5358987231,"claude-haiku-4-5-20251001":44819306,"claude-opus-4.6":407945396,"claude-sonnet-4.6":739633024,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777688442731,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":254,"awesomeMerged":90,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":19972321,"unknown":5341269472,"dog-alpha":45867490,"scanner":395996438,"reviewer":559505190,"supervisor":265177387,"outreach":95282599,"architect":191593656},"tokenTotal":6914664553,"tokenInput":767352385,"tokenOutput":21045077,"tokenCacheRead":6126267091,"tokenCacheCreate":114065253,"tokenMessages":65899,"tokenModels":{"claude-opus-4-6":5361241793,"claude-haiku-4-5-20251001":45867490,"claude-opus-4.6":408035119,"claude-sonnet-4.6":741387055,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777688799675,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":0,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":254,"awesomeMerged":90,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":19972337,"unknown":4443844750,"dog-alpha":44822036,"scanner":395996438,"reviewer":559505190,"supervisor":265177387,"outreach":95282599,"architect":191593656},"tokenTotal":6016194393,"tokenInput":767291159,"tokenOutput":18407254,"tokenCacheRead":5230495980,"tokenCacheCreate":99560397,"tokenMessages":55824,"tokenModels":{"claude-opus-4-6":4463817087,"claude-haiku-4-5-20251001":44822036,"claude-opus-4.6":408035119,"claude-sonnet-4.6":741387055,"auto":73221716,"claude-haiku-4.5":284911380}},{"t":1777689130907,"govIssues":0,"govPrs":0,"govTotal":0,"govActive":1,"govMode":"idle","beadsWorkers":26,"beadsSupervisor":50,"repos":{"console":{"issues":4,"prs":0},"console-marketplace":{"issues":0,"prs":0},"docs":{"issues":3,"prs":0},"homebrew-tap":{"issues":0,"prs":0},"console-kb":{"issues":0,"prs":0}},"agents":{"supervisor":{"busy":0,"restarts":0},"scanner":{"busy":0,"restarts":3},"reviewer":{"busy":1,"restarts":6},"architect":{"busy":0,"restarts":0},"outreach":{"busy":0,"restarts":0}},"ga4Errors":0,"adopters":11,"adopterPrs":0,"awesomeOpen":254,"awesomeMerged":90,"stars":79,"forks":64,"contributors":43,"acmm":7,"tokens":{"boot":19950328,"unknown":4449076490,"dog-alpha":44822036,"scanner":395996438,"reviewer":559505190,"supervisor":266013495,"outreach":95282599,"architect":191593656},"tokenTotal":6022240232,"tokenInput":767726828,"tokenOutput":18424063,"tokenCacheRead":5236089341,"tokenCacheCreate":99640326,"tokenMessages":55899,"tokenModels":{"claude-opus-4-6":4469026818,"claude-haiku-4-5-20251001":44822036,"claude-opus-4.6":408035119,"claude-sonnet-4.6":742223163,"auto":73221716,"claude-haiku-4.5":284911380}}];
+    window._trendData = [{"t":1777084747324,"govIssues":4,"govPrs":6,"govTotal":10,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777085584019,"govIssues":5,"govPrs":6,"govTotal":11,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777088171282,"govIssues":5,"govPrs":4,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777090861283,"govIssues":5,"govPrs":4,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777093561284,"govIssues":4,"govPrs":3,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777096261285,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777098961296,"govIssues":5,"govPrs":3,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":87},{"t":1777101661302,"govIssues":10,"govPrs":3,"govTotal":13,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90},{"t":1777104361307,"govIssues":16,"govPrs":3,"govTotal":19,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777107061311,"govIssues":18,"govPrs":4,"govTotal":22,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777109761314,"govIssues":18,"govPrs":4,"govTotal":22,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777112461316,"govIssues":18,"govPrs":4,"govTotal":22,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777115161317,"govIssues":17,"govPrs":7,"govTotal":24,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777117861318,"govIssues":8,"govPrs":2,"govTotal":10,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777119807192,"govIssues":8,"govPrs":4,"govTotal":12,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777120319567,"govIssues":6,"govPrs":3,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":85},{"t":1777122308161,"govIssues":5,"govPrs":4,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777123489938,"govIssues":3,"govPrs":2,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777126189939,"govIssues":6,"govPrs":3,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777128889947,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777131589957,"govIssues":2,"govPrs":1,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777133802340,"govIssues":2,"govPrs":2,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777135812756,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777138366348,"govIssues":0,"govPrs":6,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777140452148,"govIssues":0,"govPrs":5,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777141371944,"govIssues":0,"govPrs":6,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":66},{"t":1777143713170,"govIssues":4,"govPrs":8,"govTotal":12,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777144823965,"govIssues":3,"govPrs":6,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777145859560,"govIssues":3,"govPrs":5,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777148204615,"govIssues":5,"govPrs":2,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777150160907,"govIssues":5,"govPrs":2,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777152580156,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777155280157,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777157980158,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777160680158,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777163622277,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777165055058,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90},{"t":1777166092821,"govIssues":4,"govPrs":8,"govTotal":12,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":85},{"t":1777168792875,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777171492876,"govIssues":8,"govPrs":4,"govTotal":12,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777176209084,"govIssues":7,"govPrs":7,"govTotal":14,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0},{"t":1777178899102,"govIssues":4,"govPrs":4,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777181599104,"govIssues":3,"govPrs":2,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777184299107,"govIssues":3,"govPrs":3,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777186999110,"govIssues":5,"govPrs":4,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777189699133,"govIssues":6,"govPrs":6,"govTotal":12,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777192399140,"govIssues":14,"govPrs":5,"govTotal":19,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777195099155,"govIssues":7,"govPrs":3,"govTotal":10,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90},{"t":1777197799155,"govIssues":6,"govPrs":3,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777200499155,"govIssues":14,"govPrs":10,"govTotal":24,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777203199156,"govIssues":11,"govPrs":5,"govTotal":16,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777205899168,"govIssues":8,"govPrs":9,"govTotal":17,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777208599172,"govIssues":6,"govPrs":5,"govTotal":11,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777211299202,"govIssues":6,"govPrs":7,"govTotal":13,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777213999207,"govIssues":5,"govPrs":6,"govTotal":11,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777216699210,"govIssues":3,"govPrs":6,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777219399210,"govIssues":5,"govPrs":11,"govTotal":16,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777222099214,"govIssues":3,"govPrs":0,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777224799216,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777227499219,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777230199231,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777232899239,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777235599240,"govIssues":2,"govPrs":1,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777238299245,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777240999245,"govIssues":6,"govPrs":2,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100},{"t":1777242923175,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777243294689,"govIssues":3,"govPrs":1,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777245494726,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777246639631,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777247855975,"govIssues":2,"govPrs":2,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777248472544,"govIssues":5,"govPrs":1,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0},{"t":1777249595558,"govIssues":9,"govPrs":2,"govTotal":11,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777253204608,"govIssues":3,"govPrs":1,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777255904617,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777258604617,"govIssues":2,"govPrs":3,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777260438134,"govIssues":5,"govPrs":1,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777262220568,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777264910585,"govIssues":5,"govPrs":1,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777267610604,"govIssues":5,"govPrs":0,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777270310608,"govIssues":4,"govPrs":0,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777273010619,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777275710699,"govIssues":5,"govPrs":2,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777278410707,"govIssues":8,"govPrs":1,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777281110707,"govIssues":13,"govPrs":3,"govTotal":16,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777283810708,"govIssues":8,"govPrs":0,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777286510714,"govIssues":3,"govPrs":1,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777289210717,"govIssues":5,"govPrs":0,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":88,"awesomeOpen":0,"awesomeMerged":0},{"t":1777291910718,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0},{"t":1777294610719,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777297310720,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777300010721,"govIssues":4,"govPrs":0,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777302710722,"govIssues":3,"govPrs":1,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777304607941,"govIssues":8,"govPrs":1,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777304981026,"govIssues":7,"govPrs":1,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777305569437,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777307979478,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0},{"t":1777310679480,"govIssues":5,"govPrs":0,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777313379480,"govIssues":0,"govPrs":2,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0},{"t":1777316079483,"govIssues":0,"govPrs":25,"govTotal":25,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777318112878,"govIssues":10,"govPrs":7,"govTotal":17,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777319920052,"govIssues":22,"govPrs":4,"govTotal":26,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777322610053,"govIssues":8,"govPrs":1,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777325310059,"govIssues":5,"govPrs":0,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":75,"awesomeOpen":0,"awesomeMerged":0},{"t":1777328010059,"govIssues":5,"govPrs":1,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777330710062,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777333410066,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777336110067,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777337997347,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777339313614,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777340410630,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777344017847,"govIssues":5,"govPrs":2,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777345496097,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777348196103,"govIssues":3,"govPrs":3,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777350896106,"govIssues":4,"govPrs":4,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777353596107,"govIssues":5,"govPrs":3,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777356296111,"govIssues":5,"govPrs":3,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777358996115,"govIssues":5,"govPrs":3,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777361696117,"govIssues":8,"govPrs":5,"govTotal":13,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777364396119,"govIssues":14,"govPrs":5,"govTotal":19,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777367096120,"govIssues":14,"govPrs":8,"govTotal":22,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777369796125,"govIssues":15,"govPrs":6,"govTotal":21,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777372496130,"govIssues":18,"govPrs":10,"govTotal":28,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777375196132,"govIssues":23,"govPrs":13,"govTotal":36,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777377896132,"govIssues":21,"govPrs":7,"govTotal":28,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777380596133,"govIssues":22,"govPrs":5,"govTotal":27,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777383199255,"govIssues":19,"govPrs":4,"govTotal":23,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777385899255,"govIssues":15,"govPrs":5,"govTotal":20,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777388599258,"govIssues":11,"govPrs":4,"govTotal":15,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777391299328,"govIssues":10,"govPrs":7,"govTotal":17,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777393999375,"govIssues":9,"govPrs":6,"govTotal":15,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777396699465,"govIssues":14,"govPrs":7,"govTotal":21,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777399399476,"govIssues":7,"govPrs":7,"govTotal":14,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777402099500,"govIssues":6,"govPrs":6,"govTotal":12,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777404799536,"govIssues":7,"govPrs":5,"govTotal":12,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":85,"awesomeOpen":0,"awesomeMerged":0},{"t":1777407499566,"govIssues":10,"govPrs":5,"govTotal":15,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777410199568,"govIssues":8,"govPrs":4,"govTotal":12,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777412899569,"govIssues":8,"govPrs":5,"govTotal":13,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777415599570,"govIssues":10,"govPrs":9,"govTotal":19,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777418299576,"govIssues":5,"govPrs":6,"govTotal":11,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777420999590,"govIssues":5,"govPrs":4,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777423699597,"govIssues":4,"govPrs":6,"govTotal":10,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777426399598,"govIssues":4,"govPrs":5,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777429099599,"govIssues":5,"govPrs":5,"govTotal":10,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0},{"t":1777431524279,"govIssues":5,"govPrs":7,"govTotal":12,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777434224280,"govIssues":2,"govPrs":3,"govTotal":5,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777436924283,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777439624284,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":88,"awesomeOpen":0,"awesomeMerged":0},{"t":1777442324295,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":66,"awesomeOpen":0,"awesomeMerged":0},{"t":1777445024300,"govIssues":1,"govPrs":5,"govTotal":6,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777447724302,"govIssues":1,"govPrs":9,"govTotal":10,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777450424303,"govIssues":4,"govPrs":0,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":88,"awesomeOpen":0,"awesomeMerged":0},{"t":1777453124304,"govIssues":0,"govPrs":2,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777455824308,"govIssues":2,"govPrs":1,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777458524312,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777461224313,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777463924313,"govIssues":1,"govPrs":1,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777465934609,"govIssues":0,"govPrs":1,"govTotal":1,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777467121274,"govIssues":1,"govPrs":1,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777468528565,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777471228565,"govIssues":0,"govPrs":3,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777473928565,"govIssues":0,"govPrs":12,"govTotal":12,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777475950969,"govIssues":0,"govPrs":13,"govTotal":13,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777478640967,"govIssues":9,"govPrs":5,"govTotal":14,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777481340967,"govIssues":5,"govPrs":3,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777484040967,"govIssues":5,"govPrs":3,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777485917085,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777487667714,"govIssues":1,"govPrs":3,"govTotal":4,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777488096361,"govIssues":2,"govPrs":2,"govTotal":4,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777490786427,"govIssues":0,"govPrs":3,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777491616663,"govIssues":1,"govPrs":1,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777492563344,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777495172099,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777497872099,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777500572099,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777503272100,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777505972107,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777508672107,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777511372107,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777514072110,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":87,"awesomeOpen":0,"awesomeMerged":0},{"t":1777516772112,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777518963544,"govIssues":2,"govPrs":1,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777521663559,"govIssues":3,"govPrs":3,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777524363560,"govIssues":5,"govPrs":0,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":85,"awesomeOpen":0,"awesomeMerged":0},{"t":1777527063561,"govIssues":5,"govPrs":0,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":85,"awesomeOpen":0,"awesomeMerged":0},{"t":1777529763564,"govIssues":8,"govPrs":0,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777532463565,"govIssues":15,"govPrs":1,"govTotal":16,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777535163573,"govIssues":26,"govPrs":0,"govTotal":26,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777537863573,"govIssues":28,"govPrs":0,"govTotal":28,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777540563574,"govIssues":29,"govPrs":1,"govTotal":30,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777543263575,"govIssues":29,"govPrs":0,"govTotal":29,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777545963580,"govIssues":29,"govPrs":1,"govTotal":30,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777548663582,"govIssues":29,"govPrs":0,"govTotal":29,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":66,"awesomeOpen":0,"awesomeMerged":0},{"t":1777551363584,"govIssues":28,"govPrs":10,"govTotal":38,"govMode":"surge","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777552586014,"govIssues":15,"govPrs":4,"govTotal":19,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0},{"t":1777555276023,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777557976028,"govIssues":6,"govPrs":1,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777560676028,"govIssues":14,"govPrs":1,"govTotal":15,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777563376032,"govIssues":10,"govPrs":3,"govTotal":13,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777566076036,"govIssues":4,"govPrs":1,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0},{"t":1777568602592,"govIssues":6,"govPrs":2,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":0},{"t":1777570726232,"govIssues":5,"govPrs":2,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":0},{"t":1777572847713,"govIssues":4,"govPrs":3,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":3345},{"t":1777574819796,"govIssues":6,"govPrs":2,"govTotal":8,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":3479},{"t":1777577519800,"govIssues":3,"govPrs":2,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":3412},{"t":1777580192732,"govIssues":3,"govPrs":3,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":3412},{"t":1777582380095,"govIssues":3,"govPrs":0,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":2875},{"t":1777585080115,"govIssues":3,"govPrs":1,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":2875},{"t":1777587780116,"govIssues":3,"govPrs":1,"govTotal":4,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":2484},{"t":1777590480121,"govIssues":6,"govPrs":1,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":2094},{"t":1777593180122,"govIssues":11,"govPrs":5,"govTotal":16,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":839},{"t":1777594999192,"govIssues":2,"govPrs":1,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":801},{"t":1777596112806,"govIssues":3,"govPrs":0,"govTotal":3,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":801},{"t":1777598093306,"govIssues":2,"govPrs":2,"govTotal":4,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":0,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":801},{"t":1777600793307,"govIssues":4,"govPrs":2,"govTotal":6,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":820},{"t":1777603493324,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":388},{"t":1777606193328,"govIssues":1,"govPrs":1,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":387},{"t":1777608893337,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":0},{"t":1777611593342,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":457},{"t":1777614293343,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":384},{"t":1777616993346,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":386},{"t":1777619693375,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":0},{"t":1777622393423,"govIssues":5,"govPrs":2,"govTotal":7,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":385},{"t":1777625093425,"govIssues":4,"govPrs":5,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":426},{"t":1777627793429,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":87,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":411},{"t":1777630493457,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":0},{"t":1777633193473,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":408},{"t":1777635893477,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":85,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":367},{"t":1777638593477,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":367},{"t":1777641293479,"govIssues":3,"govPrs":6,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":0},{"t":1777643993483,"govIssues":15,"govPrs":20,"govTotal":35,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":367},{"t":1777646693485,"govIssues":14,"govPrs":20,"govTotal":34,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":365},{"t":1777649393493,"govIssues":14,"govPrs":21,"govTotal":35,"govMode":"busy","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":368},{"t":1777652093501,"govIssues":0,"govPrs":1,"govTotal":1,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":429},{"t":1777654793505,"govIssues":6,"govPrs":3,"govTotal":9,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":434},{"t":1777657493506,"govIssues":1,"govPrs":3,"govTotal":4,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":155},{"t":1777660193506,"govIssues":0,"govPrs":1,"govTotal":1,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":161},{"t":1777662893513,"govIssues":2,"govPrs":3,"govTotal":5,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":161},{"t":1777665593531,"govIssues":1,"govPrs":4,"govTotal":5,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":156},{"t":1777668293548,"govIssues":2,"govPrs":0,"govTotal":2,"govMode":"quiet","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":164},{"t":1777670993594,"govIssues":0,"govPrs":1,"govTotal":1,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":172},{"t":1777673693595,"govIssues":2,"govPrs":1,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":154},{"t":1777676393599,"govIssues":3,"govPrs":0,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":152},{"t":1777679093599,"govIssues":2,"govPrs":2,"govTotal":4,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":155},{"t":1777681793600,"govIssues":1,"govPrs":2,"govTotal":3,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":159},{"t":1777684493602,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":159},{"t":1777687193618,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":0,"adopterPrs":0,"ciPassRate":100,"awesomeOpen":0,"awesomeMerged":0,"issueToMergeAvg":161},{"t":1777688671534,"govIssues":0,"govPrs":0,"govTotal":0,"govMode":"idle","ga4Errors":0,"adopters":11,"adopterPrs":0,"ciPassRate":90,"awesomeOpen":254,"awesomeMerged":90,"issueToMergeAvg":162,"stars":79,"forks":64,"contributors":43,"acmm":7}];
+    window._timelineData = [{"t":1777603493324,"mode":"idle"},{"t":1777609793340,"mode":"idle"},{"t":1777616093344,"mode":"idle"},{"t":1777622393423,"mode":"quiet"},{"t":1777628693429,"mode":"idle"},{"t":1777634993476,"mode":"idle"},{"t":1777641293479,"mode":"quiet"},{"t":1777645552454,"mode":"busy"},{"t":1777645753220,"mode":"busy"},{"t":1777645931112,"mode":"busy"},{"t":1777646144339,"mode":"busy"},{"t":1777646350117,"mode":"busy"},{"t":1777646568249,"mode":"busy"},{"t":1777646756715,"mode":"busy"},{"t":1777646955622,"mode":"busy"},{"t":1777647167098,"mode":"busy"},{"t":1777647379262,"mode":"busy"},{"t":1777647589746,"mode":"busy"},{"t":1777647773718,"mode":"busy"},{"t":1777647987026,"mode":"busy"},{"t":1777648187440,"mode":"busy"},{"t":1777648405975,"mode":"busy"},{"t":1777648596918,"mode":"busy"},{"t":1777648795165,"mode":"busy"},{"t":1777649008726,"mode":"busy"},{"t":1777649219278,"mode":"busy"},{"t":1777649401800,"mode":"busy"},{"t":1777649608136,"mode":"busy"},{"t":1777649823416,"mode":"busy"},{"t":1777650047231,"mode":"busy"},{"t":1777650244610,"mode":"busy"},{"t":1777650434746,"mode":"idle"},{"t":1777650640199,"mode":"idle"},{"t":1777650843644,"mode":"idle"},{"t":1777651056358,"mode":"idle"},{"t":1777651240693,"mode":"idle"},{"t":1777651457850,"mode":"idle"},{"t":1777651668356,"mode":"idle"},{"t":1777651875491,"mode":"idle"},{"t":1777652079744,"mode":"idle"},{"t":1777652280708,"mode":"idle"},{"t":1777652485915,"mode":"idle"},{"t":1777652704446,"mode":"idle"},{"t":1777652914958,"mode":"idle"},{"t":1777653094815,"mode":"idle"},{"t":1777653308134,"mode":"idle"},{"t":1777653531104,"mode":"idle"},{"t":1777653741509,"mode":"quiet"},{"t":1777653941294,"mode":"quiet"},{"t":1777654150757,"mode":"quiet"},{"t":1777654381142,"mode":"quiet"},{"t":1777654592078,"mode":"quiet"},{"t":1777654793505,"mode":"quiet"},{"t":1777654980836,"mode":"quiet"},{"t":1777655197862,"mode":"quiet"},{"t":1777655416734,"mode":"quiet"},{"t":1777655620867,"mode":"quiet"},{"t":1777655837551,"mode":"quiet"},{"t":1777656051001,"mode":"quiet"},{"t":1777656258122,"mode":"quiet"},{"t":1777656467264,"mode":"normal"},{"t":1777656651521,"mode":"normal"},{"t":1777656866309,"mode":"idle"},{"t":1777657069996,"mode":"normal"},{"t":1777657286357,"mode":"idle"},{"t":1777657493180,"mode":"idle"},{"t":1777657671834,"mode":"idle"},{"t":1777657887290,"mode":"idle"},{"t":1777658093587,"mode":"idle"},{"t":1777658303948,"mode":"idle"},{"t":1777658490230,"mode":"idle"},{"t":1777658701400,"mode":"idle"},{"t":1777658912985,"mode":"idle"},{"t":1777659120872,"mode":"idle"},{"t":1777659310256,"mode":"idle"},{"t":1777659516696,"mode":"idle"},{"t":1777659723935,"mode":"idle"},{"t":1777659934376,"mode":"idle"},{"t":1777660145950,"mode":"idle"},{"t":1777660324321,"mode":"idle"},{"t":1777660535767,"mode":"idle"},{"t":1777660744451,"mode":"idle"},{"t":1777660956705,"mode":"idle"},{"t":1777661135000,"mode":"idle"},{"t":1777661350814,"mode":"idle"},{"t":1777661554179,"mode":"quiet"},{"t":1777661770573,"mode":"quiet"},{"t":1777661981769,"mode":"quiet"},{"t":1777662159310,"mode":"quiet"},{"t":1777662373893,"mode":"quiet"},{"t":1777662584927,"mode":"quiet"},{"t":1777662789902,"mode":"quiet"},{"t":1777662984734,"mode":"idle"},{"t":1777663190941,"mode":"idle"},{"t":1777663404120,"mode":"idle"},{"t":1777663615296,"mode":"quiet"},{"t":1777663798157,"mode":"quiet"},{"t":1777664006088,"mode":"quiet"},{"t":1777664225272,"mode":"quiet"},{"t":1777664429926,"mode":"quiet"},{"t":1777664635390,"mode":"quiet"},{"t":1777664820230,"mode":"quiet"},{"t":1777665029881,"mode":"idle"},{"t":1777665235991,"mode":"idle"},{"t":1777665446440,"mode":"idle"},{"t":1777665627068,"mode":"idle"},{"t":1777665846151,"mode":"idle"},{"t":1777666065831,"mode":"idle"},{"t":1777666274411,"mode":"quiet"},{"t":1777666485314,"mode":"quiet"},{"t":1777666670467,"mode":"quiet"},{"t":1777666872351,"mode":"quiet"},{"t":1777667090032,"mode":"quiet"},{"t":1777667296490,"mode":"quiet"},{"t":1777667476930,"mode":"quiet"},{"t":1777667687750,"mode":"quiet"},{"t":1777667900054,"mode":"quiet"},{"t":1777668112188,"mode":"quiet"},{"t":1777668301597,"mode":"quiet"},{"t":1777668516224,"mode":"quiet"},{"t":1777668723324,"mode":"quiet"},{"t":1777668945564,"mode":"quiet"},{"t":1777669155223,"mode":"quiet"},{"t":1777669344442,"mode":"quiet"},{"t":1777669562301,"mode":"quiet"},{"t":1777669770148,"mode":"quiet"},{"t":1777669978195,"mode":"quiet"},{"t":1777670165955,"mode":"quiet"},{"t":1777670384524,"mode":"quiet"},{"t":1777670601695,"mode":"idle"},{"t":1777670819101,"mode":"idle"},{"t":1777671001972,"mode":"idle"},{"t":1777671220432,"mode":"idle"},{"t":1777671423500,"mode":"idle"},{"t":1777671641595,"mode":"idle"},{"t":1777671858650,"mode":"idle"},{"t":1777672039002,"mode":"idle"},{"t":1777672244599,"mode":"idle"},{"t":1777672455832,"mode":"idle"},{"t":1777672674136,"mode":"idle"},{"t":1777672847567,"mode":"idle"},{"t":1777673061240,"mode":"idle"},{"t":1777673271800,"mode":"idle"},{"t":1777673481736,"mode":"idle"},{"t":1777673693595,"mode":"idle"},{"t":1777673868980,"mode":"idle"},{"t":1777674084992,"mode":"idle"},{"t":1777674309339,"mode":"idle"},{"t":1777674512139,"mode":"idle"},{"t":1777674689465,"mode":"idle"},{"t":1777674910260,"mode":"idle"},{"t":1777675111187,"mode":"quiet"},{"t":1777675322552,"mode":"idle"},{"t":1777675506119,"mode":"idle"},{"t":1777675716775,"mode":"idle"},{"t":1777675923851,"mode":"idle"},{"t":1777676135750,"mode":"idle"},{"t":1777676343134,"mode":"idle"},{"t":1777676526332,"mode":"quiet"},{"t":1777676745374,"mode":"quiet"},{"t":1777676943979,"mode":"quiet"},{"t":1777677156301,"mode":"quiet"},{"t":1777677337001,"mode":"quiet"},{"t":1777677547118,"mode":"quiet"},{"t":1777677760060,"mode":"quiet"},{"t":1777677969465,"mode":"quiet"},{"t":1777678175805,"mode":"quiet"},{"t":1777678368075,"mode":"idle"},{"t":1777678581999,"mode":"idle"},{"t":1777678786746,"mode":"idle"},{"t":1777678996346,"mode":"idle"},{"t":1777679180692,"mode":"idle"},{"t":1777679386663,"mode":"idle"},{"t":1777679596696,"mode":"idle"},{"t":1777679811830,"mode":"idle"},{"t":1777679993599,"mode":"idle"},{"t":1777680201652,"mode":"idle"},{"t":1777680417977,"mode":"idle"},{"t":1777680631088,"mode":"idle"},{"t":1777680834385,"mode":"idle"},{"t":1777681021835,"mode":"idle"},{"t":1777681230253,"mode":"idle"},{"t":1777681436870,"mode":"idle"},{"t":1777681649334,"mode":"idle"},{"t":1777681829524,"mode":"idle"},{"t":1777682041407,"mode":"idle"},{"t":1777682261210,"mode":"idle"},{"t":1777682462570,"mode":"idle"},{"t":1777682672699,"mode":"idle"},{"t":1777682857873,"mode":"idle"},{"t":1777683065412,"mode":"idle"},{"t":1777683283736,"mode":"idle"},{"t":1777683486651,"mode":"idle"},{"t":1777683665808,"mode":"idle"},{"t":1777683872971,"mode":"idle"},{"t":1777684085415,"mode":"idle"},{"t":1777684301435,"mode":"idle"},{"t":1777684493602,"mode":"idle"},{"t":1777684685216,"mode":"idle"},{"t":1777684893909,"mode":"idle"},{"t":1777685113528,"mode":"idle"},{"t":1777685321902,"mode":"idle"},{"t":1777685494749,"mode":"idle"},{"t":1777685716075,"mode":"idle"},{"t":1777685931872,"mode":"idle"},{"t":1777686142400,"mode":"idle"},{"t":1777686347049,"mode":"idle"},{"t":1777686555074,"mode":"idle"},{"t":1777686769573,"mode":"idle"},{"t":1777686975359,"mode":"idle"},{"t":1777687192854,"mode":"idle"},{"t":1777687373685,"mode":"idle"},{"t":1777687585189,"mode":"idle"},{"t":1777687859982,"mode":"idle"},{"t":1777688082984,"mode":"idle"},{"t":1777688289724,"mode":"idle"},{"t":1777688502035,"mode":"idle"},{"t":1777688687137,"mode":"idle"},{"t":1777688894254,"mode":"idle"},{"t":1777689105164,"mode":"idle"},{"t":1777689130907,"mode":"idle"}];
+
+    // Set project name — match the live dashboard's pattern
+    const _cfg = {"projectName":"KubeStellar Console","primaryRepo":"kubestellar/console","org":"kubestellar","dashboardTitle":"KubeStellar Console Hive"};
+    const _projEl = document.getElementById('project-name');
+    if (_projEl && _cfg.primaryRepo) {
+      _projEl.textContent = 'for ' + _cfg.primaryRepo;
+      document.title = '\u{1F41D} Hive Dashboard for ' + _cfg.primaryRepo + ' (Snapshot)';
+    }
+    if (_cfg.primaryRepo) window._primaryRepo = _cfg.primaryRepo;
+    if (_cfg.repo) window._hiveRepo = _cfg.repo;
+
+    // Render baked status
+    render({"timestamp":"2026-05-02T02:32:17+00:00","agents":[{"name":"supervisor","session":"supervisor","state":"running","cli":"copilot","pinned":false,"model":"Claude Sonnet 4.6","cadence":"5min","busy":"idle","doing":"","nextKick":"5/1 10:32 PM","lastKick":"5/1 10:27 PM","needsLogin":false,"restarts":0,"govBackend":"copilot","govModel":"claude-sonnet-4.6","govCostWeight":0,"govReason":"quiet_mode","pinnedBoth":false,"pinnedCli":true,"pinnedModel":true,"liveSummary":"Pass started: 2026-05-01 10:26 PM EDT | Finished: 10:28 PM EDT\n┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐\n├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤\n└───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘\nAction taken: None needed — queue empty, governor handles next kicks. Architect is paused pending operator direction.","summaryUpdated":"2026-05-02T02:32:17.001Z","structuredStatus":"WORKING","statusEvidence":""},{"name":"scanner","session":"scanner","state":"running","cli":"copilot","pinned":true,"model":"Claude Opus 4.6","cadence":"15min","busy":"idle","doing":"","nextKick":"5/1 10:33 PM","lastKick":"5/1 10:18 PM","needsLogin":false,"restarts":3,"govBackend":"copilot","govModel":"claude-opus-4.6","govCostWeight":0,"govReason":"quiet_mode","pinnedBoth":true,"pinnedCli":true,"pinnedModel":true,"liveSummary":"Pull latest changes (shell)\nThe work list shows 0 actionable issues and 0 actionable PRs. There's nothing\nto dispatch.\nRepo is up to date. Work list is empty — 0 actionable issues, 0 actionable\nPRs, nothing to merge. No work to dispatch. Standing by for next kick.","summaryUpdated":"2026-05-02T02:32:17.001Z","structuredStatus":"WORKING","statusEvidence":""},{"name":"reviewer","session":"reviewer","state":"running","cli":"copilot","pinned":true,"model":"Claude Sonnet 4.6","cadence":"15min","busy":"working","doing":"● Git pull with rebase from /tmp/hive (shell)|● Show HIGH severity comments (shell)|● Reviewing RED indicators","nextKick":"5/1 10:35 PM","lastKick":"5/1 10:12 PM","needsLogin":false,"restarts":6,"govBackend":"copilot","govModel":"claude-sonnet-4-6","govCostWeight":0,"govReason":"","pinnedBoth":true,"pinnedCli":true,"pinnedModel":true,"liveSummary":"Read copilot comments JSON (shell)\nRead GA4 anomalies JSON (shell)\nGit pull with rebase from /tmp/hive (shell)\nShow HIGH severity comments (shell)\nReviewing RED indicators","summaryUpdated":"2026-05-02T02:32:17.001Z","structuredStatus":"WORKING","statusEvidence":""},{"name":"architect","session":"architect","state":"running","cli":"copilot","pinned":false,"model":"Claude Opus 4.6","cadence":"paused","busy":"idle","doing":"","nextKick":"paused","lastKick":"5/1 1:37 PM","needsLogin":false,"restarts":0,"govBackend":"copilot","govModel":"claude-opus-4-6","govCostWeight":0,"govReason":"quiet_mode","paused":true,"pinnedBoth":false,"pinnedCli":true,"pinnedModel":true,"liveSummary":"Check for large deps impacting bundle (shell)\nCheck echarts usage spread (shell)\nOperation cancelled by user\nSession renamed to: architect-paused\n! Rewind is not available because you're not in a git repository.","summaryUpdated":"2026-05-02T02:32:17.001Z","structuredStatus":"WORKING","statusEvidence":"PR#11298 opened 12:49PM, PR#11299 opened 12:51PM, mcp-refactor agent running"},{"name":"outreach","session":"outreach","state":"running","cli":"copilot","pinned":false,"model":"Claude Sonnet 4.6","cadence":"paused","busy":"idle","doing":"","nextKick":"paused","lastKick":"5/1 12:48 PM","needsLogin":false,"restarts":0,"govBackend":"copilot","govModel":"claude-sonnet-4-6","govCostWeight":0,"govReason":"","paused":true,"pinnedBoth":false,"pinnedCli":true,"pinnedModel":true,"liveSummary":"┌───────────────────────────────────────────┬──────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────┐\n├───────────────────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────┤\n└───────────────────────────────────────────┴──────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────┘\nFor agones: the force-push reset the build status. The maintainer's LGTM was on the old head — they'll likely need to re-run /gcbrun once CI clears on the new\nhead. No action needed from us unless CI fails.","summaryUpdated":"2026-05-02T02:32:17.001Z","structuredStatus":"DONE","statusEvidence":"DhanushNehru/awesome-mcp-servers#18, Sagargupta16/awesome-mcp-servers#46, rocksun/awesome-aiops#1, guiofsaints/awesome-platform#1, hireblackout/awesome-mcp-servers#16"}],"governor":{"mode":"idle","active":true,"issues":0,"prs":0,"nextKick":"5/2 12:00 AM EDT"},"budget":{"BUDGET_WEEKLY":200000000,"BUDGET_USED":788891697,"BUDGET_REMAINING":0,"BUDGET_PCT_USED":394,"BURN_RATE_HOURLY":29218211,"BURN_RATE_INSTANT":29401112,"HOURS_ELAPSED":27,"HOURS_REMAINING":141,"PROJECTED_WEEKLY":4908659448,"PROJECTED_PCT":2454,"LAST_UPDATED":"2026-05-02T02:30:07+00:00"},"cadenceMatrix":[{"agent":"supervisor","surge":"5m","busy":"5m","quiet":"5m","idle":"5m"},{"agent":"scanner","surge":"15m","busy":"15m","quiet":"15m","idle":"15m"},{"agent":"reviewer","surge":"paused","busy":"1h","quiet":"45m","idle":"15m"},{"agent":"architect","surge":"paused","busy":"paused","quiet":"paused","idle":"30m"},{"agent":"outreach","surge":"paused","busy":"paused","quiet":"paused","idle":"2h"}],"repos":[{"name":"console","full":"kubestellar/console","issues":4,"prs":0},{"name":"console-marketplace","full":"kubestellar/console-marketplace","issues":0,"prs":0},{"name":"docs","full":"kubestellar/docs","issues":3,"prs":0},{"name":"homebrew-tap","full":"kubestellar/homebrew-tap","issues":0,"prs":0},{"name":"console-kb","full":"kubestellar/console-kb","issues":0,"prs":0}],"beads":{"workers":26,"supervisor":50},"health":{"ci":100,"brew":1,"helm":1,"nightly":1,"nightlyCompliance":1,"nightlyDashboard":1,"nightlyGhaw":1,"nightlyPlaywright":0,"nightlyRel":1,"weekly":-1,"weeklyRel":1,"hourly":1,"deploy_vllm_d":1,"deploy_pok_prod":1},"ciPassRate":100,"agentMetrics":{"scanner":{"doing":"","model":"Claude Opus 4.6","pairs":[{"issue":11371,"pr":11375,"prTitle":"🐛 fix(e2e): stabilize Playwright tests for cross-browser and mobile","state":"merged","created":null,"merged":"2026-05-01T23:49:22Z","issueTitle":"[Nightly] Playwright Cross-Browser RED: mobile + firefox + webkit failing since 2026-04-28"},{"issue":11359,"pr":11373,"prTitle":"🌱 ci: upgrade docker/setup-buildx-action to v4","state":"merged","created":null,"merged":"2026-05-01T23:23:25Z","issueTitle":"ci: upgrade docker/setup-buildx-action to v4 before Node.js 20 EOL on Actions (June 2)"},{"issue":11369,"pr":11370,"prTitle":"🐛 fix(demoMode): decouple VITE_NO_LOCAL_AGENT from isNetlifyDeployment","state":"merged","created":null,"merged":"2026-05-01T22:48:22Z","issueTitle":"Kagenti Cluster Mode Shows Demo Data Instead of Real Cluster Data"},{"issue":11358,"pr":11366,"prTitle":"fix: wire diagnostics into SubmitTab (correct submit handler)","state":"merged","created":null,"merged":"2026-05-01T22:21:28Z","issueTitle":"kjfkdjdkfjd k kdj kfdjf kdjf kdjfkdj fkdjf df"},{"issue":11358,"pr":11366,"prTitle":"fix: wire diagnostics into SubmitTab (correct submit handler)","state":"merged","created":null,"merged":"2026-05-01T22:21:28Z","issueTitle":"kjfkdjdkfjd k kdj kfdjf kdjf kdjfkdj fkdjf df"},{"issue":11348,"pr":11356,"prTitle":"🐛 fix(tests): align MCP hook tests with exponential backoff behavior","state":"merged","created":null,"merged":"2026-05-01T21:22:48Z","issueTitle":"🐛 15 test failure(s) in Coverage Suite run #1922"},{"issue":11344,"pr":11347,"prTitle":"🐛 fix(mission-sidebar): prevent horizontal text shift on chat expand","state":"merged","created":null,"merged":"2026-05-01T21:02:46Z","issueTitle":"bug: Text content shifts horizontally when expanding AI Mission chat (layout instability)"},{"issue":11345,"pr":11349,"prTitle":"✨ feat(feedback): support video uploads in bug report/feature request modal","state":"merged","created":null,"merged":"2026-05-01T21:02:57Z","issueTitle":"feature: Allow video uploads in \"Screenshots\" section of Contribute modal"}],"inProgress":[]},"reviewer":{"doing":"","model":"Claude Sonnet 4.6","coverage":91,"coverageTarget":91},"architect":{"doing":"","model":"Claude Opus 4.6","prs":0,"closed":0},"outreach":{"doing":"","model":"Claude Sonnet 4.6","stars":79,"forks":64,"contributors":43,"adopters":11,"acmm":7,"outreachOpen":254,"outreachMerged":90}},"tokens":{"timestamp":1777689085543,"lookbackHours":24,"totals":{"input":767726828,"output":18424063,"cacheRead":5236089341,"cacheCreate":99640326,"messages":55899,"sessions":744},"byModel":{"claude-opus-4-6":{"input":123680,"output":13007195,"cacheRead":4455895943,"cacheCreate":65883735,"messages":40727},"claude-haiku-4-5-20251001":{"input":4954,"output":199764,"cacheRead":44617318,"cacheCreate":2927293,"messages":1125},"claude-opus-4.6":{"input":209011822,"output":1604601,"cacheRead":197418696,"cacheCreate":11267101,"messages":4576},"claude-sonnet-4.6":{"input":376514026,"output":2599901,"cacheRead":363109236,"cacheCreate":12779026,"messages":6911},"auto":{"input":37227211,"output":211854,"cacheRead":35782651,"cacheCreate":1396906,"messages":530},"claude-haiku-4.5":{"input":144845135,"output":800748,"cacheRead":139265497,"cacheCreate":5386265,"messages":2030}},"byCli":{"claude":{"input":128634,"output":13206959,"cacheRead":4500513261,"cacheCreate":68811028,"messages":41852,"sessions":425},"copilot":{"input":767598194,"output":5217104,"cacheRead":735576080,"cacheCreate":30829298,"messages":14047,"sessions":319}},"byAgent":{"boot":{"input":3616,"output":205440,"cacheRead":19741272,"cacheCreate":12219914,"messages":1448,"sessions":360,"avgPerSession":55417},"unknown":{"input":120064,"output":12801755,"cacheRead":4436154671,"cacheCreate":53663821,"messages":39279,"sessions":18,"avgPerSession":247170916},"dog-alpha":{"input":4954,"output":199764,"cacheRead":44617318,"cacheCreate":2927293,"messages":1125,"sessions":47,"avgPerSession":953660},"scanner":{"input":202772449,"output":1494013,"cacheRead":191729976,"cacheCreate":10759158,"messages":4369,"sessions":96,"avgPerSession":4124962},"reviewer":{"input":282834859,"output":1712502,"cacheRead":274957829,"cacheCreate":7540117,"messages":4062,"sessions":68,"avgPerSession":8228017},"supervisor":{"input":136136265,"output":1149960,"cacheRead":128727270,"cacheCreate":7071091,"messages":3263,"sessions":140,"avgPerSession":1900096},"outreach":{"input":48271199,"output":241920,"cacheRead":46769480,"cacheCreate":1482182,"messages":841,"sessions":9,"avgPerSession":10586955},"architect":{"input":97583422,"output":618709,"cacheRead":93391525,"cacheCreate":3976750,"messages":1512,"sessions":6,"avgPerSession":31932276}},"sessions":[{"id":"89738e92-2a0","model":"claude-opus-4-6","cli":"claude","agent":"unknown","input":6926,"output":315122,"cacheRead":127771895,"cacheCreate":1438682,"messages":1494,"total":128093943,"project":"-Users-andan02","started":"2026-05-01T13:26:16.696Z","lastActive":"2026-05-02T02:30:49.241Z","mtime":1777689052374,"activity":[84,4,34,94,192,103,31,86,112,107,32,41,114,139,90,164,148,174,175,184,119,0,0,0,0,0,0,24,139,94]},{"id":"18020785-477","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":9,"output":540,"cacheRead":32355,"cacheCreate":33585,"messages":3,"total":32904,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:29:59.561Z","lastActive":"2026-05-02T02:30:05.087Z","mtime":1777689017727,"activity":[1,2]},{"id":"44e93e7b-667","model":"claude-opus-4-6","cli":"claude","agent":"unknown","input":87379,"output":11551047,"cacheRead":3990132966,"cacheCreate":47190535,"messages":34174,"total":4001771392,"project":"-Users-andan02","started":"2026-04-17T12:26:45.101Z","lastActive":"2026-05-02T02:30:13.997Z","mtime":1777689017148,"activity":[1405,886,615,491,804,299,1574,236,1697,204,0,12,276,353,0,459,3040,4809,1988,4516,2758,5298,3069,2768,2546,3954,2902,4282,2471,4238]},{"id":"65a4d90e-fef","model":"claude-sonnet-4.6","cli":"copilot","agent":"supervisor","input":1062057,"output":88504,"cacheRead":619533,"cacheCreate":0,"messages":16,"toolCalls":31,"total":1770095,"estimated":true,"project":"copilot-session","started":"2026-05-02T02:26:46.966Z","lastActive":"2026-05-02T02:29:19.698Z","mtime":1777688960306,"activity":[11,6]},{"id":"063ebaa1-bf4","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":566,"cacheRead":54339,"cacheCreate":33936,"messages":4,"total":54915,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:24:45.243Z","lastActive":"2026-05-02T02:25:36.129Z","mtime":1777688897900,"activity":[3,3]},{"id":"2f4ebc7b-266","model":"claude-sonnet-4.6","cli":"copilot","agent":"supervisor","input":435586,"output":3704,"cacheRead":396818,"cacheCreate":38328,"messages":13,"toolCalls":24,"total":836108,"estimated":false,"project":"copilot-session","started":"2026-05-02T02:14:45.690Z","lastActive":"2026-05-02T02:26:46.811Z","mtime":1777688806816,"activity":[14,0]},{"id":"eb0ead67-aca","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":577,"cacheRead":54341,"cacheCreate":33945,"messages":4,"total":54928,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:21:00.026Z","lastActive":"2026-05-02T02:21:17.632Z","mtime":1777688673931,"activity":[3,3]},{"id":"4ee05864-096","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":564,"cacheRead":54337,"cacheCreate":33932,"messages":4,"total":54911,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:17:29.581Z","lastActive":"2026-05-02T02:18:28.717Z","mtime":1777688449327,"activity":[3,3]},{"id":"39c7dcb2-1a7","model":"claude-opus-4.6","cli":"copilot","agent":"scanner","input":108160,"output":9013,"cacheRead":63093,"cacheCreate":0,"messages":2,"toolCalls":2,"total":180267,"estimated":true,"project":"copilot-session","started":"2026-05-02T02:17:33.151Z","lastActive":"2026-05-02T02:17:48.692Z","mtime":1777688269227,"activity":[1,2]},{"id":"473ef22f-dd9","model":"claude-opus-4.6","cli":"copilot","agent":"scanner","input":59784,"output":196,"cacheRead":29743,"cacheCreate":30037,"messages":2,"toolCalls":2,"total":89723,"estimated":false,"project":"copilot-session","started":"2026-05-02T01:57:03.553Z","lastActive":"2026-05-02T02:17:33.011Z","mtime":1777688253015,"activity":[3,0]},{"id":"979914c3-f6b","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":569,"cacheRead":54340,"cacheCreate":34083,"messages":4,"total":54919,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:13:39.943Z","lastActive":"2026-05-02T02:14:13.855Z","mtime":1777688227164,"activity":[6,0]},{"id":"b64cff50-ed2","model":"claude-haiku-4-5-20251001","cli":"claude","agent":"dog-alpha","input":123,"output":5222,"cacheRead":1042839,"cacheCreate":65402,"messages":26,"total":1048184,"project":"-Users-andan02-gt-deacon-dogs-alpha","started":"2026-05-02T02:13:59.985Z","lastActive":"2026-05-02T02:16:41.226Z","mtime":1777688201980,"activity":[16,27]},{"id":"1efd26a7-bea","model":"claude-sonnet-4.6","cli":"copilot","agent":"reviewer","input":1659464,"output":138288,"cacheRead":968020,"cacheCreate":0,"messages":25,"toolCalls":41,"total":2765774,"estimated":true,"project":"copilot-session","started":"2026-05-02T02:11:48.573Z","lastActive":"2026-05-02T02:15:09.960Z","mtime":1777688110766,"activity":[13,13]},{"id":"0bb2a243-245","model":"claude-sonnet-4.6","cli":"copilot","agent":"supervisor","input":897969,"output":11662,"cacheRead":844400,"cacheCreate":51804,"messages":21,"toolCalls":44,"total":1754031,"estimated":false,"project":"copilot-session","started":"2026-05-02T02:00:00.356Z","lastActive":"2026-05-02T02:14:45.665Z","mtime":1777688085667,"activity":[22,0]},{"id":"596a9386-dc7","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":569,"cacheRead":54339,"cacheCreate":33937,"messages":4,"total":54918,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:10:13.326Z","lastActive":"2026-05-02T02:11:08.778Z","mtime":1777688008759,"activity":[3,3]},{"id":"183b7a68-ffe","model":"claude-sonnet-4.6","cli":"copilot","agent":"reviewer","input":7649532,"output":33866,"cacheRead":7408846,"cacheCreate":238663,"messages":101,"toolCalls":146,"total":15092244,"estimated":false,"project":"copilot-session","started":"2026-05-02T01:51:43.713Z","lastActive":"2026-05-02T02:11:48.393Z","mtime":1777687908396,"activity":[70,32]},{"id":"5e752a97-d12","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":558,"cacheRead":54338,"cacheCreate":33933,"messages":4,"total":54906,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:05:54.135Z","lastActive":"2026-05-02T02:07:04.755Z","mtime":1777687784920,"activity":[3,3]},{"id":"a8b9510e-d44","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":566,"cacheRead":54340,"cacheCreate":33939,"messages":4,"total":54916,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T02:01:26.650Z","lastActive":"2026-05-02T02:02:18.064Z","mtime":1777687534968,"activity":[3,3]},{"id":"a037711e-ef3","model":"claude-sonnet-4.6","cli":"copilot","agent":"supervisor","input":729432,"output":4229,"cacheRead":699178,"cacheCreate":29727,"messages":21,"toolCalls":33,"total":1432839,"estimated":false,"project":"copilot-session","started":"2026-05-02T01:46:58.500Z","lastActive":"2026-05-02T01:59:59.992Z","mtime":1777687200005,"activity":[22,0]},{"id":"3ca77d22-24a","model":"claude-opus-4-6","cli":"claude","agent":"boot","input":10,"output":575,"cacheRead":54342,"cacheCreate":33948,"messages":4,"total":54927,"project":"-Users-andan02-gt-deacon-dogs-boot","started":"2026-05-02T01:55:13.205Z","lastActive":"2026-05-02T01:56:50.772Z","mtime":1777687167049,"activity":[3,3]}],"weekly":{"totals":{"input":767788901,"output":21107825,"cacheRead":6140056059,"sessions":782},"totalTokens":6928952785,"billableTokens":788896726,"byAgent":{"boot":{"input":3986,"output":226426,"cacheRead":21751855,"sessions":397},"unknown":{"input":181209,"output":15442973,"cacheRead":5333366643,"sessions":19},"dog-alpha":{"input":5512,"output":221322,"cacheRead":49361481,"sessions":52},"scanner":{"input":202772449,"output":1494013,"cacheRead":191729976,"sessions":95},"supervisor":{"input":136136265,"output":1149960,"cacheRead":128727270,"sessions":139},"reviewer":{"input":282834859,"output":1712502,"cacheRead":274957829,"sessions":67},"outreach":{"input":48271199,"output":241920,"cacheRead":46769480,"sessions":8},"architect":{"input":97583422,"output":618709,"cacheRead":93391525,"sessions":5}},"resetDay":4},"hourlyBurnRate":{"total":4166564593,"billable":29405556,"byAgent":{"boot":801482,"unknown":4129865335,"dog-alpha":1904164,"supervisor":10071369,"scanner":512316,"reviewer":23409927},"byAgentBillable":{"boot":8631,"unknown":11960474,"dog-alpha":9908,"supervisor":5175659,"scanner":302202,"reviewer":11948682}}},"issueToMerge":{"avg_minutes":162,"median_minutes":55,"p90_minutes":167,"count":78,"fastest_minutes":8,"slowest_minutes":6240,"updated_at":"2026-05-02T02:30:35Z","history":[{"t":1777593600000,"avg":150,"median":173},{"t":1777615200000,"avg":421,"median":44},{"t":1777636800000,"avg":106,"median":135},{"t":1777658400000,"avg":72,"median":55}]},"ghRateLimits":{"alerts":[],"pullbacks":[],"updated_at":"2026-05-02T02:31:59+00:00"},"summaries":{"supervisor":{"task":"Processing kick","progress":"Kick delivered, agent working","results":"","updated":"2026-05-02T02:26:47+00:00","status":"WORKING","evidence":""},"scanner":{"task":"Processing kick","progress":"Kick delivered, agent working","results":"","updated":"2026-05-02T02:17:38+00:00","status":"WORKING","evidence":""},"reviewer":{"task":"Processing kick","progress":"Kick delivered, agent working","results":"","updated":"2026-05-02T02:31:56+00:00","status":"WORKING","evidence":""},"architect":{"task":"Architect pass — implementing HIGH priority refactors","progress":"3 PRs open (#11298 visual-test-strictness, #11299 strict-api-mock, MCP refactor in progress). Assessing remaining HIGH items.","results":"","updated":"2026-05-01T16:55:43Z","status":"WORKING","evidence":"PR#11298 opened 12:49PM, PR#11299 opened 12:51PM, mcp-refactor agent running"},"outreach":{"task":"Pass 79 complete","progress":"Closed, all tasks finished","results":"5 new PRs opened, 3 violations fixed, 1 PR updated (alphabetical order)","updated":"2026-05-01T17:08:55Z","status":"DONE","evidence":"DhanushNehru/awesome-mcp-servers#18, Sagargupta16/awesome-mcp-servers#46, rocksun/awesome-aiops#1, guiofsaints/awesome-platform#1, hireblackout/awesome-mcp-servers#16"}}});
+
+    // Git version
+    const _v = {"hash":"b1e9aae281d7bf09a21650fe89ac4be87f77da85","short":"b1e9aae","behind":0,"dirty":false,"ts":1777688971572};
+    const _gv = document.getElementById('git-version');
+    if (_gv && _v.short) {
+      let _html = '<span style="color:inherit">' + _v.short + '</span>';
+      if (_v.dirty) _html += ' <span class="git-dirty">*</span>';
+      if (_v.behind > 0) _html += ' <span class="git-behind">' + _v.behind + ' behind</span>';
+      _gv.innerHTML = _html;
+    }
+
+    // Format snapshot timestamp
+    const _snapTs = '2026-05-02T02:32:21.558Z';
+    const _snapEl = document.getElementById('snap-time');
+    if (_snapEl) {
+      const d = new Date(_snapTs);
+      _snapEl.textContent = d.toLocaleDateString([], {month:'short',day:'numeric',year:'numeric'}) +
+        ' ' + d.toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
+    }
+
+    // Disable interactive functions
+    function kick() {}
+    function switchCli() {}
+    function switchModel() {}
+  
+  </script>
+</body>
+</html>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,7 @@ export default function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!docs|api|_next|_vercel|agenda|blog|code|community|drive|infomercial|join_us|joinus|ladder_stats|linkedin|quickstart|slack|survey|tv|youtube|.*\\..*).*)",
+    "/((?!docs|api|live|_next|_vercel|agenda|blog|code|community|drive|infomercial|join_us|joinus|ladder_stats|linkedin|quickstart|slack|survey|tv|youtube|.*\\..*).*)",
     "/",
   ],
 };


### PR DESCRIPTION
## Summary
- Adds a static snapshot of the hive dashboard at `kubestellar.io/live/hive`
- Self-contained HTML file with all data baked in at build time
- Renders the full dashboard (governor, cadence matrix, token usage, repos, agents) in read-only mode
- Interactive controls (kick, CLI switch, model switch) are hidden
- "Read-only snapshot" banner shows capture timestamp

## Test plan
- [ ] Deploy preview serves `/live/hive/` with the full dashboard
- [ ] No JavaScript errors in console
- [ ] All dashboard sections render (governor, tokens, repos, beads, agents)
- [ ] No interactive buttons visible
- [ ] Does not affect any existing routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)