### PR TITLE
fix: add hive project routing and static generation

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -18,6 +18,7 @@ function getProjectFromSlug(slug: string[]): ProjectId {
     if (slug[0] === 'multi-plugin') return 'multi-plugin'
     if (slug[0] === 'kubestellar-mcp') return 'kubestellar-mcp'
     if (slug[0] === 'console') return 'console'
+    if (slug[0] === 'hive') return 'hive'
     if (slug[0] === 'kubestellar') return 'kubestellar'
   }
   return 'kubestellar'
@@ -544,6 +545,14 @@ export async function generateStaticParams() {
   for (const route of Object.keys(consoleMap.routeMap)) {
     if (route !== '') {
       allParams.push({ slug: ['console', ...route.split('/')] })
+    }
+  }
+
+  // Hive routes (prefixed with 'hive')
+  const hiveMap = buildPageMap('hive')
+  for (const route of Object.keys(hiveMap.routeMap)) {
+    if (route !== '') {
+      allParams.push({ slug: ['hive', ...route.split('/')] })
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `hive` to `getProjectFromSlug()` so `/docs/hive/*` routes resolve to the hive project instead of falling through to kubestellar
- Adds hive routes to `generateStaticParams()` so all hive pages are pre-rendered at build time

Without this fix, all `/docs/hive/*` URLs (e.g. `/docs/hive/overview/introduction`) hit a Next.js runtime error — the page renders the error boundary instead of content.

Fixes the broken hive introduction page at `kubestellar.io/docs/hive/overview/introduction`.

## Test plan
- [x] `npx next build` succeeds — hive pages appear in `.next/server/app/docs/hive/overview/`
- [ ] Verify `/docs/hive/overview/introduction` renders correctly on the Netlify deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)