### PR TITLE
📖 Update kubestellar-mcp docs to v0.8.17

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -174,8 +174,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.8.16 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.8.16",
+        "label": "v0.8.17 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.8.17",
         "isDefault": true
       },
       "main": {
@@ -187,6 +187,11 @@
       "0.8.1": {
         "label": "v0.8.1",
         "branch": "docs/kubestellar-mcp/0.8.1",
+        "isDefault": false
+      },
+      "0.8.16": {
+        "label": "v0.8.16",
+        "branch": "docs/kubestellar-mcp/0.8.16",
         "isDefault": false
       }
     }
@@ -220,7 +225,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.8.16"
+      "currentVersion": "0.8.17"
     }
   },
   "relatedProjects": [
@@ -267,5 +272,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-04-26T05:56:19.512Z"
+  "updatedAt": "2026-05-03T06:07:44.456Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -186,8 +186,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.8.16 (Latest)",
-    branch: "docs/kubestellar-mcp/0.8.16",
+    label: "v0.8.17 (Latest)",
+    branch: "docs/kubestellar-mcp/0.8.17",
     isDefault: true,
   },
   main: {
@@ -195,6 +195,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.8.16": {
+    label: "v0.8.16",
+    branch: "docs/kubestellar-mcp/0.8.16",
+    isDefault: false,
   },
   "0.8.1": {
     label: "v0.8.1",


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.8.17.

- Created branch: `docs/kubestellar-mcp/0.8.17`
- Source: kubestellar/kubestellar-mcp@v0.8.17

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release