### PR TITLE
fix: chunk pagination to avoid GitHub 422 on large repos

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -153,21 +153,64 @@ function getLevelForPoints(totalPoints) {
 
 // ── Fetch items from GitHub REST API ──────────────────────────────────
 
-async function fetchItemsSince(repo, sinceDate) {
+const MAX_PAGES_PER_QUERY = 95;
+const CHUNK_DAYS = 30;
+
+async function fetchPagedItems(repo, sinceDate, untilDate) {
   const allItems = [];
 
-  for (let page = 1; ; page++) {
-    const url = `${API_BASE}/repos/${repo}/issues?state=all&per_page=${REST_PER_PAGE}&page=${page}&sort=created&direction=desc&since=${sinceDate}`;
+  for (let page = 1; page <= MAX_PAGES_PER_QUERY; page++) {
+    const url = `${API_BASE}/repos/${repo}/issues?state=all&per_page=${REST_PER_PAGE}&page=${page}&sort=created&direction=asc&since=${sinceDate}`;
 
     if (page > 1) await delay(REST_PAGE_DELAY_MS);
 
-    const items = await ghFetch(url);
-    allItems.push(...items);
+    let items;
+    try {
+      items = await ghFetch(url);
+    } catch (err) {
+      if (err.message.includes("422")) {
+        console.warn(`    Page ${page} hit GitHub pagination limit for ${repo}, returning ${allItems.length} items collected so far.`);
+        break;
+      }
+      throw err;
+    }
+
+    for (const item of items) {
+      if (untilDate && item.created_at >= untilDate) continue;
+      allItems.push(item);
+    }
 
     if (items.length < REST_PER_PAGE) break;
+  }
 
-    const oldest = items[items.length - 1];
-    if (oldest && oldest.created_at < sinceDate) break;
+  return allItems;
+}
+
+async function fetchItemsSince(repo, sinceDate) {
+  const since = new Date(sinceDate);
+  const now = new Date();
+  const totalDays = Math.ceil((now - since) / (86400 * 1000));
+
+  if (totalDays <= CHUNK_DAYS) {
+    return fetchPagedItems(repo, sinceDate, null);
+  }
+
+  const allItems = [];
+  let chunkStart = new Date(since);
+
+  while (chunkStart < now) {
+    const chunkEnd = new Date(chunkStart);
+    chunkEnd.setUTCDate(chunkEnd.getUTCDate() + CHUNK_DAYS);
+    const untilISO = chunkEnd < now ? chunkEnd.toISOString() : null;
+
+    const items = await fetchPagedItems(repo, chunkStart.toISOString(), untilISO);
+    allItems.push(...items);
+
+    if (items.length > 0) {
+      console.log(`    ${repo} chunk ${chunkStart.toISOString().slice(0, 10)}..${(untilISO || now.toISOString()).slice(0, 10)}: ${items.length} items`);
+    }
+
+    chunkStart = chunkEnd;
   }
 
   return allItems;


### PR DESCRIPTION
## Summary
- GitHub REST API returns HTTP 422 when paginating past page 99 for large datasets
- `kubestellar/console` has 12,000+ items in 2026 — the full rebuild fetched **0 items** from console (captured in workflow run logs: `Warning: failed to fetch kubestellar/console: GitHub API 422`)
- The snapshot saved after the first full run only had 2,366 items (all from the other 3 repos)
- clubanderson's score dropped from the broken-but-partially-working 3.6M to 1.59M because console data was missing entirely

## Fix
- Split large date ranges into 30-day chunks so each query stays well under the ~9,900 item pagination limit
- Handle 422 errors gracefully within chunks (return items collected so far instead of throwing)
- Each 30-day chunk for console has ~2,400 items (24 pages) — well under the limit

## Test plan
- [ ] Trigger workflow with `full=true` and `force=true` after merge
- [ ] Verify workflow logs show `kubestellar/console` returning 12,000+ items across chunks
- [ ] Verify clubanderson's score exceeds the 3,684,000 baseline
- [ ] Verify all contributors meet or exceed their previous scores

Fixes the regression introduced in #1724 where the full rebuild silently lost all console data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)