### PR TITLE
docs: add requirements enforcement note to ladder levels

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -640,6 +640,7 @@
     "titleSpan": "Ladder",
     "subtitle": "A transparent, merit-based path from first-time contributor to trusted maintainer in the KubeStellar community",
     "requirementsLabel": "Requirements:",
+    "requirementsNote": "Failure to meet these requirements may result in removal from the program or title revocation.",
     "goodStandingLabel": "Opportunities in Good Standing:",
     "nextLevelLabel": "Next Level:",
     "statsQuestion": "How do we audit our contributor ladder?",

--- a/src/app/[locale]/ladder/page.tsx
+++ b/src/app/[locale]/ladder/page.tsx
@@ -333,6 +333,9 @@ export default function MaintainerLadderPage() {
                             </li>
                           ))}
                         </ul>
+                        <p className="text-xs text-amber-400/80 italic mt-2">
+                          {t("requirementsNote")}
+                        </p>
                       </div>
 
                       {level.goodStanding && (
@@ -425,6 +428,9 @@ export default function MaintainerLadderPage() {
                               </li>
                             ))}
                           </ul>
+                          <p className="text-xs text-amber-400/80 italic mt-3">
+                            {t("requirementsNote")}
+                          </p>
                         </div>
 
                         {level.goodStanding && (


### PR DESCRIPTION
## Summary
- Adds a note beneath each level's requirements: *"Failure to meet these requirements may result in removal from the program or title revocation."*
- Displayed in amber/italic text on both mobile and desktop layouts

## Test plan
- [ ] Verify note appears under each level's requirements on deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)