### PR TITLE
feat: post Netlify deploy errors as PR comments

### DIFF
--- a/.github/workflows/netlify-error-reporter.yml
+++ b/.github/workflows/netlify-error-reporter.yml
@@ -1,0 +1,113 @@
+name: netlify-error-reporter
+
+on:
+  status:
+    # Fires when Netlify posts commit status updates
+
+jobs:
+  report-netlify-failure:
+    if: >-
+      github.event.state == 'failure' &&
+      contains(github.event.context, 'netlify')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: read
+    steps:
+      - name: Find PR for this commit
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMIT_SHA="${{ github.event.sha }}"
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+            --jq '.[0].number // empty' 2>/dev/null || true)
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch Netlify deploy error
+        if: steps.find-pr.outputs.pr_number != ''
+        id: netlify
+        env:
+          NETLIFY_API_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
+        run: |
+          SITE_ID="f24d63c2-83cc-4384-a3db-b0db089c7091"
+          COMMIT_SHA="${{ steps.find-pr.outputs.commit_sha }}"
+
+          # Find the deploy for this commit
+          DEPLOY_JSON=$(curl -sf \
+            -H "Authorization: Bearer ${NETLIFY_API_TOKEN}" \
+            "https://api.netlify.com/api/v1/sites/${SITE_ID}/deploys?per_page=20" \
+            | jq --arg sha "$COMMIT_SHA" '[.[] | select(.commit_ref == $sha)] | first // empty')
+
+          if [ -z "$DEPLOY_JSON" ] || [ "$DEPLOY_JSON" = "null" ]; then
+            echo "No deploy found for commit ${COMMIT_SHA}"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DEPLOY_ID=$(echo "$DEPLOY_JSON" | jq -r '.id')
+          ERROR_MSG=$(echo "$DEPLOY_JSON" | jq -r '.error_message // empty')
+          DEPLOY_STATE=$(echo "$DEPLOY_JSON" | jq -r '.state')
+          DEPLOY_URL=$(echo "$DEPLOY_JSON" | jq -r '.deploy_url // empty')
+          ADMIN_URL=$(echo "$DEPLOY_JSON" | jq -r '.admin_url // empty')
+
+          if [ -z "$ERROR_MSG" ] && [ "$DEPLOY_STATE" = "error" ]; then
+            # Try the deploy log endpoint for more detail
+            LOG_OUTPUT=$(curl -sf \
+              -H "Authorization: Bearer ${NETLIFY_API_TOKEN}" \
+              "https://api.netlify.com/api/v1/deploys/${DEPLOY_ID}/log" \
+              | jq -r '.[] | select(.section == "building" or .section == "preparation") | .message' \
+              | grep -i "error\|fail\|fatal" | head -5 || true)
+            if [ -n "$LOG_OUTPUT" ]; then
+              ERROR_MSG="$LOG_OUTPUT"
+            else
+              ERROR_MSG="Deploy failed (no error message available — check Netlify dashboard)"
+            fi
+          fi
+
+          if [ -n "$ERROR_MSG" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "deploy_id=${DEPLOY_ID}" >> "$GITHUB_OUTPUT"
+            # Use a temp file for multiline error messages
+            echo "$ERROR_MSG" > /tmp/netlify_error.txt
+            echo "admin_url=${ADMIN_URL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post error comment on PR
+        if: steps.netlify.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ steps.find-pr.outputs.pr_number }}"
+          DEPLOY_ID="${{ steps.netlify.outputs.deploy_id }}"
+          ADMIN_URL="${{ steps.netlify.outputs.admin_url }}"
+          ERROR_MSG=$(cat /tmp/netlify_error.txt)
+
+          # Check if we already commented on this deploy (avoid duplicates)
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | contains(\"${DEPLOY_ID}\"))] | length" 2>/dev/null || echo "0")
+
+          if [ "$EXISTING" != "0" ]; then
+            echo "Already commented on deploy ${DEPLOY_ID}, skipping"
+            exit 0
+          fi
+
+          BODY=$(cat <<EOF
+          ## Netlify Deploy Preview Failed
+
+          **Deploy ID:** \`${DEPLOY_ID}\`
+          **Dashboard:** ${ADMIN_URL}
+
+          \`\`\`
+          ${ERROR_MSG}
+          \`\`\`
+
+          <sub>Posted by netlify-error-reporter workflow</sub>
+          EOF
+          )
+
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="$BODY"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow triggered by Netlify commit status failures
- Queries the Netlify API for the deploy error message using `NETLIFY_API_TOKEN` repo secret
- Posts the error as a PR comment so agents and humans can see why the build failed without logging into Netlify

This unblocks autonomous merge workflows — previously Netlify errors were only visible on the Netlify dashboard, causing the scanner to stall on failing PRs with no way to diagnose the issue.

## Test plan

- [ ] Verify workflow triggers on a Netlify deploy failure (introduce a bad config temporarily)
- [ ] Verify comment is posted with the correct error message
- [ ] Verify duplicate comments are not posted for the same deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)