### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@88f4d5fff50ceea648cdd3848ed1835ebded5fe3
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@88f4d5fff50ceea648cdd3848ed1835ebded5fe3
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  pull-requests: read
-
 jobs:
   copilot-dco:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@88f4d5fff50ceea648cdd3848ed1835ebded5fe3
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:

**Standard Workflows:**
- `add-help-wanted.yml` - Add help-wanted label to issues
- `assignment-helper.yml` - Handle issue assignments
- `feedback.yml` - Collect feedback
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - Security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Assign Copilot to issues with `ai-fix-requested` label
- `copilot-automation.yml` - Automate Copilot PR processing (DCO, labels)
- `copilot-dco.yml` - Override DCO for Copilot PRs

Auto-generated by workflow sync