### PR TITLE
Fix ACMM history cron to 10pm EDT (02:00 UTC)

### DIFF
--- a/.github/workflows/generate-acmm-history.yml
+++ b/.github/workflows/generate-acmm-history.yml
@@ -2,8 +2,8 @@ name: Generate ACMM History
 
 on:
   schedule:
-    # Mon, Wed, Fri, Sun at 03:00 UTC
-    - cron: '0 3 * * 0,1,3,5'
+    # Mon, Wed, Fri, Sun at 10pm EDT (02:00 UTC) — quiet period for token budget
+    - cron: '0 2 * * 0,1,3,5'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary

- Shifts ACMM history scan from 03:00 UTC to 02:00 UTC (10pm EDT)
- Runs during quiet period when repo token budget is available

One-line cron change.

## Test plan

- [ ] Verify cron expression `0 2 * * 0,1,3,5` = Mon/Wed/Fri/Sun at 02:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)