### PR TITLE
Switch ACMM scanner to dedicated GitHub App token

### DIFF
--- a/.github/workflows/generate-acmm-history.yml
+++ b/.github/workflows/generate-acmm-history.yml
@@ -15,9 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ACMM_APP_ID }}
+          private-key: ${{ secrets.ACMM_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -25,7 +32,7 @@ jobs:
 
       - name: Generate ACMM history
         env:
-          GITHUB_TOKEN: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: node scripts/generate-acmm-history.mjs
 
       - name: Commit and push if changed
@@ -52,7 +59,7 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const tag = '[acmm-history-failure]';
             const { data: issues } = await github.rest.issues.listForRepo({


### PR DESCRIPTION
## Summary

- Replaces `LEADERBOARD_GITHUB_TOKEN` (personal) with dedicated `acmm-scanner` GitHub App
- App has read-only `Contents` + `Metadata` permissions — minimum needed for Tree API
- Separate 5,000 req/hr rate limit, doesn't burn personal token budget
- Secrets: `ACMM_APP_ID` and `ACMM_APP_PRIVATE_KEY` (already configured)

## Test plan

- [ ] Trigger workflow manually after merge — verify scan completes with app token
- [ ] Check `acmm-history.json` is updated with new data point

🤖 Generated with [Claude Code](https://claude.com/claude-code)