### PR TITLE
Fix ACMM level computation: proper threshold walk

### DIFF
--- a/scripts/generate-acmm-history.mjs
+++ b/scripts/generate-acmm-history.mjs
@@ -443,6 +443,7 @@ async function main() {
 
   console.log(`Scanning ${REPOS.length} repos for ${today}...`)
   const scores = {}
+  const latestDetectedIds = {}
   let scanned = 0
   let failed = 0
 
@@ -451,9 +452,11 @@ async function main() {
 
     if (data?.detectedIds) {
       scores[repo] = data.detectedIds.length
+      latestDetectedIds[repo] = data.detectedIds
     } else {
       const prev = history.scores[repo]
       scores[repo] = prev?.length ? prev[prev.length - 1] : 0
+      latestDetectedIds[repo] = history.detectedIds?.[repo] ?? []
       failed++
     }
 
@@ -473,6 +476,9 @@ async function main() {
     if (!history.scores[repo]) history.scores[repo] = []
     history.scores[repo].push(scores[repo] ?? 0)
   }
+
+  // Store detectedIds for latest scan only (used for proper level computation)
+  history.detectedIds = latestDetectedIds
 
   // Trim to MAX_DATA_POINTS (26 weeks × 4 scans/week = 104)
   while (history.dates.length > MAX_DATA_POINTS) {

--- a/src/app/[locale]/acmm-leaderboard/page.tsx
+++ b/src/app/[locale]/acmm-leaderboard/page.tsx
@@ -87,6 +87,50 @@ const CUMULATIVE_SCANNABLE: Record<number, number> = {};
 const TOTAL_CRITERIA = 65;
 const TOTAL_SCANNABLE = 34;
 
+// ── Level computation (mirrors computeLevel.ts from console) ─────────
+// Scannable criterion IDs per level — L2 uses the virtual OR-group.
+// Must stay in sync with scannableIdsByLevel.ts in kubestellar/console.
+
+const AGENT_INSTRUCTION_IDS = new Set([
+  "acmm:claude-md", "acmm:copilot-instructions",
+  "acmm:agents-md", "acmm:cursor-rules",
+]);
+
+const SCANNABLE_IDS_BY_LEVEL: Record<number, string[]> = {
+  2: ["acmm:agent-instructions", "acmm:prompts-catalog", "acmm:editor-config"],
+  3: ["acmm:pr-acceptance-metric", "acmm:pr-review-rubric", "acmm:quality-dashboard", "acmm:ci-matrix"],
+  4: ["acmm:auto-qa-tuning", "acmm:nightly-compliance", "acmm:copilot-review-apply", "acmm:layered-safety", "acmm:risk-assessment-config", "acmm:auto-schema-lint", "acmm:copilot-workspace"],
+  5: ["acmm:github-actions-ai", "acmm:auto-qa-self-tuning", "acmm:public-metrics", "acmm:auto-deprecation-enforcer", "acmm:pipeline-as-code", "acmm:self-healing-ci"],
+  6: ["acmm:auto-issue-gen", "acmm:multi-agent-orchestration", "acmm:merge-queue", "acmm:auto-rollback", "acmm:dependency-auto-upgrade", "acmm:auto-changelog"],
+};
+
+const LEVEL_COMPLETION_THRESHOLD = 0.7;
+const MIN_LEVEL = 1;
+const MAX_LEVEL = 6;
+
+function levelFromDetectedIds(rawIds: string[]): number {
+  const detected = new Set(rawIds);
+  // Synthesise virtual OR-group: any instruction file → virtual ID
+  for (const id of AGENT_INSTRUCTION_IDS) {
+    if (detected.has(id)) { detected.add("acmm:agent-instructions"); break; }
+  }
+  // Threshold walk L2–L6
+  let level = MIN_LEVEL;
+  for (let n = MIN_LEVEL + 1; n <= MAX_LEVEL; n++) {
+    const required = SCANNABLE_IDS_BY_LEVEL[n];
+    if (!required?.length) continue;
+    const met = required.filter((id) => detected.has(id)).length;
+    const threshold = n === 2 ? 1 / required.length : LEVEL_COMPLETION_THRESHOLD;
+    if (met / required.length >= threshold) {
+      level = n;
+    } else {
+      break;
+    }
+  }
+  return level;
+}
+
+/** Fallback: estimate level from score count when detectedIds unavailable. */
 function levelFromScore(score: number): number {
   const levels = [6, 5, 4, 3, 2, 1, 0] as const;
   for (const lvl of levels) {
@@ -127,6 +171,8 @@ function ScoreBar({ score, level }: { score: number; level: number }) {
 interface AcmmHistory {
   dates: string[];
   scores: Record<string, number[]>;
+  /** Detected criterion IDs from the latest scan (used for proper level computation). */
+  detectedIds?: Record<string, string[]>;
   generated_at?: string;
 }
 
@@ -558,7 +604,11 @@ export default function AcmmLeaderboardPage() {
       const scores = history.scores[p.repo];
       if (!scores?.length) return p;
       const latestScore = scores[scores.length - 1];
-      return { ...p, score: latestScore, level: levelFromScore(latestScore) };
+      const ids = history.detectedIds?.[p.repo];
+      const level = ids?.length
+        ? levelFromDetectedIds(ids)
+        : levelFromScore(latestScore);
+      return { ...p, score: latestScore, level };
     });
   }, [history]);
 


### PR DESCRIPTION
## Summary

The naive `levelFromScore` was computing levels wrong. A project with 22 total criteria was rated L4, but most detections were L0 prerequisites and bonus AEF/fullsend criteria — actual L3 completion was only 25% (needs 70%).

**Example: backstage/backstage**
- Before: 22 criteria → L4 (wrong — counted total, not per-level)
- After: 22 criteria → L2 (correct — only 1/4 L3 criteria met, threshold is 70%)

### Changes
- **`generate-acmm-history.mjs`**: Now stores `detectedIds` (criterion ID arrays) for the latest scan alongside score history
- **`page.tsx`**: Proper threshold walk mirroring `computeLevel.ts` from console:
  - L2 "Instructed": needs any 1 of 3 scannable criteria (33%)
  - L3–L6: needs ≥70% of scannable criteria at each level
  - Walk breaks at first failed level (no skipping)
  - Falls back to score-based estimate when `detectedIds` unavailable

## Test plan

- [ ] Trigger workflow to populate `detectedIds` in history JSON
- [ ] Verify backstage/backstage shows L2 (not L4)
- [ ] Verify kubestellar/console shows correct level
- [ ] Verify level pill counts update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)