### PR TITLE
Fix ACMM leaderboard: sync scannable IDs with console

### DIFF
--- a/src/app/[locale]/acmm-leaderboard/page.tsx
+++ b/src/app/[locale]/acmm-leaderboard/page.tsx
@@ -96,12 +96,13 @@ const AGENT_INSTRUCTION_IDS = new Set([
   "acmm:agents-md", "acmm:cursor-rules",
 ]);
 
+// Synced from kubestellar/console web/src/lib/acmm/scannableIdsByLevel.ts
 const SCANNABLE_IDS_BY_LEVEL: Record<number, string[]> = {
   2: ["acmm:agent-instructions", "acmm:prompts-catalog", "acmm:editor-config"],
   3: ["acmm:pr-acceptance-metric", "acmm:pr-review-rubric", "acmm:quality-dashboard", "acmm:ci-matrix"],
-  4: ["acmm:auto-qa-tuning", "acmm:nightly-compliance", "acmm:copilot-review-apply", "acmm:layered-safety", "acmm:risk-assessment-config", "acmm:auto-schema-lint", "acmm:copilot-workspace"],
-  5: ["acmm:github-actions-ai", "acmm:auto-qa-self-tuning", "acmm:public-metrics", "acmm:auto-deprecation-enforcer", "acmm:pipeline-as-code", "acmm:self-healing-ci"],
-  6: ["acmm:auto-issue-gen", "acmm:multi-agent-orchestration", "acmm:merge-queue", "acmm:auto-rollback", "acmm:dependency-auto-upgrade", "acmm:auto-changelog"],
+  4: ["acmm:auto-qa-tuning", "acmm:nightly-compliance", "acmm:copilot-review-apply", "acmm:auto-label", "acmm:ai-fix-workflow", "acmm:tier-classifier", "acmm:security-ai-md"],
+  5: ["acmm:github-actions-ai", "acmm:auto-qa-self-tuning", "acmm:public-metrics", "acmm:policy-as-code", "acmm:reflection-log", "acmm:audit-trail"],
+  6: ["acmm:auto-issue-gen", "acmm:multi-agent-orchestration", "acmm:merge-queue", "acmm:strategic-dashboard", "acmm:risk-assessment-config", "acmm:observability-runbook"],
 };
 
 const LEVEL_COMPLETION_THRESHOLD = 0.7;


### PR DESCRIPTION
## Summary
- Sync `SCANNABLE_IDS_BY_LEVEL` in the leaderboard page with the console's `scannableIdsByLevel.ts` (source of truth)
- L4-L6 had stale criteria IDs (e.g., `layered-safety`, `auto-schema-lint`, `copilot-workspace`) that no longer exist
- Correct IDs: L4 now has `auto-label, ai-fix-workflow, tier-classifier, security-ai-md`; L5 has `policy-as-code, reflection-log, audit-trail`; L6 has `strategic-dashboard, risk-assessment-config, observability-runbook`

## Impact
Console was showing as L3 instead of L5+ because 3 of 7 L4 criteria were phantom IDs that could never be detected.

## Test plan
- [ ] After deploy, verify console shows L5+ on leaderboard
- [ ] Verify Backstage still shows L2 (only has L3 1/4 = 25%, below 70%)