### PR TITLE
Clarify Kubernetes secrets, environment variable documentation and fix subheading casing

### DIFF
--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -141,8 +141,8 @@ For the complete kubeconfig-driven registration flow, including required format,
 Choose your deployment method:
 
 - [Curl one-liner](#curl-quickstart) - Fastest, downloads pre-built binaries
-- [Run from source (no OAuth)](#run-from-source) - For development, no GitHub credentials needed
-- [Run from source (with OAuth)](#run-from-source-with-oauth) - Full GitHub login experience
+- [Run From Source (no OAuth)](#run-from-source) - For development, no GitHub credentials needed
+- [Run From Source (with OAuth)](#run-from-source-with-oauth) - Full GitHub login experience
 - [Helm (Kubernetes)](#helm-installation) - Production deployment
 - [OpenShift](#openshift-installation) - OpenShift with Routes
 - [Docker](#docker-installation) - Single-node or development
@@ -703,7 +703,7 @@ brew install kubestellar-ops kubestellar-deploy
 
 **Solutions**:
 1. Verify the secret contains correct credentials
-2. Check callback URL matches exactly (see [Run from Source with OAuth](#run-from-source-with-oauth))
+2. Check callback URL matches exactly (see [Run From Source with OAuth](#run-from-source-with-oauth))
 3. View pod logs: `kubectl logs -n ksc deployment/ksc-kubestellar-console`
 
 ### "GITHUB_CLIENT_SECRET is not set"
@@ -711,7 +711,7 @@ brew install kubestellar-ops kubestellar-deploy
 **Cause**: You're running `startup-oauth.sh` without a `.env` file.
 
 **Solutions**:
-1. Create a `.env` file with `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` (see [Run from Source with OAuth](#run-from-source-with-oauth))
+1. Create a `.env` file with `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` (see [Run From Source with OAuth](#run-from-source-with-oauth))
 2. Or use `./start-dev.sh` instead — it doesn't require OAuth credentials
 
 ### "exchange_failed" After GitHub Login

--- a/docs/content/console/installation.md
+++ b/docs/content/console/installation.md
@@ -161,7 +161,7 @@ This starts the backend (port 8080) and opens the frontend in your browser. No O
 
 ---
 
-## Run from Source
+## Run From Source
 
 For contributors or if you want to build from source. No GitHub OAuth required.
 
@@ -185,7 +185,7 @@ Open http://localhost:5174
 
 ---
 
-## Run from Source with OAuth
+## Run From Source with OAuth
 
 To enable GitHub login (for multi-user deployments or to test the full auth flow):
 

--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -243,7 +243,7 @@ Before proceeding with the installation, you need to configure GitHub OAuth, whi
    GITHUB_CLIENT_SECRET=your_client_secret
    ```
 
-3. Make the environment variables available to Kubernetes Secrets:
+3. Export the environment variables into your current shell so the upcoming `kubectl create secret` command can use them:
 	```bash	
 	export $(cat .env | xargs)
 	```

--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -243,7 +243,7 @@ Before proceeding with the installation, you need to configure GitHub OAuth, whi
    GITHUB_CLIENT_SECRET=your_client_secret
    ```
 
-3. Make the environment variables available to Helm:
+3. Make the environment variables available to Kubernetes Secrets:
 	```bash	
 	export $(cat .env | xargs)
 	```

--- a/docs/content/console/quickstart.md
+++ b/docs/content/console/quickstart.md
@@ -244,7 +244,7 @@ Before proceeding with the installation, you need to configure GitHub OAuth, whi
    ```
 
 3. Export the environment variables into your current shell so the upcoming `kubectl create secret` command can use them:
-	```bash	
+	```bash
 	export $(cat .env | xargs)
 	```
 


### PR DESCRIPTION
This PR updates
1. `docs/content/console/installation.md` and `docs/content/console/console-features.md ` to align the casing to keep subheading style consistent.
2. Making the environment variables available to `Kubernetes Secrets` instead of `Helm`
Fixes #2216