### PR TITLE
feat: add live hive dashboard links to leaderboard pages

### DIFF
--- a/src/app/[locale]/acmm-leaderboard/page.tsx
+++ b/src/app/[locale]/acmm-leaderboard/page.tsx
@@ -697,6 +697,19 @@ export default function AcmmLeaderboardPage() {
             {" "}· {TOTAL_SCANNABLE} publicly detectable signals out of {TOTAL_CRITERIA} ACMM criteria
           </p>
 
+          {/* Hive live dashboard link */}
+          <div className="mt-4 mb-2 flex justify-center">
+            <a
+              href="https://kubestellar.io/live/hive"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-purple-500/30 bg-purple-500/10 text-purple-300 text-sm hover:bg-purple-500/20 transition-colors"
+            >
+              <span>&#x1F41D;</span>
+              <span><strong>Level 6 in practice</strong> &mdash; KubeStellar/console is the only L5+ project. See the autonomous agents running live.</span>
+            </a>
+          </div>
+
           {/* Quick stats — level filters + badge filter */}
           <div className="flex flex-wrap justify-center gap-3 mt-6">
             {[6, 5, 4, 3, 2, 1, 0].map((lvl) => {

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -749,6 +749,19 @@ export default function LeaderboardPage() {
                   View Contributor Ladder
                 </Link>
               </div>
+
+              {/* Hive live dashboard link */}
+              <div className="mt-4 flex justify-center">
+                <a
+                  href="https://kubestellar.io/live/hive"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-amber-500/30 bg-amber-500/10 text-amber-300 text-sm hover:bg-amber-500/20 transition-colors"
+                >
+                  <span>&#x1F41D;</span>
+                  <span><strong>See AI agents in action</strong> &mdash; Watch 9 autonomous agents maintain these repos live</span>
+                </a>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Adds a banner link to `kubestellar.io/live/hive` on the **Contributor Leaderboard** page (`/en/leaderboard`)
- Adds a banner link to `kubestellar.io/live/hive` on the **ACMM Leaderboard** page (`/en/acmm-leaderboard`)
- Both banners use the page's existing styling (rounded card, border, hover effect)
- Leaderboard banner: amber-themed, "See AI agents in action"
- ACMM banner: purple-themed, "Level 6 in practice"

## Test plan
- [ ] Verify banner appears on `/en/leaderboard` below "View Contributor Ladder" link
- [ ] Verify banner appears on `/en/acmm-leaderboard` above the level filter buttons
- [ ] Both link to `kubestellar.io/live/hive` and open in new tab