### PR TITLE
fix: improve 404 page + redirect /hive to live dashboard

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -97,6 +97,19 @@
   # Enable spam filtering
   spam_protection = true
 
+# Redirect /hive and /:locale/hive to the live hive dashboard
+[[redirects]]
+  from = "/hive"
+  to = "/live/hive"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/en/hive"
+  to = "/live/hive"
+  status = 301
+  force = true
+
 # Serve static hive dashboard snapshot (bypass Next.js middleware)
 [[redirects]]
   from = "/live/hive"

--- a/src/components/NotFoundUI.tsx
+++ b/src/components/NotFoundUI.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { usePathname } from "next/navigation";
 import Link from "next/link";
 
 export default function NotFoundUI() {
   const t = useTranslations("notFound");
+  const pathname = usePathname();
 
   return (
     <section className="px-4 py-32 sm:px-6 lg:px-8">
@@ -16,6 +18,13 @@ export default function NotFoundUI() {
         <p className="text-xl sm:text-2xl text-gray-300 mb-8 max-w-3xl mx-auto leading-relaxed">
           {t("description")}
         </p>
+
+        {pathname && (
+          <div className="mb-8 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 border border-white/10 backdrop-blur-sm">
+            <span className="text-sm text-gray-500">Requested:</span>
+            <code className="text-sm text-purple-400 font-mono">{pathname}</code>
+          </div>
+        )}
 
         <p className="text-lg text-gray-400 max-w-2xl mx-auto mb-16">
           {t("message")}


### PR DESCRIPTION
## Summary

- **404 page now shows the requested URL** in a styled code block so users can see what path they tried
- **Added Netlify redirects** for `/hive` and `/en/hive` → `/live/hive` — previously `/hive` hit the Next.js middleware which redirected to `/en/hive` which returned a bare 404 page
- The 404 page already has the space theme (StarField, GridLines) but wasn't rendering properly for `/en/hive` — the redirect fixes that specific case, and the URL display helps with any future 404s

## Test plan

- [ ] Visit `kubestellar.io/hive` → should redirect to `/live/hive` (hive dashboard)
- [ ] Visit `kubestellar.io/en/hive` → should redirect to `/live/hive`
- [ ] Visit `kubestellar.io/en/nonexistent` → should show space-themed 404 with the attempted path displayed
- [ ] "Return Home" and "View Documentation" links work