### PR TITLE
Reorder console navigation and add cluster registration link

### DIFF
--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -199,8 +199,9 @@ const NAV_STRUCTURE_CONSOLE: Array<{ title: string; items: NavItem[] }> = [
     items: [
       { 'Introduction': 'readme.md' },
       { 'Quick Start': 'quickstart.md' },
-      { 'Installation': 'installation.md' },
       { 'Architecture': 'architecture.md' },
+      { 'Installation': 'installation.md' },
+      { 'Cluster Registration': 'cluster-registration.md' },
       { 'Agentic Quality Controls': 'agentic-quality.md' },
       { 'Demo Mode': 'demo-mode.md' },
       { 'Configuration': 'configuration.md' },


### PR DESCRIPTION

## Summary

Reorganizes the console documentation navigation structure and adds the missing `Cluster Registration` page to the console page-map.

## Changes

- Made the `Architecture` and `Installation `page appear after the `Quick Start` page, so users can better understand the console architecture before reading the installation page.
- Added `Cluster Registration` to the console page-map navigation structure. I also placed it after installation, so users can learn how to register clusters to kubestella after installation. 

## Why

This improves the documentation structure and user navigation experience.

The `Cluster Registration` documentation already exists: `https://kubestellar.io/docs/console/cluster-registration` and can be found through search, but it was not included in the console page-map navigation structure. Adding it to the navigation makes it easier for users to discover and access.

Adding it to the navigation ensures users can easily find instructions on registering clusters without relying on search.
