### PR TITLE
📖 Update kubestellar docs to v0.30.0

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -46,8 +46,8 @@
     },
     "kubestellar": {
       "latest": {
-        "label": "v0.30.0-rc.1 (Latest)",
-        "branch": "docs/0.30.0-rc.1",
+        "label": "v0.30.0 (Latest)",
+        "branch": "docs/0.30.0",
         "isDefault": true
       },
       "main": {
@@ -220,7 +220,7 @@
     "kubestellar": {
       "name": "KubeStellar",
       "basePath": "",
-      "currentVersion": "0.30.0-rc.1"
+      "currentVersion": "0.30.0"
     },
     "a2a": {
       "name": "A2A",
@@ -281,11 +281,11 @@
   ],
   "editBaseUrls": {
     "console": "https://github.com/kubestellar/docs/edit/main/docs/content/console",
-    "kubestellar": "https://github.com/kubestellar/docs/edit/docs/0.30.0-rc.1/docs/content",
+    "kubestellar": "https://github.com/kubestellar/docs/edit/docs/0.30.0/docs/content",
     "a2a": "https://github.com/kubestellar/a2a/edit/main/docs",
     "kubeflex": "https://github.com/kubestellar/kubeflex/edit/main/docs",
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-05-08T14:47:14.084Z"
+  "updatedAt": "2026-05-13T22:20:52.860Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -41,7 +41,7 @@ export interface ProjectConfig {
 const KUBESTELLAR_VERSIONS: Record<string, VersionInfo> = {
   latest: {
     label: "v0.30.0-rc.1 (Latest)",
-    branch: "docs/0.30.0-rc.1",
+    branch: "docs/0.30.0",
     isDefault: true,
   },
   main: {
@@ -136,7 +136,7 @@ const KUBESTELLAR_VERSIONS: Record<string, VersionInfo> = {
 // a2a versions
 const A2A_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.1.0 (Latest)",
+    label: "v0.30.0 (Latest)",
     branch: "docs/a2a/0.1.0",
     isDefault: true,
   },
@@ -275,7 +275,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar",
     name: "KubeStellar",
     basePath: "",
-    currentVersion: "0.30.0-rc.1",
+    currentVersion: "0.30.0",
     contentPath: "docs/content",
     versions: KUBESTELLAR_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar release v0.30.0.

- Created branch: `docs/0.30.0`
- Source: kubestellar/kubestellar@main

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release