### PR TITLE
fix: netlify reporter opens issues on direct-to-main deploy failures

### DIFF
--- a/.github/workflows/netlify-error-reporter.yml
+++ b/.github/workflows/netlify-error-reporter.yml
@@ -1,8 +1,7 @@
-name: netlify-error-reporter
+name: Netlify Deploy Failure Reporter
 
 on:
   status:
-    # Fires when Netlify posts commit status updates
 
 jobs:
   report-netlify-failure:
@@ -12,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
       statuses: read
     steps:
       - name: Find PR for this commit
@@ -26,7 +26,6 @@ jobs:
           echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Fetch Netlify deploy error
-        if: steps.find-pr.outputs.pr_number != ''
         id: netlify
         env:
           NETLIFY_API_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
@@ -34,7 +33,12 @@ jobs:
           SITE_ID="f24d63c2-83cc-4384-a3db-b0db089c7091"
           COMMIT_SHA="${{ steps.find-pr.outputs.commit_sha }}"
 
-          # Find the deploy for this commit
+          if [ -z "$NETLIFY_API_TOKEN" ]; then
+            echo "Missing NETLIFY_API_TOKEN secret"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           DEPLOY_JSON=$(curl -sf \
             -H "Authorization: Bearer ${NETLIFY_API_TOKEN}" \
             "https://api.netlify.com/api/v1/sites/${SITE_ID}/deploys?per_page=20" \
@@ -49,16 +53,14 @@ jobs:
           DEPLOY_ID=$(echo "$DEPLOY_JSON" | jq -r '.id')
           ERROR_MSG=$(echo "$DEPLOY_JSON" | jq -r '.error_message // empty')
           DEPLOY_STATE=$(echo "$DEPLOY_JSON" | jq -r '.state')
-          DEPLOY_URL=$(echo "$DEPLOY_JSON" | jq -r '.deploy_url // empty')
           ADMIN_URL=$(echo "$DEPLOY_JSON" | jq -r '.admin_url // empty')
 
           if [ -z "$ERROR_MSG" ] && [ "$DEPLOY_STATE" = "error" ]; then
-            # Try the deploy log endpoint for more detail
             LOG_OUTPUT=$(curl -sf \
               -H "Authorization: Bearer ${NETLIFY_API_TOKEN}" \
               "https://api.netlify.com/api/v1/deploys/${DEPLOY_ID}/log" \
               | jq -r '.[] | select(.section == "building" or .section == "preparation") | .message' \
-              | grep -i "error\|fail\|fatal" | head -5 || true)
+              | grep -i "error\|fail\|fatal" | head -10 || true)
             if [ -n "$LOG_OUTPUT" ]; then
               ERROR_MSG="$LOG_OUTPUT"
             else
@@ -69,15 +71,14 @@ jobs:
           if [ -n "$ERROR_MSG" ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             echo "deploy_id=${DEPLOY_ID}" >> "$GITHUB_OUTPUT"
-            # Use a temp file for multiline error messages
             echo "$ERROR_MSG" > /tmp/netlify_error.txt
             echo "admin_url=${ADMIN_URL}" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Post error comment on PR
-        if: steps.netlify.outputs.found == 'true'
+      - name: Post comment on PR
+        if: steps.netlify.outputs.found == 'true' && steps.find-pr.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -86,7 +87,6 @@ jobs:
           ADMIN_URL="${{ steps.netlify.outputs.admin_url }}"
           ERROR_MSG=$(cat /tmp/netlify_error.txt)
 
-          # Check if we already commented on this deploy (avoid duplicates)
           EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --jq "[.[] | select(.body | contains(\"${DEPLOY_ID}\"))] | length" 2>/dev/null || echo "0")
 
@@ -111,3 +111,61 @@ jobs:
 
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             -f body="$BODY"
+
+      - name: Open issue for direct-to-main failures
+        if: steps.netlify.outputs.found == 'true' && steps.find-pr.outputs.pr_number == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DEPLOY_ID="${{ steps.netlify.outputs.deploy_id }}"
+          ADMIN_URL="${{ steps.netlify.outputs.admin_url }}"
+          COMMIT_SHA="${{ steps.find-pr.outputs.commit_sha }}"
+          ERROR_MSG=$(cat /tmp/netlify_error.txt)
+          TAG="[netlify-deploy-failure]"
+
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues" \
+            --jq "[.[] | select(.state == \"open\" and (.title | contains(\"${TAG}\")))] | length" \
+            -f state=open -f per_page=20 2>/dev/null || echo "0")
+
+          if [ "$EXISTING" != "0" ]; then
+            ISSUE_NUMBER=$(gh api "repos/${{ github.repository }}/issues" \
+              --jq "[.[] | select(.state == \"open\" and (.title | contains(\"${TAG}\")))] | first | .number" \
+              -f state=open -f per_page=20)
+            gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
+              -f body="Still failing as of $(date -u +%Y-%m-%dT%H:%M:%SZ).
+
+          **Commit:** ${COMMIT_SHA}
+          **Deploy ID:** \`${DEPLOY_ID}\`
+          **Dashboard:** ${ADMIN_URL}
+
+          \`\`\`
+          ${ERROR_MSG}
+          \`\`\`"
+            echo "Commented on existing issue #${ISSUE_NUMBER}"
+            exit 0
+          fi
+
+          gh label create "ci-failure" --color "b60205" --description "CI/CD pipeline failure" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "${TAG} Netlify production deploy failing" \
+            --label "ci-failure,kind/bug" \
+            --body "## Netlify production deploy is failing
+
+          The Netlify build for a direct-to-main commit failed. The live site is serving stale content until this is resolved.
+
+          **Commit:** [\`${COMMIT_SHA}\`](https://github.com/${{ github.repository }}/commit/${COMMIT_SHA})
+          **Deploy ID:** \`${DEPLOY_ID}\`
+          **Dashboard:** ${ADMIN_URL}
+
+          \`\`\`
+          ${ERROR_MSG}
+          \`\`\`
+
+          ### Impact
+          - Leaderboard data is not updating on the live site
+          - Any other static data committed to main is stale
+
+          > Auto-generated by netlify-error-reporter. Subsequent failures will be appended as comments."


### PR DESCRIPTION
## Summary
- Updated `netlify-error-reporter` to handle direct-to-main commit failures (not just PR deploys)
- When a Netlify build fails for a commit with no associated PR, it now opens a `ci-failure` issue with the full error
- Subsequent failures append comments to the existing issue instead of creating duplicates
- Matches the version just merged on `kubestellar/console` (#13858)

## Context
The leaderboard workflow commits data directly to main every 4 hours. When PR #13836 broke the Netlify build, no alert was raised because the reporter only handled PR failures. The site served stale data for 2 days before anyone noticed.

## Test plan
- [ ] PR deploy failures still post comments on PRs
- [ ] Direct-to-main deploy failures open a new `ci-failure` issue
- [ ] Subsequent failures comment on the existing issue