### PR TITLE
fix: gitignore worktree directories to prevent broken gitlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ next-env.d.ts
 # Local Netlify folder
 .netlify
 deno.lock
+
+# git worktrees — prevent accidental commits that create broken gitlinks
+*-worktree
+*-worktree/


### PR DESCRIPTION
## Summary
- Adds `*-worktree` pattern to `.gitignore` to prevent git worktree directories from being accidentally committed
- This caused 4 broken gitlink entries that broke all Netlify deploys (fixed in #3201)

## Root cause
Hive agents create git worktrees (e.g. `fix-2585-worktree`) inside the repo. When `git add .` runs, git sees the `.git` file in the worktree directory and records it as a submodule pointer (gitlink). Without a `.gitmodules` entry, Netlify can't check out these "submodules" and all builds fail.

## Test plan
- [ ] Netlify deploy-preview passes
- [ ] Verify `*-worktree` directories can no longer be staged