### PR TITLE
📖 Update kubestellar-mcp docs to v0.8.20

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -146,8 +146,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.8.17 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.8.17",
+        "label": "v0.8.20 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.8.20",
         "isDefault": true
       },
       "main": {
@@ -164,6 +164,11 @@
       "0.8.1": {
         "label": "v0.8.1",
         "branch": "docs/kubestellar-mcp/0.8.1",
+        "isDefault": false
+      },
+      "0.8.17": {
+        "label": "v0.8.17",
+        "branch": "docs/kubestellar-mcp/0.8.17",
         "isDefault": false
       }
     },
@@ -242,7 +247,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.8.17"
+      "currentVersion": "0.8.20"
     },
     "console": {
       "name": "Console",
@@ -299,5 +304,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-05-14T06:47:20.015Z"
+  "updatedAt": "2026-05-24T06:23:27.340Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.8.17 (Latest)",
-    branch: "docs/kubestellar-mcp/0.8.17",
+    label: "v0.8.20 (Latest)",
+    branch: "docs/kubestellar-mcp/0.8.20",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.8.17": {
+    label: "v0.8.17",
+    branch: "docs/kubestellar-mcp/0.8.17",
+    isDefault: false,
   },
   "0.8.16": {
     label: "v0.8.16",
@@ -307,7 +312,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.8.17",
+    currentVersion: "0.8.20",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.8.20.

- Created branch: `docs/kubestellar-mcp/0.8.20`
- Source: kubestellar/kubestellar-mcp@v0.8.20

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release