### PR TITLE
Add Emeritus tier to contributor ladder

### DIFF
--- a/docs/content/contributing/contributor_ladder.md
+++ b/docs/content/contributing/contributor_ladder.md
@@ -16,7 +16,7 @@ To provide contributors with a clear understanding of how to grow within the Kub
 
 Each level reflects a growing commitment to the project, increased responsibilities, and expanded leadership opportunities.
 
-```
+```text
 Contributor → Unpaid Intern → Paid Intern → Mentor → Maintainer
                                                           ↓
                                                       Emeritus

--- a/docs/content/contributing/contributor_ladder.md
+++ b/docs/content/contributing/contributor_ladder.md
@@ -2,6 +2,8 @@
 
 This document outlines the process by which contributors to the [KubeStellar](https://github.com/kubestellar/kubestellar) open source project can progress toward becoming maintainers, and defines a transparent, merit-based path that rewards consistent engagement and community contribution.
 
+For the org-wide inactive member and emeritus policy, see [Community Membership](https://github.com/kubestellar/.github/blob/main/community-membership.md).
+
 ---
 
 ## Purpose
@@ -13,6 +15,16 @@ To provide contributors with a clear understanding of how to grow within the Kub
 ## Contributor Journey
 
 Each level reflects a growing commitment to the project, increased responsibilities, and expanded leadership opportunities.
+
+```
+Contributor → Unpaid Intern → Paid Intern → Mentor → Maintainer
+                                                          ↓
+                                                      Emeritus
+                                                      (inactive)
+                                                          ↓
+                                                    Reinstatement
+                                                   (back to prior level)
+```
 
 ---
 
@@ -30,14 +42,14 @@ Each level reflects a growing commitment to the project, increased responsibilit
 
 **Timeframe:** 12-week internship  
 **Quantitative Requirements (within 12 weeks):**
-- Open at least **6 “help wanted” issues**
+- Open at least **6 "help wanted" issues**
 - **Merge at least 20 PRs**
   - Of those, at least **8 PRs must be merged within the first 6 weeks**
 - Attend weekly team meetings or submit summaries asynchronously
 - Work collaboratively with mentors
 
 Promotion to paid intern requires completion of the above plus:
-- A mentor’s recommendation
+- A mentor's recommendation
 - Strong communication and follow-through
 
 ---
@@ -64,18 +76,61 @@ Promotion to paid intern requires completion of the above plus:
 
 ---
 
+### 5. Emeritus
+
+**Emeritus** is not a demotion — it is a recognition that a contributor made meaningful contributions to KubeStellar but is no longer actively participating. Any member at any level of the ladder may move to Emeritus status, either voluntarily or through the inactivity process.
+
+**How members move to Emeritus:**
+- **Voluntarily**: A member may request Emeritus status at any time by notifying a maintainer
+- **Inactivity**: Members with **no contributions across any KubeStellar repository within 9 months** are moved to Emeritus after a 30-day notification and grace period (see [Community Membership](https://github.com/kubestellar/.github/blob/main/community-membership.md) for the full process)
+
+**What Emeritus members retain:**
+- Listed in the Emeritus roll below
+- Full attribution of past contributions in git history
+- Welcome to participate in community discussions, meetings, and public channels
+- May submit pull requests and issues as external contributors
+
+**What Emeritus members do not have:**
+- GitHub organization membership or write access
+- Approval or review permissions in OWNERS files
+- CI trigger permissions
+- Access to private maintainer channels or security advisories
+
+**Returning from Emeritus:**
+
+Emeritus members have a streamlined path back — they do not start from scratch:
+
+1. Signal intent by opening an issue on [kubestellar/.github](https://github.com/kubestellar/.github) or contacting a maintainer
+2. Make at least **3 meaningful contributions** (PRs, reviews, or issue triage) within 30 days
+3. Obtain sponsorship from an active maintainer who confirms re-familiarization with current practices
+4. Receive approval from a simple majority of active maintainers
+
+Upon reinstatement, the member returns to the **same level** they held before going Emeritus, provided they still meet that level's requirements. If the project has evolved significantly, maintainers may recommend reinstatement at a lower level with a clear path to regain the previous level.
+
+---
+
+## Emeritus Roll
+
+| Name | Previous Role | Date | Contributions |
+|------|---------------|------|---------------|
+| — | — | — | — |
+
+---
+
 ## Maintainer Activity Requirements
 
 Maintainers are expected to remain active by meeting the following **bi-monthly (every 2 months)** contribution minimums:
 
 | Metric                                | Requirement (Per 2 Months) |
 |---------------------------------------|----------------------------|
-| “Help Wanted” Issues                  | ≥ 2                        |
+| "Help Wanted" Issues                  | ≥ 2                        |
 | **PRs Merged**                        | ≥ 3                        |
 | PR Reviews or Constructive Comments   | ≥ 8                        |
 | Community Meeting Attendance          | ≥ 3                        |
 
 All maintainers will be listed in a shared Google Sheet where these metrics are tracked publicly.
+
+Maintainers who fail to meet activity thresholds for **2 consecutive cycles** (4 months) will be contacted and offered the choice to re-engage or move to Emeritus. If no response is received within 30 days, they are moved to Emeritus per the [Community Membership](https://github.com/kubestellar/.github/blob/main/community-membership.md) policy.
 
 ---
 
@@ -83,8 +138,8 @@ All maintainers will be listed in a shared Google Sheet where these metrics are 
 
 - Evaluations occur every 6 weeks for interns and every 8 weeks for maintainers
 - Interns who do not meet the required output may be removed from the program
-- Maintainers who fail to meet activity thresholds for 2 consecutive cycles will be reviewed for possible status change
 - Contributors may re-enter or regain status based on future contributions
+- The 9-month inactivity window applies to **all** org members, not just maintainers
 
 ---
 
@@ -100,8 +155,8 @@ Contribution metrics will be gathered via GitHub API and updated to a public Goo
 
 ## Join the Pathway
 
-If you’re interested in becoming an intern or nominating someone, please attend a [KubeStellar Community Meeting](https://github.com/kubestellar/community), or open an issue with the label `maintainer-pathway`.
+If you're interested in becoming an intern or nominating someone, please attend a [KubeStellar Community Meeting](https://github.com/kubestellar/community), or open an issue with the label `maintainer-pathway`.
 
 ---
 
-*Maintained by the KubeStellar team. Last updated: July 2025.*
+*Maintained by the KubeStellar team. Last updated: May 2026.*


### PR DESCRIPTION
## Summary
- Adds **Emeritus** as a formal tier in the contributor ladder
- Includes an ASCII diagram showing the full journey including Emeritus and reinstatement
- Adds an **Emeritus Roll** table to track members who've moved to Emeritus status
- Cross-links to the new `community-membership.md` in `kubestellar/.github` for the full inactivity policy
- Tightens maintainer inactivity escalation to align with the org-wide 9-month policy
- Updates the "Last updated" date

Companion PR: `kubestellar/.github` — adds the org-wide community membership and inactive member policy.

## Test plan
- [ ] Review Emeritus section for clarity
- [ ] Confirm cross-links to `kubestellar/.github` community-membership.md resolve correctly after companion PR merges
- [ ] Verify the contributor journey diagram renders correctly on the docs site