### PR TITLE
Fix broken agenda short link

### DIFF
--- a/docs/content/community/meetings.md
+++ b/docs/content/community/meetings.md
@@ -12,7 +12,7 @@ KubeStellar community meetings are the place to follow current work, bring quest
 
 - [Upcoming agendas](https://github.com/kubestellar/kubestellar/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-meeting)
 - [Past agendas and notes](https://github.com/kubestellar/kubestellar/issues?q=is%3Aissue+is%3Aclosed+label%3Acommunity-meeting)
-- [Community meeting agenda document](https://docs.google.com/document/d/1XppfxSOD7AOX1lVVVIPWjpFkrxakfBfVzcybRg17-PM/edit?usp=share_link)
+- Meeting topics are tracked publicly in the GitHub agenda issues linked above.
 
 ## Recordings
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -385,7 +385,7 @@
 
 [[redirects]]
   from = "/agenda"
-  to = "https://docs.google.com/document/d/1XppfxSOD7AOX1lVVVIPWjpFkrxakfBfVzcybRg17-PM/edit?usp=share_link"
+  to = "/docs/community/meetings#agendas-and-notes"
   status = 301
   force = true
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,8 +31,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/agenda",
-        destination:
-          "https://docs.google.com/document/d/1XppfxSOD7AOX1lVVVIPWjpFkrxakfBfVzcybRg17-PM/edit?usp=share_link",
+        destination: "/docs/community/meetings#agendas-and-notes",
         permanent: true,
       },
       {


### PR DESCRIPTION
## Summary
- route /agenda to the public community meetings page instead of a private Google Doc
- remove the inaccessible Google Doc link from the meetings page and point readers to the public GitHub agenda issues

## Validation
- npm run lint
- npm run lint:md
- npm run build currently fails on Windows before evaluating this change because 	sx scripts/generate-shared-config.ts hits an existing ERR_UNSUPPORTED_ESM_URL_SCHEME path-loading issue

Fixes #4308