### PR TITLE
📖 Update kubestellar-mcp docs to v0.8.21

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -146,8 +146,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.8.20 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.8.20",
+        "label": "v0.8.21 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.8.21",
         "isDefault": true
       },
       "main": {
@@ -169,6 +169,11 @@
       "0.8.17": {
         "label": "v0.8.17",
         "branch": "docs/kubestellar-mcp/0.8.17",
+        "isDefault": false
+      },
+      "0.8.20": {
+        "label": "v0.8.20",
+        "branch": "docs/kubestellar-mcp/0.8.20",
         "isDefault": false
       }
     },
@@ -247,7 +252,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.8.20"
+      "currentVersion": "0.8.21"
     },
     "console": {
       "name": "Console",
@@ -304,5 +309,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-05-24T06:23:27.340Z"
+  "updatedAt": "2026-05-31T06:35:29.148Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.8.20 (Latest)",
-    branch: "docs/kubestellar-mcp/0.8.20",
+    label: "v0.8.21 (Latest)",
+    branch: "docs/kubestellar-mcp/0.8.21",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.8.20": {
+    label: "v0.8.20",
+    branch: "docs/kubestellar-mcp/0.8.20",
+    isDefault: false,
   },
   "0.8.17": {
     label: "v0.8.17",
@@ -312,7 +317,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.8.20",
+    currentVersion: "0.8.21",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.8.21.

- Created branch: `docs/kubestellar-mcp/0.8.21`
- Source: kubestellar/kubestellar-mcp@v0.8.21

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release