### PR TITLE
fix: skip Netlify deploy previews for hive snapshot PRs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@
 [build]
   command = "NEXT_PUBLIC_BRANCH=${BRANCH:-main} npm run build"
   publish = ".next"
+  ignore = "if echo \"$BRANCH\" | grep -q '^chore/hive-snapshot'; then exit 0; fi; exit 1"
 
 [build.environment]
   NODE_VERSION = "20.11.1"


### PR DESCRIPTION
## Summary
- Adds a Netlify `ignore` rule to skip deploy preview builds for hive snapshot PR branches (`chore/hive-snapshot-*`)
- Snapshot PRs only update static HTML in `public/live/hive/` and don't need a full Next.js build
- The deploy preview was taking 6-8 minutes per snapshot PR, gating merge via required status checks and causing the live snapshot page on kubestellar.io to be 20+ minutes stale (target is <20 minutes)
- Bluefin snapshot PRs were unaffected because they merge with `--admin`, but kubestellar ones waited for all checks including Netlify

## Test plan
- [ ] Verify next hive dashboard snapshot PR skips Netlify deploy preview
- [ ] Verify snapshot staleness on kubestellar.io drops to <20 minutes
- [ ] Verify regular (non-snapshot) PRs still get deploy previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)