### PR TITLE
fix: use script for Netlify ignore, check both BRANCH and HEAD

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build]
   command = "NEXT_PUBLIC_BRANCH=${BRANCH:-main} npm run build"
   publish = ".next"
-  ignore = "if echo \"$BRANCH\" | grep -q '^chore/hive-snapshot'; then exit 0; fi; exit 1"
+  ignore = "/bin/bash scripts/netlify-ignore.sh"
 
 [build.environment]
   NODE_VERSION = "20.11.1"

--- a/scripts/netlify-ignore.sh
+++ b/scripts/netlify-ignore.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Netlify ignore script — exit 0 to skip build, exit 1 to build.
+# Skips deploy preview builds for hive snapshot branches.
+
+echo "[netlify-ignore] BRANCH=$BRANCH HEAD=$HEAD PULL_REQUEST=$PULL_REQUEST REVIEW_ID=$REVIEW_ID COMMIT_REF=$COMMIT_REF"
+
+# Check both BRANCH and HEAD — Netlify may use either for the PR branch name
+for var in "$BRANCH" "$HEAD"; do
+  case "$var" in
+    chore/hive-snapshot*)
+      echo "[netlify-ignore] Skipping build — hive snapshot branch: $var"
+      exit 0
+      ;;
+  esac
+done
+
+echo "[netlify-ignore] Proceeding with build"
+exit 1


### PR DESCRIPTION
## Summary
- The inline `ignore` rule from #4872 wasn't skipping deploy previews for hive snapshot PRs — Netlify was still building them
- Moves to a `scripts/netlify-ignore.sh` script file with diagnostic logging
- Checks both `$BRANCH` and `$HEAD` env vars since Netlify may use either for the PR branch name in deploy preview context
- Adds echo logging so we can see in the Netlify build log what variables are set and whether the skip triggers

## Test plan
- [ ] Check Netlify deploy log for the next `chore/hive-snapshot-*` PR to see the diagnostic output
- [ ] Verify snapshot PRs skip the Netlify deploy preview build
- [ ] Verify non-snapshot PRs still build normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)