### PR TITLE
fix: add Netlify redirects for hive API docs pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -111,7 +111,32 @@
   status = 301
   force = true
 
-# Serve static hive dashboard snapshot (bypass Next.js middleware)
+# Serve static hive dashboard snapshots (bypass Next.js middleware)
+# Wildcard rule resolves directory paths to index.html for all instances
+[[redirects]]
+  from = "/live/hive/*/api-docs"
+  to = "/live/hive/:splat/api-docs/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/live/hive/*/api-docs/"
+  to = "/live/hive/:splat/api-docs/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/live/hive/api-docs"
+  to = "/live/hive/api-docs/index.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/live/hive/api-docs/"
+  to = "/live/hive/api-docs/index.html"
+  status = 200
+  force = true
+
 [[redirects]]
   from = "/live/hive"
   to = "/live/hive/index.html"


### PR DESCRIPTION
## Summary
- Add Netlify redirect rules so `/live/hive/*/api-docs` and `/live/hive/api-docs` resolve to their `index.html` files
- Next.js doesn't auto-resolve directory paths for static files in `public/`
- Without these rules, the Redoc API docs pages return 404 even though the files exist in the repo

## Test plan
- [ ] Verify `kubestellar.io/live/hive/bluefin/api-docs` loads Redoc
- [ ] Verify `kubestellar.io/live/hive/api-docs` loads Redoc (once v1 snapshot includes it)