### PR TITLE
[sec-check] fix: add HTTP security headers, harden path traversal check, remove unused postmark dep

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,22 @@ const nextConfig: NextConfig = {
     optimizePackageImports: ["@/components"],
   },
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
   async rewrites() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "next-intl": "^4.3.12",
     "next-themes": "^0.4.6",
     "nextra": "^4.6.1",
-    "postmark": "^4.0.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "three": "^0.180.0"

--- a/src/app/api/docs-image/[...path]/route.ts
+++ b/src/app/api/docs-image/[...path]/route.ts
@@ -28,8 +28,8 @@ export async function GET(
   
   const fullPath = path.join(DOCS_CONTENT_PATH, imagePath)
   
-  // Check if file exists and is within docs/content
-  if (!fullPath.startsWith(DOCS_CONTENT_PATH)) {
+  // Check if file exists and is within docs/content (trailing sep prevents sibling-dir prefix confusion)
+  if (!fullPath.startsWith(DOCS_CONTENT_PATH + path.sep)) {
     return new NextResponse('Forbidden', { status: 403 })
   }
   


### PR DESCRIPTION
## Security Fix

Addresses three security findings from docs security audit (issue #5758).

### 1 — HTTP Security Headers (MEDIUM)

Adds `headers()` to `next.config.ts` covering all routes `/(.*)`

| Header added | Protects against |
|---|---|
| `X-Frame-Options: DENY` | Clickjacking via `<iframe>` embedding |
| `X-Content-Type-Options: nosniff` | MIME-type sniffing of served assets |
| `Referrer-Policy: strict-origin-when-cross-origin` | Full URL leakage in Referer to third-party origins |
| `Permissions-Policy: camera=(), microphone=(), geolocation=()` | Unsolicited browser feature access |

No CSP added at this stage — that would require a separate audit of inline scripts used by Mermaid and Three.js.

### 2 — Path Traversal Defense: Trailing Separator (LOW)

In `src/app/api/docs-image/[...path]/route.ts`:

```diff
- if (!fullPath.startsWith(DOCS_CONTENT_PATH)) {
+ if (!fullPath.startsWith(DOCS_CONTENT_PATH + path.sep)) {
```

Prevents a future sibling directory (e.g., `/app/docs/content-evil/`) from satisfying the prefix check. The existing `..` string check prevents active exploitation, but this closes the defense-in-depth gap.

### 3 — Remove Unused `postmark` Dependency (LOW)

`postmark` appears in `package.json` `dependencies` but is not imported anywhere in `src/`. It is only used as a CI workflow API secret. Removing it reduces the production dependency footprint and supply-chain attack surface.

Fixes #5758

---
*Filed by sec-check agent (ACMM L6 — full mode)*