### PR TITLE
[sec-check] fix: HTML-encode search snippets to prevent XSS via dangerouslySetInnerHTML

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -66,6 +66,14 @@ function readLocalFile(filePath: string): string | null {
   return null
 }
 
+/** HTML-encode special characters so they render as text in innerHTML */
+function htmlEncode(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
 export async function GET(request: NextRequest) {
   try {
     const sp = request.nextUrl.searchParams
@@ -109,14 +117,19 @@ export async function GET(request: NextRequest) {
           (start > 0 ? "..." : "") +
           text.slice(start, end) +
           (end < text.length ? "..." : "")
+
+        // HTML-encode the snippet so HTML entities in docs content (&lt;img&gt;
+        // etc.) cannot become live HTML when rendered via dangerouslySetInnerHTML.
+        // Only the <mark>/<\/mark> tags we insert below are trusted raw HTML.
+        const encodedSnippet = htmlEncode(snippet)
         const rx = new RegExp(
           `(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
           "gi"
         )
-        highlightedSnippet = snippet.replace(rx, "<mark>$1</mark>")
+        highlightedSnippet = encodedSnippet.replace(rx, "<mark>$1</mark>")
       } else {
         snippet = text.slice(0, 140) + (text.length > 140 ? "..." : "")
-        highlightedSnippet = snippet
+        highlightedSnippet = htmlEncode(snippet)
       }
 
       const category =


### PR DESCRIPTION
## Security Fix

`src/app/api/search/route.ts` builds `highlightedSnippet` from MDX file content and serves it to `DocsNavbar.tsx` which renders it via `dangerouslySetInnerHTML`. The `toPlainText()` helper strips HTML tags but **not** HTML entities (`&lt;`, `&gt;`, `&amp;`).

### XSS Path

A docs PR containing text like `&lt;img src=x onerror=alert(document.cookie)&gt;` would:
1. Pass `toPlainText()` unchanged (entities ≠ tags)
2. Appear in `highlightedSnippet` when a visitor searches for matching text
3. Be decoded by `innerHTML` in the browser → `<img src=x onerror=...>` executes

### Fix

Added `htmlEncode()` helper that encodes `&`, `<`, `>` in the raw snippet **before** inserting `<mark>` tags. This ensures only the intentional `<mark>`/`</mark>` pairs are raw HTML — all docs-sourced characters are safely encoded.

```ts
function htmlEncode(str: string): string {
  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
}
// ...
const encodedSnippet = htmlEncode(snippet)
highlightedSnippet = encodedSnippet.replace(rx, "<mark>$1</mark>")
```

Fixes #5760

---
*Filed by sec-check agent (ACMM L6 — full mode)*