### PR TITLE
[sec-check] fix: loop script/style/on* stripping in transformMdx.ts (CWE-116, CodeQL #106-108)

### DIFF
--- a/src/lib/transformMdx.ts
+++ b/src/lib/transformMdx.ts
@@ -40,6 +40,8 @@ export function convertHtmlScriptsToJsxComments(input: string): string {
   // input so that one removal reconstitutes the dangerous pattern, e.g.:
   //   <scr<script>ipt>...</scr</script>ipt>
   // Repeating until the string no longer changes closes this gap.
+  // Use \s* on closing tags to also catch </script > / </style > with trailing
+  // whitespace before >, which the bare </script> pattern would miss (CodeQL).
   const stripLoop = (str: string, re: RegExp): string => {
     let prev: string;
     do {
@@ -49,9 +51,9 @@ export function convertHtmlScriptsToJsxComments(input: string): string {
     return str;
   };
 
-  s = stripLoop(s, /<script\b[^>]*>[\s\S]*?<\/script>/gi);
+  s = stripLoop(s, /<script\b[^>]*>[\s\S]*?<\/script\s*>/gi);
   s = stripLoop(s, /<script\b[^>]*\/>/gi);
-  s = stripLoop(s, /<style\b[^>]*>[\s\S]*?<\/style>/gi);
+  s = stripLoop(s, /<style\b[^>]*>[\s\S]*?<\/style\s*>/gi);
 
   // Strip HTML event-handler attributes (onclick, onload, etc.).
   // Require `=` after the attribute name so normal prose words like

--- a/src/lib/transformMdx.ts
+++ b/src/lib/transformMdx.ts
@@ -34,16 +34,31 @@ export function convertHtmlScriptsToJsxComments(input: string): string {
     /<!--([\s\S]*?)-->/g,
     (_m, comment) => `{/*${comment.trim()}*/}`
   );
-  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
-  s = s.replace(/<script\b[^>]*\/>/gi, "");
-  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
+
+  // Loop until stable to prevent nested-tag bypass (CWE-116 / CodeQL #106-#108).
+  // A single-pass replace on a multi-character pattern can be bypassed by crafting
+  // input so that one removal reconstitutes the dangerous pattern, e.g.:
+  //   <scr<script>ipt>...</scr</script>ipt>
+  // Repeating until the string no longer changes closes this gap.
+  const stripLoop = (str: string, re: RegExp): string => {
+    let prev: string;
+    do {
+      prev = str;
+      str = str.replace(re, "");
+    } while (str !== prev);
+    return str;
+  };
+
+  s = stripLoop(s, /<script\b[^>]*>[\s\S]*?<\/script>/gi);
+  s = stripLoop(s, /<script\b[^>]*\/>/gi);
+  s = stripLoop(s, /<style\b[^>]*>[\s\S]*?<\/style>/gi);
 
   // Strip HTML event-handler attributes (onclick, onload, etc.).
   // Require `=` after the attribute name so normal prose words like
   // "onto", "once", "one", "only" are NOT removed.
-  s = s.replace(
-    /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|\{[^}]*\}|[^\s>]+)/gi,
-    ""
+  s = stripLoop(
+    s,
+    /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|\{[^}]*\}|[^\s>]+)/gi
   );
   s = s.replace(/\sstyle\s*=\s*(?:"[\s\S]*?"|'[\s\S]*?')/gi, "");
   s = s.replace(/\sstyle\s*=\s*\{\{[\s\S]*?\}\}/gi, "");

--- a/src/lib/transformMdx.ts
+++ b/src/lib/transformMdx.ts
@@ -40,8 +40,8 @@ export function convertHtmlScriptsToJsxComments(input: string): string {
   // input so that one removal reconstitutes the dangerous pattern, e.g.:
   //   <scr<script>ipt>...</scr</script>ipt>
   // Repeating until the string no longer changes closes this gap.
-  // Use \s* on closing tags to also catch </script > / </style > with trailing
-  // whitespace before >, which the bare </script> pattern would miss (CodeQL).
+  // Use [^>]* on closing tags to match any closing-tag variant (</script >,
+  // </script\t\n bar>, etc.) that \s*> would not handle (CodeQL alert).
   const stripLoop = (str: string, re: RegExp): string => {
     let prev: string;
     do {
@@ -51,9 +51,9 @@ export function convertHtmlScriptsToJsxComments(input: string): string {
     return str;
   };
 
-  s = stripLoop(s, /<script\b[^>]*>[\s\S]*?<\/script\s*>/gi);
+  s = stripLoop(s, /<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi);
   s = stripLoop(s, /<script\b[^>]*\/>/gi);
-  s = stripLoop(s, /<style\b[^>]*>[\s\S]*?<\/style\s*>/gi);
+  s = stripLoop(s, /<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi);
 
   // Strip HTML event-handler attributes (onclick, onload, etc.).
   // Require `=` after the attribute name so normal prose words like


### PR DESCRIPTION
## Security Fix

Fixes incomplete multi-character sanitization in `src/lib/transformMdx.ts` (CodeQL HIGH alerts #106, #107, #108 — `js/incomplete-multi-character-sanitization`).

### Problem

`convertHtmlScriptsToJsxComments()` used single-pass `String.replace()` to strip `<script>`, `<style>`, and `on*=` event handler attributes. Single-pass stripping on multi-character patterns is bypassable:

```
Input:  <scr<script>ipt>alert(1)</scr</script>ipt>
After 1 pass (removes inner <script>...</script>):
Output: <script>alert(1)</script>  ← bypass survived
```

This is the classic **nested-tag bypass** (CWE-116 / CWE-80). If a contributor submits MDX content with a crafted payload, it survives into the built HTML and executes JavaScript for all docs site visitors.

### Fix

Add a `stripLoop` helper that repeats the replacement until the string no longer changes:

```typescript
const stripLoop = (str: string, re: RegExp): string => {
  let prev: string;
  do { prev = str; str = str.replace(re, ""); } while (str !== prev);
  return str;
};
```

Then replace the three single-pass calls with `stripLoop`:

```typescript
s = stripLoop(s, /<script\b[^>]*>[\s\S]*?<\/script>/gi);  // was: s.replace(...)
s = stripLoop(s, /<script\b[^>]*\/>/gi);
s = stripLoop(s, /<style\b[^>]*>[\s\S]*?<\/style>/gi);
s = stripLoop(s, /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|\{[^}]*\}|[^\s>]+)/gi);
```

### Changed files

- `src/lib/transformMdx.ts` — adds `stripLoop` helper (+12 lines) and converts 4 single-pass replace calls to loop-based calls

Fixes #5728
Fixes #5770

---
*Filed by sec-check agent (ACMM L6 — full mode)*