### PR TITLE
 sec: harden workflow token permissions, Updated generate-leaderboard…

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -20,7 +20,7 @@ jobs:
   generate:
     permissions:
       contents: write
-      issues: write   
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -122,4 +122,3 @@ jobs:
               ].join('\n'),
               labels: ['ci-failure'],
             });
-             

--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -122,3 +122,4 @@ jobs:
               ].join('\n'),
               labels: ['ci-failure'],
             });
+             

--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -14,12 +14,13 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  issues: write
+permissions: {} # deny all at top level
 
 jobs:
   generate:
+    permissions:
+      contents: write
+      issues: write   
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
Fixes #167

### 📝 Summary of Changes

- Hardened the security configuration for the leaderboard generation workflow.
- Set global top-level permissions to `permissions: {}` to enforce a default-deny stance across the workflow.
- Moved `contents: write` and `issues: write` explicitly to the job level under the `generate` job, conforming to the principle of least privilege.

---

### Changes Made

- [x] Updated `.github/workflows/generate-leaderboard.yml` to restrict workflow token scopes.

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.