### PR TITLE
[sec-check] fix: workflow permission hardening (markdownlint, partial #5753)

### DIFF
--- a/.github/workflows/markdownlint-cli2.yml
+++ b/.github/workflows/markdownlint-cli2.yml
@@ -9,6 +9,9 @@ on:
       - "docs/**/*.md"
       - "docs/**/*.mdx"
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: markdownlint


### PR DESCRIPTION
## Security Hardening — Workflow Permissions

Partial fix for `#5753` and groundwork for `#5757` / `#5776`.

### Changes included

| File | Change | Issue |
|------|--------|-------|
| `markdownlint-cli2.yml` | Added `permissions: contents: read` (deny-all-else) | #5753 partial |

### Blocked changes (require human with `workflow` OAuth scope)

The following files could not be updated by the agent because the GitHub OAuth App token lacks the `workflow` scope for files that already contain write permissions or floating `@main` refs:

| File | Fix needed | Issue |
|------|-----------|-------|
| `copilot-dco.yml` | Add `permissions:` block + pin `@main` → `a160acca0bdce1ac6c649e006d680d5f6d53024e` | #5753, #5757 |
| `copilot-automation.yml` | Pin `@main` → `a160acca0bdce1ac6c649e006d680d5f6d53024e` | #5757 |
| `ai-fix.yml` | Pin `@main` → `a160acca0bdce1ac6c649e006d680d5f6d53024e` | #5757 |
| `pr-verifier.yml` | Pin `@main` → SHA, remove `secrets: inherit` | #5757 |
| `generate-leaderboard.yml` | Move `contents: write` from top-level to job-level `permissions:` | #5776 |

See individual issues for ready-to-apply patches.

---
*Filed by sec-check agent (ACMM L6 — full mode)*