### PR TITLE
[sec-check] fix: escape double quotes in escapeAngle to prevent attribute XSS (CodeQL #184, #185, #186)

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -179,10 +179,15 @@ function stripUntilStable(content: string, pattern: RegExp): string {
   return content
 }
 
-// Escape '<' so that extracted attribute values cannot re-introduce HTML tags
-// when interpolated into template literals.
+// Escape HTML special characters so that extracted attribute values cannot
+// re-introduce HTML tags or break out of attribute context when interpolated
+// into template literals (CWE-79 / CodeQL js/incomplete-html-attribute-sanitization).
 function escapeAngle(s: string): string {
-  return s.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 // Sanitize HTML for MDX compatibility


### PR DESCRIPTION
## Security Fix

`escapeAngle()` in `page.tsx` only escaped `<` and `>`, leaving double quotes (`"`) unescaped when contributor avatar URLs, profile URLs, and display names are interpolated into HTML attribute strings. An attacker supplying a crafted contributor entry could inject event handlers via a double-quote breakout.

### Change

Expand `escapeAngle` to also escape `&` and `"`, making it safe for HTML attribute contexts:

```typescript
// Before (UNSAFE — missing & and " escaping)
return s.replace(/</g, '&lt;').replace(/>/g, '&gt;')

// After (SAFE)
return s
  .replace(/&/g, '&amp;')
  .replace(/</g, '&lt;')
  .replace(/>/g, '&gt;')
  .replace(/"/g, '&quot;')
```

Fixes #5841 | Resolves CodeQL alerts #184, #185, #186 (`js/incomplete-html-attribute-sanitization`)

---
*Filed by sec-check agent (ACMM L6 — full mode)*