### PR TITLE
[sec-check] fix: use exact hostname matching in getBaseUrl to prevent URL bypass (CodeQL #8)

### DIFF
--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -45,12 +45,16 @@ export function getBaseUrl(): string {
   const host = window.location.host;
   const protocol = window.location.protocol;
 
-  // Check if we're on a Netlify preview or other non-production domain
+  // Check if we're on a Netlify preview or other non-production domain.
+  // Use exact-match or proper suffix checks rather than substring includes() to
+  // prevent hostname bypass (CWE-20 / CodeQL js/incomplete-url-substring-sanitization).
+  const hostname = host.split(":")[0]; // strip port for comparison
   if (
-    host.includes("netlify.app") ||
-    host.includes("previews.kubestellar.io") ||
-    host.includes("localhost") ||
-    host.includes("127.0.0.1")
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname.endsWith(".netlify.app") ||
+    hostname === "previews.kubestellar.io" ||
+    hostname.endsWith(".previews.kubestellar.io")
   ) {
     // Use the current host for preview/local environments
     return `${protocol}//${host}`;


### PR DESCRIPTION
## Security Fix

`getBaseUrl()` in `src/lib/url.ts` used `host.includes(...)` to detect preview/local environments. Substring checks can be bypassed by hostnames that embed the target string in non-host positions (e.g. `evil-previews.kubestellar.io`). CodeQL flags this as `js/incomplete-url-substring-sanitization` (HIGH, open since January 2026).

### Change

Replace `includes()` substring checks with exact equality (`===`) and proper suffix checks (`endsWith()`):

```typescript
// Before (UNSAFE)
host.includes("previews.kubestellar.io")

// After (SAFE)
const hostname = host.split(":")[0];  // strip port
hostname === "previews.kubestellar.io" ||
hostname.endsWith(".previews.kubestellar.io")
```

Covers all four cases: `localhost`, `127.0.0.1`, `*.netlify.app`, and `previews.kubestellar.io`/`*.previews.kubestellar.io`.

Fixes #5842 | Resolves CodeQL alert #8 (`js/incomplete-url-substring-sanitization`)

---
*Filed by sec-check agent (ACMM L6 — full mode)*