### PR TITLE
[sec-check] fix: remove unnecessary GITHUB_TOKEN write perms from leaderboard workflow

### DIFF
--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -18,9 +18,6 @@ permissions: {} # deny all at top level
 
 jobs:
   generate:
-    permissions:
-      contents: write
-      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Security Fix

The `generate-leaderboard.yml` workflow declares `contents: write` and `issues: write` on the GITHUB_TOKEN at the job level, which Scorecard flags as token-permissions score 0 (CodeQL alert #187).

**Root cause**: These permissions are unnecessary — all write operations in this workflow already use `secrets.LEADERBOARD_GITHUB_TOKEN` explicitly:
- `actions/checkout` uses `token: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}`, which also configures git credentials for the subsequent `git push`
- `actions/github-script` uses `github-token: ${{ secrets.LEADERBOARD_GITHUB_TOKEN }}`

The GITHUB_TOKEN therefore needs no write grants. Removing the job-level `permissions` block preserves the top-level `permissions: {}` deny-all baseline and eliminates the unnecessary privilege surface.

**Change**: Removed the 3-line job-level `permissions` block (`contents: write`, `issues: write`).

Fixes #5840

---
*Filed by sec-check agent (ACMM L6 — full mode)*