### PR TITLE
[sec-check] fix: pin Dockerfile.rollout-checker base image digest and oci-cli version

### DIFF
--- a/cluster-objects/Dockerfile.rollout-checker
+++ b/cluster-objects/Dockerfile.rollout-checker
@@ -1,14 +1,13 @@
 # Dockerfile.rollout-checker
-FROM docker.io/alpine/kubectl:1.34.1
+FROM docker.io/alpine/kubectl:1.34.1@sha256:8413f8890d19aa03f63851654f642957e65ba59654b0c9357ddc6ec0b05b63a6
 
 # Install runtime dependencies and OCI CLI
 RUN apk add --no-cache python3 py3-pip bash jq curl gettext \
-    && pip install --break-system-packages --no-cache-dir oci-cli \
+    && pip install --break-system-packages --no-cache-dir oci-cli==3.86.0 \
     && rm -rf /var/cache/apk/*
 
-# (Optional) Print versions only during runtime, not build
+# (Optional) Print versions only during rebuild, not build
 # ENTRYPOINT ["bash", "-c", "kubectl version --client && oci --version && bash"]
 
 WORKDIR /scripts
 ENTRYPOINT ["/bin/bash"]
-


### PR DESCRIPTION
## Security Fix

Pin the unpinned base image and pip dependency in `cluster-objects/Dockerfile.rollout-checker`.

### Changes

| Item | Before | After |
|------|--------|-------|
| Base image | `docker.io/alpine/kubectl:1.34.1` | `docker.io/alpine/kubectl:1.34.1@sha256:8413f8890d19aa03f63851654f642957e65ba59654b0c9357ddc6ec0b05b63a6` |
| oci-cli pip package | `oci-cli` (unpinned, always latest) | `oci-cli==3.86.0` |

### Why

Unpinned image tags and pip packages are resolved at build time against whatever version the registry or PyPI currently serves. A supply-chain attacker who compromises the upstream tag or package can silently inject malicious code into every subsequent build without any change to this repository.

Pinning to a digest (for the image) and an exact version (for pip) ensures reproducible, auditable builds. Dependabot / Renovate can open PRs when updates are available.

Fixes #5849

---
*Filed by sec-check agent (ACMM L6 — full mode)*