### PR TITLE
[sec-check] fix: loop-stabilize unclosed &lt;iframe&gt; removal to prevent nested-tag bypass (CodeQL #189)

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -106,9 +106,11 @@ function sanitizeHtmlForMdx(content: string): string {
   sanitized = sanitized.replace(/<tr>[\s\S]*?<\/tr>/gi, '')
   sanitized = sanitized.replace(/<td[^>]*>[\s\S]*?<\/td>/gi, '')
   
-  // Remove all iframe tags — also handles unclosed <iframe ...> without </iframe>
+  // Remove all iframe tags (both closed and unclosed forms), loop-stabilized to
+  // prevent nested-tag reconstruction bypass (e.g. <if<iframe>rame src="evil">
+  // reassembles to <iframe src="evil"> after a single-pass removal of the inner tag).
   sanitized = stripUntilStable(sanitized, /<iframe[\s\S]*?<\/iframe>/gi)
-  sanitized = sanitized.replace(/<iframe\b[^>]*\/?>/gi, '')
+  sanitized = stripUntilStable(sanitized, /<iframe\b[^>]*\/?>/gi)
   
   // Normalize all img tags - handle both <img ...> and <img ... />
   sanitized = sanitized.replace(/<img\s+([^>]*?)\/?>/gi, (match, attrs) => {


### PR DESCRIPTION
## Security Fix

Changes `sanitized.replace(/<iframe\b[^>]*\/?>/gi, '')` to `stripUntilStable(sanitized, /<iframe\b[^>]*\/?>/gi)` in `sanitizeHtmlForMdx()`.

### Why

The closed-form `<iframe>...</iframe>` removal already uses `stripUntilStable()` to prevent nested-tag reconstruction. The open/self-closing form (tags without a closing `</iframe>`) used a plain single-pass `replace()`, which can be bypassed:

```
Input:  <if<iframe>rame src="javascript:evil()">
Pass 1: removes inner <iframe>, leaves: <iframe src="javascript:evil()">
Result: injected <iframe> survives into rendered page
```

Applying `stripUntilStable()` catches the reconstructed tag on the next iteration.

Fixes #5861
Resolves CodeQL alert [#189 (js/incomplete-multi-character-sanitization)](https://github.com/kubestellar/docs/security/code-scanning/189)

---
*Filed by sec-check agent (ACMM L6 — full mode)*