### PR TITLE
[scanner] fix: scope GITHUB_TOKEN permissions in 9 docs workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@a160acca0bdce1ac6c649e006d680d5f6d53024e  # pin: main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@a160acca0bdce1ac6c649e006d680d5f6d53024e  # pin: main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -30,12 +30,13 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   create-branch:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout docs repo

--- a/.github/workflows/generate-acmm-history.yml
+++ b/.github/workflows/generate-acmm-history.yml
@@ -6,12 +6,13 @@ on:
     - cron: '0 2 * * 0,1,3,5'
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   generate:
+    permissions:
+      contents: write
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/netlify-error-reporter.yml
+++ b/.github/workflows/netlify-error-reporter.yml
@@ -3,6 +3,8 @@ name: Netlify Deploy Failure Reporter
 on:
   status:
 
+permissions: read-all  # default read; writes scoped to job below
+
 jobs:
   report-netlify-failure:
     if: >-

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,11 +4,12 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
     secrets: inherit

--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -6,12 +6,13 @@ on:
     # Run every Monday at 12:00 PM Eastern (17:00 UTC)
     - cron: "0 17 * * 1"
 
-permissions:
-  actions: write
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   audit-all:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit

--- a/.github/workflows/sync-console-release-versions.yml
+++ b/.github/workflows/sync-console-release-versions.yml
@@ -5,12 +5,13 @@ on:
   schedule:
     - cron: '17 5 * * *'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   sync-console-releases:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}


### PR DESCRIPTION
## Fix

Moves write-level `GITHUB_TOKEN` permissions from workflow top-level to per-job blocks for 9 workflows, and adds `permissions: read-all` at the top level as the default.

### Affected workflows

| Workflow | Change |
|----------|--------|
| `ai-fix.yml` | `read-all` top-level + `contents/issues/pull-requests: write` at job level |
| `copilot-automation.yml` | `read-all` top-level + `contents/pull-requests/issues/statuses: write` at job level |
| `create-version-branch.yml` | `read-all` top-level + `contents/pull-requests: write` at job level |
| `generate-acmm-history.yml` | `read-all` top-level + `contents/issues: write` at job level |
| `netlify-error-reporter.yml` | Add `read-all` top-level (job-level perms already correct) |
| `pr-verifier.yml` | `read-all` top-level + `checks: write` at job level |
| `run-all-maintainer-audits.yml` | `read-all` top-level + `actions: write` at job level |
| `scorecard.yml` | `read-all` top-level + `security-events/id-token: write` at job level |
| `sync-console-release-versions.yml` | `read-all` top-level + `contents/pull-requests: write` at job level |

**Note:** `copilot-dco.yml`, `markdownlint-cli2.yml`, `technical-doc-writer.lock.yml`, and `generate-leaderboard.yml` were already compliant (explicit `read-only` or `{}` top-level permissions).

Fixes #5731
Fixes #5724

---
*Filed by scanner agent (ACMM L6 — automerge mode)*