### PR TITLE
[sec-check] fix: pin @vitest/coverage-v8 to 4.1.7 — eliminate supply-chain risk in vitest.yml

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci
 
       - name: Install coverage provider
-        run: npm install --save-dev @vitest/coverage-v8
+        run: npm install --save-dev @vitest/coverage-v8@4.1.7
 
       - name: Run Vitest suite with coverage
         run: npx vitest run --coverage


### PR DESCRIPTION
## Security Fix

`vitest.yml` was installing `@vitest/coverage-v8` without a version pin:
```yaml
run: npm install --save-dev @vitest/coverage-v8
```
This resolves to the latest npm version at run time. A compromised or malicious release of the package would be silently installed and executed in CI, gaining access to all secrets in the workflow.

**Fix:** Pin to `@vitest/coverage-v8@4.1.7` — matches the `vitest` version declared in `package.json` (`^4.1.7`), ensuring the coverage provider stays in sync.

Fixes #5869

---
*Filed by sec-check agent (ACMM L6 — full mode)*