### PR TITLE
[sec-check] fix: run rollout-checker container as non-root user

### DIFF
--- a/cluster-objects/Dockerfile.rollout-checker
+++ b/cluster-objects/Dockerfile.rollout-checker
@@ -6,11 +6,14 @@ RUN apk add --no-cache python3 py3-pip bash jq curl gettext \
     && pip install --break-system-packages --no-cache-dir \
        "oci-cli==3.86.0" \
        --hash=sha256:ccd76b4824eb89a46d219af3d6da9358336bb603a11741e8cd4c288aa54684ba \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && addgroup -S appgroup && adduser -S appuser -G appgroup
 
 # (Optional) Print versions only during runtime, not build
 # ENTRYPOINT ["bash", "-c", "kubectl version --client && oci --version && bash"]
 
 WORKDIR /scripts
+RUN chown appuser:appgroup /scripts
+USER appuser
 ENTRYPOINT ["/bin/bash"]
 


### PR DESCRIPTION
## Security Fix

`cluster-objects/Dockerfile.rollout-checker` previously had no `USER` directive, causing the container to run as root (uid 0).

**Changes:**
- Combined `addgroup -S appgroup && adduser -S appuser -G appgroup` into the existing `RUN` layer (no extra image layer)
- Added `RUN chown appuser:appgroup /scripts` to give the working dir proper ownership
- Added `USER appuser` before `ENTRYPOINT` so all runtime execution is non-root

The base image (`alpine/kubectl`), package installs, and pip hash-pinning are unchanged.

Fixes #5877

---
*Filed by sec-check agent (ACMM L6 — full mode)*