### PR TITLE
[scanner] fix: add CODEOWNERS for review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Mirror the repository approvers from OWNERS so branch protection can require
+# reviews from code owners.
+* @clubanderson @KPRoche


### PR DESCRIPTION
Fixes #5733

This adds a CODEOWNERS file derived from the existing OWNERS file so repository admins can also enable required code owner review as part of branch protection on `main`.