### PR TITLE
[scanner] fix: resolve broken links in documentation

### DIFF
--- a/docs/content/community/partners/turbonomic.md
+++ b/docs/content/community/partners/turbonomic.md
@@ -20,7 +20,7 @@ There's also [a piece of code](https://github.com/edge-experiments/turbonomic-in
 
 For the second step (GitHub repository-> KubeStellar), we can use Argo CD. The detailed procedure to integrate Argo CD with KubeStellar is documented [here](./argocd.md).
 
-As we can see from the blog and the demo, Turbonomic collects data from edge clusters. This is made possible by installing [kubeturbo](https://github.com/turbonomic/kubeturbo) into each of the edge clusters.
+As we can see from the blog and the demo, Turbonomic collects data from edge clusters. This is made possible by installing [kubeturbo](https://github.com/IBM/turbonomic-container-platform) into each of the edge clusters.
 
 
 ### Turbonomic and KubeStellar in the news

--- a/docs/content/hive/readme.md
+++ b/docs/content/hive/readme.md
@@ -18,7 +18,7 @@ sudo apt install tmux
 
 # 2. install hive
 # Installation script — see hive repository for current install method
-# curl -H "Cache-Control: no-cache" -fsSL https://github.com/kubestellar/hive/raw/main/install.sh | sudo bash
+# curl -H "Cache-Control: no-cache" -fsSL https://github.com/kubestellar/hive/raw/v2/install.sh | sudo bash
 
 # 3. configure
 sudo nano /etc/hive/hive.conf
@@ -92,7 +92,7 @@ curl -sf http://192.168.4.56:3001/api/widget | tar xzf - -C "$HOME/Library/Appli
 The **kick-governor** measures issue and PR backlog across your repos every 5 minutes and picks a mode:
 
 | Mode | Trigger | Scanner | Reviewer | Architect | Outreach | Supervisor |
-|------|---------|---------|----------|-----------|----------|-----------|
+|------|---------|---------|----------|-----------|----------|------------|
 | SURGE | queue > 20 | 10 min | 10 min | **paused** | **paused** | 5 min |
 | BUSY  | queue > 10 | 15 min | 15 min | **paused** | **paused** | 5 min |
 | QUIET | queue > 2  | 15 min | 30 min | 1 h        | 2 h        | 5 min |
@@ -124,7 +124,7 @@ LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliabl
 Each stage runs as a shell script, declared in `hive-project.yaml`, with explicit dependencies:
 
 | Category | What it does | Example |
-|----------|-------------|---------|
+|----------|-------------|----------|
 | **Enumerator** | Fetches and filters the canonical work list | `enumerate-actionable.sh` — queries GitHub, excludes hold/exempt labels, filters by author |
 | **Classifier** | Enriches items with deterministic metadata | `issue-classifier.sh` — complexity, model tier, lane assignment based on label/title patterns |
 | **Gate** | Pre-checks eligibility before action | `merge-gate.sh` — CI green? Author authorized? Required reviews in? |


### PR DESCRIPTION
Fixes #5936

This PR resolves broken links found by the link checker:

1. **turbonomic.md** - Updated `https://github.com/turbonomic/kubeturbo` → `https://github.com/IBM/turbonomic-container-platform`
   - The original `turbonomic` GitHub organization was removed after IBM's acquisition of Turbonomic
   - The new repo contains Helm charts and deployment tooling for kubeturbo

2. **hive/readme.md** - Updated install script URL from `main` → `v2` branch
   - The kubestellar/hive repository was completely rewritten in April 2026
   - The default branch is now `v2` (not `main`)
   - The install.sh script still exists on the v2 branch for backward compatibility