### PR TITLE
[scanner] fix: pin infra workflow refs and add fork guards

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4  # main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4  # main
     secrets: inherit


### PR DESCRIPTION
Fixes #5940

Pins kubestellar/infra reusable workflow references to immutable commit SHAs and adds fork guards to pull_request_target workflows.

- Pin all 9 reusable workflow references from @main to immutable commit SHA a160acca0bdce1ac6c649e006d680d5f6d53024e
- Add fork guards to pull_request_target workflows