### PR TITLE
📖 docs: fix AI features homepage link

### DIFF
--- a/docs/content/console/acmm-dashboard.md
+++ b/docs/content/console/acmm-dashboard.md
@@ -42,7 +42,7 @@ Shows the repository's current maturity level (L1 through L5) as a ring gauge, t
 
 ### ACMM Balance (trend chart)
 
-Weekly bar chart showing the ratio of AI-generated vs human-authored contributions. A level-anchored target slider lets you set a goal (e.g., "aim for L3 = 55% AI"). Click a "Use L{n}" snap button to jump to that level's target. The target persists per-repo in localStorage.
+Weekly bar chart showing the ratio of AI-generated vs human-authored contributions. A level-anchored target slider lets you set a goal (e.g., "aim for L3 = 55% AI"). Click a `Use L{n}` snap button to jump to that level's target. The target persists per-repo in localStorage.
 
 ### Feedback Loop Inventory
 

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -1,9 +1,8 @@
 import { compileMdx } from 'nextra/compile'
-import { Callout, Tabs } from 'nextra/components'
+import { Callout, Mermaid, Tabs } from 'nextra/components'
 import { evaluate } from 'nextra/evaluate'
 import { useMDXComponents as getMDXComponents } from '../../../../mdx-components'
 import { convertHtmlScriptsToJsxComments } from '@/lib/transformMdx'
-import { MermaidComponent } from '@/lib/Mermaid'
 import { sanitizeHtmlForMdx, removeCommentPatterns } from '@/lib/sanitizeHtml'
 import { buildPageMap, docsContentPath } from '../page-map'
 import { CURRENT_VERSION, type ProjectId } from '@/config/versions'
@@ -148,7 +147,7 @@ export default async function DocPage({ params }: Props) {
     const components = getMDXComponents({
       Callout,
       Tabs,
-      MermaidComponent,
+      Mermaid,
       convertHtmlScriptsToJsxComments
     })
     

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import { GridLines, StarField, LanguageSwitcher } from "./index";
 import { useTranslations } from "next-intl";
 import { getLocalizedUrl } from "@/lib/url";
-import { useGithubStats, useNavDropdowns } from "./navbar";
+import { useGithubStats, useNavDropdowns } from "./navbar/index";
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);

--- a/src/components/master-page/AboutSection.tsx
+++ b/src/components/master-page/AboutSection.tsx
@@ -126,7 +126,7 @@ export default function AboutSection() {
 
         <div className="mt-20 grid gap-10 gap-y-20 lg:grid-cols-3 feature-cards">
           {/* Feature 1 - Advanced card with 3D hover effect */}
-          <div className="feature-card relative group perspective cursor-pointer" onClick={() => router.push("/docs/console/features/ai-features")}>
+          <div className="feature-card relative group perspective cursor-pointer" onClick={() => router.push("/docs/console/ai-integration/ai-features")}>
             <div className="card-3d-container relative transition-all duration-500 group-hover:rotate-y-10 w-full h-full transform-style-3d">
               <div className="absolute -inset-0.5 bg-gradient-to-r from-primary-600 to-purple-600 rounded-xl blur opacity-30 group-hover:opacity-90 transition duration-500"></div>
               <div className="relative bg-gray-800/50 backdrop-blur-md rounded-xl shadow-lg p-8 transition-all duration-300 transform group-hover:translate-y-[-8px] group-hover:shadow-xl border border-gray-700/50 h-full flex flex-col justify-between h-full">
@@ -156,7 +156,7 @@ export default function AboutSection() {
 
                 {/* Animated arrow on hover */}
                 <Link
-                  href="/docs/console/features/ai-features"
+                  href="/docs/console/ai-integration/ai-features"
                   className="block h-8 overflow-hidden"
                 >
                   <div className="transform translate-y-8 group-hover:translate-y-0 transition-transform duration-300 text-primary-600 dark:text-primary-400 flex items-center">


### PR DESCRIPTION
## Summary
- update the homepage AI features card link to the generated AI Integration route
- replace the broken `/docs/console/features/ai-features` URL with `/docs/console/ai-integration/ai-features`
- provide the `Mermaid` MDX component and escape an ACMM dashboard label so deploy previews can prerender docs pages
- make the navbar barrel import explicit so type-check/build works on case-insensitive filesystems too

Fixes #5958

## Verification
- `npm test -- src/__tests__/page-map.test.ts`
- `npm run lint`
- `npm run type-check`
- `NEXT_PUBLIC_BRANCH=${BRANCH:-main} npm run build`
- `curl -I -L https://kubestellar.io/docs/console/features/ai-features` returns 404
- `curl -I -L https://kubestellar.io/docs/console/ai-integration/ai-features` returns 200
- Netlify deploy preview is green: https://deploy-preview-5959--kubestellar-docs.netlify.app