### PR TITLE
fix: update search-route tests to match current implementation

### DIFF
--- a/src/__tests__/search-route.test.ts
+++ b/src/__tests__/search-route.test.ts
@@ -28,19 +28,19 @@ const mockFiles: Record<string, string> = {
 vi.mock('fs', () => ({
   default: {
     existsSync: (filePath: string) => {
-      const rel = filePath.replace(/.*\/docs\//, '')
+      const rel = filePath.replace(/.*\/docs\/content\//, '')
       return rel in mockFiles
     },
     readFileSync: (filePath: string) => {
-      const rel = filePath.replace(/.*\/docs\//, '')
+      const rel = filePath.replace(/.*\/docs\/content\//, '')
       return mockFiles[rel] || ''
     },
   },
 }))
 
-vi.mock('../../docs/page-map', () => ({
+vi.mock('../../app/docs/page-map', () => ({
   buildPageMap: () => ({ routeMap: mockRouteMap }),
-  docsContentPath: '/fake/docs/',
+  docsContentPath: '/fake/docs/content',
   basePath: 'docs',
 }))
 


### PR DESCRIPTION
Fixes pre-existing Vitest failures in `search-route.test.ts` that are blocking all PRs in this repo (including docs#5961 and docs#5957).

## Changes

The search route implementation uses `../../app/docs/page-map` as the import path and stores docs in `docs/content/`, but the tests had outdated mocks pointing to `../../docs/page-map` with `docs/` paths.

Updated test mocks to match the actual implementation:
- ✅ Changed mock path from `'../../docs/page-map'` to `'../../app/docs/page-map'`
- ✅ Updated `docsContentPath` to `'/fake/docs/content'` to match actual path structure  
- ✅ Fixed file path pattern matching in fs mocks to use `docs/content/` instead of `docs/`

## Fixes

This resolves all 5 failing test assertions:
- ✅ "returns matching results for a valid query" — expected 0 to be greater than 0
- ✅ "prioritizes title matches over content matches" — expected 0 to be greater than 0  
- ✅ "generates correct URLs from route keys" — expected undefined to be defined
- ✅ "extracts category from first path segment" — expected undefined to be 'Getting Started'
- ✅ "is case-insensitive" — expected 0 to be greater than 0

The tests now correctly mock the file system and page-map module, allowing the search route handler to find and process the mock documentation files.