### PR TITLE
[scanner] fix: resolve 17 broken nav-generated doc links via routeMap fallback

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -4,7 +4,7 @@ import { evaluate } from 'nextra/evaluate'
 import { useMDXComponents as getMDXComponents } from '../../../../mdx-components'
 import { convertHtmlScriptsToJsxComments } from '@/lib/transformMdx'
 import { sanitizeHtmlForMdx, removeCommentPatterns } from '@/lib/sanitizeHtml'
-import { buildPageMap, docsContentPath } from '../page-map'
+import { buildPageMap, docsContentPath, getContentPath } from '../page-map'
 import { CURRENT_VERSION, type ProjectId } from '@/config/versions'
 import fs from 'fs'
 import path from 'path'
@@ -86,7 +86,7 @@ async function getPageContent(slug: string[], projectId?: ProjectId): Promise<st
   const filePath = slug.join('/') + '.md'
   
   const contentPath = projectId 
-    ? path.join(docsContentPath, '..', projectId, 'content')
+    ? getContentPath(projectId)
     : docsContentPath
 
   // Try .md first, then .mdx
@@ -94,6 +94,21 @@ async function getPageContent(slug: string[], projectId?: ProjectId): Promise<st
   if (!content) {
     const mdxPath = slug.join('/') + '.mdx'
     content = readLocalFile(mdxPath, contentPath)
+  }
+
+  // If direct lookup failed, consult the routeMap for nav-generated routes
+  if (!content) {
+    const mapProjectId = projectId || 'kubestellar'
+    const { routeMap } = buildPageMap(mapProjectId)
+    const routeKey = slug.join('/')
+    const mappedFile = routeMap[routeKey]
+    if (mappedFile) {
+      content = readLocalFile(mappedFile, contentPath)
+      if (!content) {
+        // Also try in the default docs content path (for general sections)
+        content = readLocalFile(mappedFile, docsContentPath)
+      }
+    }
   }
   
   return content
@@ -112,9 +127,9 @@ async function buildContent(slug: string[], projectId?: ProjectId): Promise<stri
 }
 
 function getProjectFromSlug(slug: string[]): { projectId: ProjectId | undefined; docSlug: string[] } {
-  const knownProjects = ['kubestellar', 'clusteradm-ocm', 'ks-core']
+  const knownProjects: string[] = ['kubestellar', 'clusteradm-ocm', 'ks-core', 'multi-plugin', 'hive', 'kubestellar-mcp', 'console', 'a2a', 'kubeflex']
   
-  if (slug.length > 0 && knownProjects.includes(slug[0] as ProjectId)) {
+  if (slug.length > 0 && knownProjects.includes(slug[0])) {
     return {
       projectId: slug[0] as ProjectId,
       docSlug: slug.slice(1)


### PR DESCRIPTION
Fixes #6005, Fixes #6006, Fixes #6007, Fixes #6008, Fixes #6009, Fixes #6010, Fixes #6011, Fixes #6012, Fixes #6013, Fixes #6014, Fixes #6015, Fixes #6016, Fixes #6017, Fixes #6018, Fixes #6019, Fixes #6020, Fixes #6021

## Root Cause

The page-map navigation system generates routes by slugifying nav item titles (e.g., the nav entry `{ 'Architecture': 'architecture_guide.md' }` under section "Overview" creates route `/docs/multi-plugin/overview/architecture`). However, `page.tsx` was resolving slugs directly to file paths (`overview/architecture.md`) without consulting the `routeMap` that maps slug-based routes back to actual file paths.

This caused ALL nav-generated routes where the slugified title differs from the filename to 404.

## Fix

1. **Expanded `getProjectFromSlug`** to recognize all valid `ProjectId` values (multi-plugin, hive, kubestellar-mcp, console, a2a, kubeflex) — previously only recognized kubestellar, clusteradm-ocm, ks-core
2. **Fixed content path resolution** — use `getContentPath()` from page-map instead of a broken relative path formula
3. **Added routeMap fallback** — when direct file lookup fails, consult `buildPageMap()` routeMap to resolve nav-generated slug routes to their actual file paths

This single fix resolves all 17 broken link issues since they all share the same root cause.