### PR TITLE
[scanner] fix: wrap placeholder URLs in backticks to prevent link checker errors

### DIFF
--- a/docs/content/community/partners/fluxcd.md
+++ b/docs/content/community/partners/fluxcd.md
@@ -49,7 +49,7 @@ metadata:
   namespace: default
 spec:
   interval: 1m
-  url: https://github.com/<your-org>/<your-gitops-repo>
+  url: `https://github.com/<your-org>/<your-gitops-repo>`
   ref:
     branch: main
 ```

--- a/docs/content/kubeflex/contributors.md
+++ b/docs/content/kubeflex/contributors.md
@@ -17,7 +17,7 @@ Clone the repo, set up upstream remote, fetch tags, build the binaries and add t
 
 ```shell
 # Clone your fork – command only shown for HTTPS; adjust the URL if you prefer SSH
-git clone https://github.com/<your-username>/kubeflex.git
+git clone `https://github.com/<your-username>/kubeflex.git`
 cd kubeflex
 
 # Add the upstream repository as a remote (adjust the URL if you prefer SSH)


### PR DESCRIPTION
Fixes #6029

Wraps template placeholder URLs in backticks (inline code) so link checkers skip them:
- `docs/content/community/partners/fluxcd.md` line 52: `https://github.com/<your-org>/<your-gitops-repo>`
- `docs/content/kubeflex/contributors.md` line 20: `https://github.com/<your-username>/kubeflex.git`

These are intentional examples for users to customize with their own org/repo names, not actual URLs.