### PR TITLE
🌱 [scanner] fix: resolve 7 remaining broken nav-generated doc links

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -56,6 +56,16 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: "/architecture_guide",
+        destination: "/docs/multi-plugin/overview/architecture",
+        permanent: true,
+      },
+      {
+        source: "/installation_guide",
+        destination: "/docs/multi-plugin/getting-started/installation",
+        permanent: true,
+      },
+      {
         source: "/code",
         destination: "https://github.com/kubestellar/kubestellar",
         permanent: true,


### PR DESCRIPTION
Fixes #6022, Fixes #6023, Fixes #6024, Fixes #6025, Fixes #6026, Fixes #6027, Fixes #6028

These issues share the same root cause as #6005-#6021 (fixed in PR #6030) — nav-generated slug routes where the slugified title differs from the content filename.

## Summary

PR #6030's routeMap fallback already handles 5 of these 7 issues:
- #6022: `/docs/contributing/contributing-to-docs-website/version-management` → `contributing/documentation/docs-version-inc.md`
- #6023: `/docs/contributing/ci-cd/github-actions` → `contributing/operations/github-actions.md`
- #6025: `/docs/multi-plugin/reference/api-reference` → `multi-plugin/api_reference.md`
- #6026: `/docs/contributing/contributor-ladder` → `contributing/contributor_ladder.md`
- #6028: `/docs/contributing/ci-cd/demoting-component-repo-docs` → `contributing/operations/demote-component-docs.md`

Issues #6024 and #6027 had broken links missing the `/docs/multi-plugin/` prefix:
- #6024: `/architecture_guide` → now redirects to `/docs/multi-plugin/overview/architecture`
- #6027: `/installation_guide` → now redirects to `/docs/multi-plugin/getting-started/installation`

## Changes

- Add redirects in `next.config.ts` for legacy root-level multi-plugin doc URLs (`/architecture_guide` and `/installation_guide`)