### PR TITLE
[scanner] fix: repair broken links on multi-plugin page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -57,12 +57,27 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/architecture_guide",
-        destination: "/docs/multi-plugin/overview/architecture",
+        destination: "/docs/multi-plugin/architecture_guide",
+        permanent: true,
+      },
+      {
+        source: "/development_guide",
+        destination: "/docs/multi-plugin/development_guide",
         permanent: true,
       },
       {
         source: "/installation_guide",
-        destination: "/docs/multi-plugin/getting-started/installation",
+        destination: "/docs/multi-plugin/installation_guide",
+        permanent: true,
+      },
+      {
+        source: "/api_reference",
+        destination: "/docs/multi-plugin/api_reference",
+        permanent: true,
+      },
+      {
+        source: "/usage_guide",
+        destination: "/docs/multi-plugin/usage_guide",
         permanent: true,
       },
       {


### PR DESCRIPTION
Fixes #6034
Fixes #6035
Fixes #6036
Fixes #6037
Fixes #6038

## Summary

All 5 broken links (`/architecture_guide`, `/development_guide`, `/installation_guide`, `/api_reference`, `/usage_guide`) were returning 404 errors. These URLs are used on the multi-plugin documentation page.

## Changes

Updated `next.config.ts` redirects to point to the correct paths:
- `/architecture_guide` → `/docs/multi-plugin/architecture_guide` (fixed)
- `/development_guide` → `/docs/multi-plugin/development_guide` (added)
- `/installation_guide` → `/docs/multi-plugin/installation_guide` (fixed)
- `/api_reference` → `/docs/multi-plugin/api_reference` (added)
- `/usage_guide` → `/docs/multi-plugin/usage_guide` (added)

## Testing

These redirects will route traffic to the existing markdown files in `docs/content/multi-plugin/`.