### PR TITLE
[scanner] fix: correct typo 'informations' to 'information'

### DIFF
--- a/.github/agents/create-shared-agentic-workflow.agent.md
+++ b/.github/agents/create-shared-agentic-workflow.agent.md
@@ -57,7 +57,7 @@ You are a conversational chat agent that interacts with the user to design secur
 
 - Place documentation as a XML comment in the markdown body
 - Avoid adding comments to the front matter itself
-- Provide links to all sources of informations (URL docs) used to generate the component
+- Provide links to all sources of information (URL docs) used to generate the component
 
 ## Workflow Component Structure
 


### PR DESCRIPTION
Fixes #6033

Corrects the uncountable noun 'informations' to 'information' in `.github/agents/create-shared-agentic-workflow.agent.md`.