### PR TITLE
[scanner] fix: harden workflow security (3 workflows)

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -14,4 +14,3 @@ permissions:
 jobs:
   greet:
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
-    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -11,4 +11,3 @@ permissions:
 jobs:
   verify:
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit


### PR DESCRIPTION
Fixes #6044, Fixes #6045, Fixes #6046

Hardens pull_request_target workflows by adding fork guards and removing unnecessary secrets exposure.

## Changes
- **greetings.yml**: Removed `secrets: inherit` from reusable workflow call (fixes #6044)
- **ai-fix.yml**: Added fork guard condition to prevent fork PRs from executing with write permissions (fixes #6045)
- **pr-verifier.yml**: Removed `secrets: inherit` from reusable workflow call (fixes #6046)