### PR TITLE
[scanner] fix: repair broken internal links in docs

### DIFF
--- a/docs/content/community/partners/security-ecosystem.md
+++ b/docs/content/community/partners/security-ecosystem.md
@@ -11,7 +11,7 @@ KubeStellar Console includes built-in support for OSCAL-based compliance assessm
 - **Per-Cluster Status**: Real-time compliance posture across your multi-cluster fleet
 - **Trestle Integration**: Compliance data streaming and continuous assessment
 
-For configuration details, see [Compliance Trestle (OSCAL) Card](../console/console-features.md#compliance-trestle-oscal).
+For configuration details, see [Compliance Trestle (OSCAL) Card](../../console/console-features.md#compliance-trestle-oscal).
 
 ## Security Partners
 
@@ -28,6 +28,6 @@ For configuration details, see [Compliance Trestle (OSCAL) Card](../console/cons
 ## Integration Resources
 
 For comprehensive information on security ecosystem integrations:
-- [KubeStellar Security Model](../console/security-model.md)
-- [Console Features Guide](../console/console-features.md)
+- [KubeStellar Security Model](../../console/security-model.md)
+- [Console Features Guide](../../console/console-features.md)
 - [Partner Integrations](./argocd.md)

--- a/docs/content/hive/overview/intro.md
+++ b/docs/content/hive/overview/intro.md
@@ -124,7 +124,7 @@ LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliabl
 Each stage runs as a shell script, declared in `hive-project.yaml`, with explicit dependencies:
 
 | Category | What it does | Example |
-|----------|-------------|----------|
+|----------|-------------|---------|
 | **Enumerator** | Fetches and filters the canonical work list | `enumerate-actionable.sh` — queries GitHub, excludes hold/exempt labels, filters by author |
 | **Classifier** | Enriches items with deterministic metadata | `issue-classifier.sh` — complexity, model tier, lane assignment based on label/title patterns |
 | **Gate** | Pre-checks eligibility before action | `merge-gate.sh` — CI green? Author authorized? Required reviews in? |
@@ -314,4 +314,4 @@ journalctl -u claude-scanner # raw service log
 
 ---
 
-Apache 2.0  ·  [Architecture](architecture.md)
+Apache 2.0  ·  [Architecture](../architecture.md)

--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -18,11 +18,11 @@ KubeStellar provides a unified control plane for managing workloads across multi
 
 Choose the component that best fits your needs:
 
-- **[KubeStellar Core](./kubestellar-core/overview/introduction.md)** - The main KubeStellar platform
-- **[kubectl-multi Plugin](./multi-plugin/overview/introduction.md)** - Multi-cluster kubectl plugin
+- **[KubeStellar Core](./kubestellar/user-guide-intro.md)** - The main KubeStellar platform
+- **[kubectl-multi Plugin](./multi-plugin/overview.md)** - Multi-cluster kubectl plugin
 - **[A2A (Application to Application)](./a2a/intro.md)** - Application-level multi-cluster management
-- **[KubeFlex](./kubeflex/intro.md)** - Flexible Kubernetes control planes
-- **[Console](./console/overview.md)** - Web-based management interface
+- **[KubeFlex](./kubeflex/readme.md)** - Flexible Kubernetes control planes
+- **[Console](./console/readme.md)** - Web-based management interface
 
 ## Documentation Sections
 
@@ -32,9 +32,9 @@ Choose the component that best fits your needs:
 
 ## Quick Links
 
-- [Installation Guide](./kubestellar-core/installation/installation.md)
-- [Quick Start](./kubestellar-core/getting-started/quick-start.md)
-- [Architecture](./kubestellar-core/architecture/architecture.md)
+- [Installation Guide](./console/installation.md)
+- [Quick Start](./kubestellar/get-started.md)
+- [Architecture](./kubestellar/architecture.md)
 - [GitHub Repository](https://github.com/kubestellar/kubestellar)
 
 ## Support

--- a/docs/content/multi-plugin/getting-started.md
+++ b/docs/content/multi-plugin/getting-started.md
@@ -27,11 +27,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](../installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](../usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](../architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](../development_guide.md)** - Contributing and development workflow
-- **[API Reference](../api_reference.md)** - Code organization and technical implementation
+- **[Installation Guide](./installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](./usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](./architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](./development_guide.md)** - Contributing and development workflow
+- **[API Reference](./api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack
 


### PR DESCRIPTION
Fixes #6054, Fixes #6055, Fixes #6056, Fixes #6057

Also fixes additional broken internal links found in issue #6053:
- security-ecosystem.md references to console files
- hive/overview/intro.md architecture link
- introduction.md guide links

## Changes

### docs/content/multi-plugin/getting-started.md
- Fixed links to installation_guide.md, usage_guide.md, architecture_guide.md, development_guide.md, and api_reference.md
- Changed from `../` to `./` since files are in the same directory

### docs/content/community/partners/security-ecosystem.md
- Fixed console references from `../console/` to `../../console/`
- Corrected path from community/partners/ to console/

### docs/content/hive/overview/intro.md  
- Fixed architecture link from `architecture.md` to `../architecture.md`
- Now correctly points to docs/content/hive/architecture.md

### docs/content/introduction.md
- Updated `kubestellar-core/` references to actual paths
- Changed KubeStellar Core link to `./kubestellar/user-guide-intro.md`
- Changed kubectl-multi Plugin link to `./multi-plugin/overview.md`
- Changed KubeFlex link to `./kubeflex/readme.md`
- Changed Console link to `./console/readme.md`
- Changed Quick Links to point to actual files:
  - Installation Guide: `./console/installation.md`
  - Quick Start: `./kubestellar/get-started.md`
  - Architecture: `./kubestellar/architecture.md`