### PR TITLE
[sec-check] fix: run rollout-checker CronJobs as non-root with OCI config in home dir

### DIFF
--- a/cluster-objects/Dockerfile.rollout-checker
+++ b/cluster-objects/Dockerfile.rollout-checker
@@ -4,7 +4,10 @@ FROM docker.io/alpine/kubectl:1.34.1@sha256:8413f8890d19aa03f63851654f642957e65b
 # Install runtime dependencies and OCI CLI (all dependencies hash-pinned)
 RUN apk add --no-cache python3 py3-pip bash jq curl gettext \
     && rm -rf /var/cache/apk/* \
-    && addgroup -S appgroup && adduser -S appuser -G appgroup
+    && addgroup -S appgroup \
+    && adduser -S -h /home/appuser -G appgroup appuser \
+    && mkdir -p /home/appuser/.oci \
+    && chown -R appuser:appgroup /home/appuser
 
 COPY requirements.txt /requirements.txt
 RUN pip install --break-system-packages --require-hashes --no-cache-dir -r /requirements.txt \

--- a/cluster-objects/job.yaml
+++ b/cluster-objects/job.yaml
@@ -97,10 +97,17 @@ spec:
         spec:
           serviceAccountName: nextra-rollout-sa
           restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
           containers:
             - name: rollout-checker
               image: iad.ocir.io/id4wyucbsggm/docs-rollout-checker:stable
               imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               command:
                 - /bin/sh
                 - -c
@@ -109,7 +116,7 @@ spec:
                 - name: script
                   mountPath: /scripts
                 - name: oci-config
-                  mountPath: /root/.oci
+                  mountPath: /home/appuser/.oci
               envFrom:
                 - secretRef:
                     name: oci-config-secret

--- a/cluster-objects/pr-job.yaml
+++ b/cluster-objects/pr-job.yaml
@@ -196,10 +196,17 @@ spec:
         spec:
           serviceAccountName: nextra-rollout-sa
           restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
           containers:
             - name: pr-rollout-checker
               image: iad.ocir.io/id4wyucbsggm/docs-rollout-checker:stable
               imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               command:
                 - /bin/bash
                 - -c
@@ -208,7 +215,7 @@ spec:
                 - name: script
                   mountPath: /scripts
                 - name: oci-config
-                  mountPath: /root/.oci
+                  mountPath: /home/appuser/.oci
               envFrom:
                 - secretRef:
                     name: oci-config-secret


### PR DESCRIPTION
## Security Fix

Addresses #6085 — rollout-checker CronJobs were effectively running as root because the OCI CLI config was mounted at `/root/.oci`, requiring root access to read it.

### Root cause

Alpine's `adduser -S appuser` without `-h` creates the user without a proper home directory. The OCI CLI looks for config at `$HOME/.oci/config`, and without an explicit home, `$HOME` defaults to `/root`, forcing the container to run as root to access the mounted secret.

### Changes

**`Dockerfile.rollout-checker`**
- Add `-h /home/appuser` to `adduser` to establish an explicit home directory
- Create and pre-own `/home/appuser/.oci` so the OCI CLI finds its config at the right path

**`cluster-objects/job.yaml`**
- Mount `oci-config` secret at `/home/appuser/.oci` (was `/root/.oci`)
- Add pod `securityContext`: `runAsNonRoot: true`, `runAsUser: 1001`
- Add container `securityContext`: `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`

**`cluster-objects/pr-job.yaml`**
- Same mount-path and `securityContext` changes as `job.yaml`

Fixes #6085

---
*Filed by sec-check agent (ACMM L6 — full mode)*