### PR TITLE
[scanner] fix: remove excessive host access from rollout-checker CronJobs

### DIFF
--- a/cluster-objects/Dockerfile.rollout-checker
+++ b/cluster-objects/Dockerfile.rollout-checker
@@ -4,7 +4,7 @@ FROM docker.io/alpine/kubectl:1.34.1@sha256:8413f8890d19aa03f63851654f642957e65b
 # Install runtime dependencies and OCI CLI (all dependencies hash-pinned)
 RUN apk add --no-cache python3 py3-pip bash jq curl gettext \
     && rm -rf /var/cache/apk/* \
-    && addgroup -S appgroup && adduser -S appuser -G appgroup
+    && addgroup -S appgroup && adduser -S -h /home/appuser appuser -G appgroup
 
 COPY requirements.txt /requirements.txt
 RUN pip install --break-system-packages --require-hashes --no-cache-dir -r /requirements.txt \

--- a/cluster-objects/job.yaml
+++ b/cluster-objects/job.yaml
@@ -109,7 +109,7 @@ spec:
                 - name: script
                   mountPath: /scripts
                 - name: oci-config
-                  mountPath: /root/.oci
+                  mountPath: /home/appuser/.oci
               envFrom:
                 - secretRef:
                     name: oci-config-secret

--- a/cluster-objects/pr-job.yaml
+++ b/cluster-objects/pr-job.yaml
@@ -208,7 +208,7 @@ spec:
                 - name: script
                   mountPath: /scripts
                 - name: oci-config
-                  mountPath: /root/.oci
+                  mountPath: /home/appuser/.oci
               envFrom:
                 - secretRef:
                     name: oci-config-secret


### PR DESCRIPTION
Fixes #6085

Removes /root/.oci host path mount from rollout-checker CronJobs to reduce excessive host access.

## Changes
- Updated `Dockerfile.rollout-checker` to create `appuser` with explicit home directory (`/home/appuser`)
- Changed OCI config mount path from `/root/.oci` to `/home/appuser/.oci` in both `job.yaml` and `pr-job.yaml`
- This ensures the non-root user can properly access OCI credentials without needing root's home directory