### PR TITLE
[scanner] fix: resolve broken links

### DIFF
--- a/docs/content/multi-plugin/api_reference.md
+++ b/docs/content/multi-plugin/api_reference.md
@@ -435,4 +435,4 @@ func buildHeader(resourceType string, allNamespaces, showLabels bool) string {
 }
 ```
 
-This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](/docs/multi-plugin/usage_guide), and for architectural details, see the [Architecture Guide](/docs/multi-plugin/architecture_guide).
+This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](usage_guide.md), and for architectural details, see the [Architecture Guide](architecture_guide.md).

--- a/docs/content/multi-plugin/getting-started.md
+++ b/docs/content/multi-plugin/getting-started.md
@@ -27,11 +27,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
-- **[API Reference](/docs/multi-plugin/api_reference)** - Code organization and technical implementation
+- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](development_guide.md)** - Contributing and development workflow
+- **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/installation_guide.md
+++ b/docs/content/multi-plugin/installation_guide.md
@@ -202,6 +202,6 @@ make uninstall
 ## Next Steps
 
 After successful installation:
-1. Read the [Usage Guide](/docs/multi-plugin/usage_guide) for detailed examples
-2. Check the [Architecture Guide](/docs/multi-plugin/architecture_guide) to understand how it works
-3. See [Development Guide](/docs/multi-plugin/development_guide) if you want to contribute
+1. Read the [Usage Guide](usage_guide.md) for detailed examples
+2. Check the [Architecture Guide](architecture_guide.md) to understand how it works
+3. See [Development Guide](development_guide.md) if you want to contribute

--- a/docs/content/multi-plugin/overview.md
+++ b/docs/content/multi-plugin/overview.md
@@ -77,11 +77,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
-- **[API Reference](/docs/multi-plugin/api_reference)** - Code organization and technical implementation
+- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](development_guide.md)** - Contributing and development workflow
+- **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/overview/introduction.md
+++ b/docs/content/multi-plugin/overview/introduction.md
@@ -27,11 +27,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
-- **[API Reference](/docs/multi-plugin/api_reference)** - Code organization and technical implementation
+- **[Installation Guide](../installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](../usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](../architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](../development_guide.md)** - Contributing and development workflow
+- **[API Reference](../api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/readme.md
+++ b/docs/content/multi-plugin/readme.md
@@ -77,11 +77,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
-- **[API Reference](/docs/multi-plugin/api_reference)** - Code organization and technical implementation
+- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](development_guide.md)** - Contributing and development workflow
+- **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/reference.md
+++ b/docs/content/multi-plugin/reference.md
@@ -435,4 +435,4 @@ func buildHeader(resourceType string, allNamespaces, showLabels bool) string {
 }
 ```
 
-This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](/docs/multi-plugin/usage_guide), and for architectural details, see the [Architecture Guide](/docs/multi-plugin/architecture_guide).
+This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](usage_guide.md), and for architectural details, see the [Architecture Guide](architecture_guide.md).

--- a/docs/content/multi-plugin/usage_guide.md
+++ b/docs/content/multi-plugin/usage_guide.md
@@ -288,6 +288,6 @@ kubectl multi get --help
 
 ## Next Steps
 
-- Learn about the internal [Architecture](/docs/multi-plugin/architecture_guide)
-- Contribute to development with the [Development Guide](/docs/multi-plugin/development_guide)
+- Learn about the internal [Architecture](architecture_guide.md)
+- Contribute to development with the [Development Guide](development_guide.md)
 - Check the [API Reference](api_reference.md) for technical details


### PR DESCRIPTION
Fixes #6090

Resolves broken links detected in automated link check run.

Changed absolute web paths (`/docs/multi-plugin/xxx`) to relative markdown file references (`xxx.md`) for all internal documentation links in the multi-plugin directory.

## Changes
- Updated links in 8 files to use relative paths instead of absolute web routes
- Files in the root multi-plugin directory now use `xxx.md` format
- Files in the `overview/` subdirectory now use `../xxx.md` format