### PR TITLE
[scanner] fix: tighten permissions in run-all-maintainer-audits.yml

### DIFF
--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -6,11 +6,15 @@ on:
     # Run every Monday at 12:00 PM Eastern (17:00 UTC)
     - cron: "0 17 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   audit-all:
+    # actions:write needed to trigger maintainer-metrics.lock.yml workflow via gh workflow run
+    # This is the minimum permission required for workflow_dispatch operations
     permissions:
+      contents: read
       actions: write
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fixes #6092

Tightens workflow permissions in run-all-maintainer-audits.yml to follow the principle of least privilege.

## Changes
- Changed workflow-level permissions from `read-all` to explicit `contents: read`
- Kept job-level `actions: write` with explanatory comment (required for `gh workflow run`)
- Added `contents: read` at job level for clarity
- Added comment explaining why `actions: write` is necessary for workflow_dispatch operations

This ensures the workflow has minimal permissions while maintaining functionality.