### PR TITLE
[scanner] fix: document workflow permission requirements (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -17,6 +17,7 @@ permissions: read-all
 jobs:
   ai-fix:
     permissions:
+      # Required: reusable workflow creates PRs and issue comments for AI-powered fixes
       contents: write
       issues: write
       pull-requests: write

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -20,6 +20,7 @@ jobs:
   copilot-automation:
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
+      # Required: reusable workflow creates commits, PR comments, and status checks
       contents: write
       pull-requests: write
       issues: write

--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -35,6 +35,7 @@ permissions: read-all
 jobs:
   create-branch:
     permissions:
+      # Required: creates version branches and PRs to update version metadata
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-acmm-history.yml
+++ b/.github/workflows/generate-acmm-history.yml
@@ -11,6 +11,7 @@ permissions: read-all
 jobs:
   generate:
     permissions:
+      # Required: commits ACMM history data and creates failure tracking issues
       contents: write
       issues: write
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-console-release-versions.yml
+++ b/.github/workflows/sync-console-release-versions.yml
@@ -10,6 +10,7 @@ permissions: read-all
 jobs:
   sync-console-releases:
     permissions:
+      # Required: creates version branches and PRs to sync console release metadata
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #6095

## Summary
Adds inline comments to workflow files explaining why job-level write permissions are required. All flagged permissions are legitimately needed:

- **copilot-automation.yml**: Creates commits, PR comments, and status checks via reusable workflow
- **ai-fix.yml**: Creates PRs and issue comments for AI-powered fixes via reusable workflow  
- **sync-console-release-versions.yml**: Creates version branches and PRs to sync console release metadata
- **generate-acmm-history.yml**: Commits ACMM history data and creates failure tracking issues
- **create-version-branch.yml**: Creates version branches and PRs to update version metadata

## Approach
Rather than removing permissions (which would break functionality), this PR adds inline documentation explaining **why** each permission is required. This improves auditability for Scorecard reviews without compromising security.

## Note
- Skipped `technical-doc-writer.lock.yml` as it's auto-generated and shouldn't be manually edited
- `run-all-maintainer-audits.yml` already had an excellent comment explaining its `actions:write` permission