### PR TITLE
[scanner] fix: add explicit token permissions to workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,10 +4,11 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   label:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   assignment-helper:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24

--- a/.github/workflows/auto-label-bugs.yml
+++ b/.github/workflows/auto-label-bugs.yml
@@ -8,11 +8,12 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   label:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label bug reports

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  pull-requests: read
+permissions: read-all
 
 jobs:
   copilot-dco:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 jobs:
   feedback:
+    permissions:
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,11 +6,11 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   greet:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,12 +4,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   label-helper:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit

--- a/.github/workflows/preview-links-comment.yml
+++ b/.github/workflows/preview-links-comment.yml
@@ -6,13 +6,12 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
-  pull-requests: write
-  actions: read
+permissions: read-all
 
 jobs:
   post-preview-links:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,10 +5,11 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit


### PR DESCRIPTION
Fixes #6105

## Summary

Reduces security risk by moving write permissions from top-level to job-level in 9 workflow files. This follows OpenSSF Scorecard best practices to minimize the blast radius of potential token compromise.

## Changes

**Top-level permissions**: Changed from specific write permissions to `read-all` (consistent with Scorecard recommendations)

**Job-level permissions**: Moved write permissions to job scope with minimum required access:

- `add-help-wanted.yml` → `issues: write`
- `assignment-helper.yml` → `issues: write`
- `auto-label-bugs.yml` → `issues: write`
- `copilot-dco.yml` → `read-all` (no write needed)
- `feedback.yml` → `pull-requests: write`
- `greetings.yml` → `issues: write`, `pull-requests: write`
- `label-helper.yml` → `issues: write`, `pull-requests: write`
- `preview-links-comment.yml` → `pull-requests: write`
- `stale.yml` → `issues: write`

## Impact

This addresses 11 Scorecard token-permission alerts by ensuring:
1. Default permissions are read-only at the workflow level
2. Write permissions are explicitly scoped to jobs that need them
3. The principle of least privilege is enforced throughout

## Testing

Workflow files follow the same pattern as existing compliant workflows in this repository (`scorecard.yml`, `pr-verifier.yml`, `run-all-maintainer-audits.yml`).