### PR TITLE
[scanner] fix: correct broken documentation links

### DIFF
--- a/docs/content/kubeflex/users.md
+++ b/docs/content/kubeflex/users.md
@@ -25,7 +25,7 @@ Kubeflex configuration is now stored as part of the kubeconfig extension data, h
 
 ## Installation
 
-Installation instructions are [here](../kubestellar/installation.md#kubeflex-setup).
+Installation instructions are [here](quickstart.md).
 
 ## Usage
 

--- a/docs/content/news/drasi-case-study-verified-install-mission.md
+++ b/docs/content/news/drasi-case-study-verified-install-mission.md
@@ -6,7 +6,7 @@ When a project maintainer runs your guided install workflow, finds bugs, reports
 
 That's exactly what happened with [Drasi](https://drasi.io), a CNCF Sandbox project for change data capture in cloud-native applications. A Drasi maintainer ran the KubeStellar Console install mission at [console.kubestellar.io/missions/install-drasi](https://console.kubestellar.io/missions/install-drasi) end-to-end — found issues, reported them, tracked engagement in [drasi-project/drasi-platform#400](https://github.com/drasi-project/drasi-platform/issues/400), and confirmed the experience was solid enough to recommend.
 
-Drasi is now listed in [KubeStellar Console's ADOPTERS file](https://github.com/kubestellar/console/blob/main/ADOPTERS.MD) — and is the first CNCF Sandbox project to have a maintainer-verified install mission in the console.
+Drasi is now listed in [KubeStellar Console's ADOPTERS file](https://github.com/kubestellar/console/blob/main/ADOPTERS.md) — and is the first CNCF Sandbox project to have a maintainer-verified install mission in the console.
 
 ---
 

--- a/docs/content/news/kubestellar-for-ai-infrastructure.md
+++ b/docs/content/news/kubestellar-for-ai-infrastructure.md
@@ -154,7 +154,7 @@ helm install kubestellar kubestellar/kubestellar-operator
 ```
 
 **Explore the integrations:**
-- [LLM-d Dashboards](../console/dashboards.md#llm-d-overview-dashboard)
+- [LLM-d Dashboards](../console/dashboards.md#aiml-dashboard)
 - [Kagenti Setup](../console/kagenti-llm-provider-setup.md)
 - [AI Missions](../console/ai-missions-setup.md)
 


### PR DESCRIPTION
This PR fixes broken documentation links identified by the link checker.

## Changes

### Fixed in Issue #6107:
1. **kubeflex/users.md** (line 28): Updated installation link from non-existent `../kubestellar/installation.md#kubeflex-setup` to `quickstart.md`
2. **news/drasi-case-study-verified-install-mission.md** (line 9): Fixed file extension case from `ADOPTERS.MD` to `ADOPTERS.md` (GitHub URLs are case-sensitive)
3. **news/kubestellar-for-ai-infrastructure.md** (line 157): Updated anchor from non-existent `#llm-d-overview-dashboard` to `#aiml-dashboard`

### Issues #6108-6111 (not included):
These issues report broken links for `/installation_guide`, `/development_guide`, `/usage_guide`, and `/architecture_guide`. However, redirects for these URLs already exist in `next.config.ts` (lines 59-82) that properly redirect to `/docs/multi-plugin/*`. These will be addressed separately by commenting on those issues.

Fixes #6107