### PR TITLE
Fix legacy multi-plugin redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -98,6 +98,37 @@
   # Enable spam filtering
   spam_protection = true
 
+# Redirect legacy multi-plugin shortcuts before Next.js locale middleware.
+[[redirects]]
+  from = "/architecture_guide"
+  to = "/docs/multi-plugin/architecture_guide"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/development_guide"
+  to = "/docs/multi-plugin/development_guide"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/installation_guide"
+  to = "/docs/multi-plugin/installation_guide"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/api_reference"
+  to = "/docs/multi-plugin/api_reference"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/usage_guide"
+  to = "/docs/multi-plugin/usage_guide"
+  status = 301
+  force = true
+
 # Redirect /hive and /:locale/hive to the live hive dashboard
 [[redirects]]
   from = "/hive"


### PR DESCRIPTION
## Summary
- Add forced Netlify redirects for legacy multi-plugin shortcut URLs before the locale middleware handles them.
- Mirror the existing Next.js redirect targets for the multi-plugin guide pages.

Fixes #6115
Fixes #6116
Fixes #6117
Fixes #6118

## Testing
- `git diff --check`
- Verified the legacy root URLs currently redirect through `/en/...` and 404.
- Verified the `/docs/multi-plugin/...` redirect targets return 200.

Not run: full site build (dependencies are not installed in this checkout).