### PR TITLE
[scanner] fix: update broken links in multi-plugin docs

### DIFF
--- a/docs/content/multi-plugin/getting-started.md
+++ b/docs/content/multi-plugin/getting-started.md
@@ -27,10 +27,10 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](development_guide.md)** - Contributing and development workflow
+- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
 - **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack

--- a/docs/content/multi-plugin/installation_guide.md
+++ b/docs/content/multi-plugin/installation_guide.md
@@ -204,4 +204,4 @@ make uninstall
 After successful installation:
 1. Read the [Usage Guide](usage_guide.md) for detailed examples
 2. Check the [Architecture Guide](architecture_guide.md) to understand how it works
-3. See [Development Guide](development_guide.md) if you want to contribute
+3. See [Development Guide](/docs/multi-plugin/development_guide) if you want to contribute

--- a/docs/content/multi-plugin/overview.md
+++ b/docs/content/multi-plugin/overview.md
@@ -77,10 +77,10 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](development_guide.md)** - Contributing and development workflow
+- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
 - **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack

--- a/docs/content/multi-plugin/overview/introduction.md
+++ b/docs/content/multi-plugin/overview/introduction.md
@@ -27,10 +27,10 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](../installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](../usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](../architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](../development_guide.md)** - Contributing and development workflow
+- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
 - **[API Reference](../api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack

--- a/docs/content/multi-plugin/readme.md
+++ b/docs/content/multi-plugin/readme.md
@@ -77,10 +77,10 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](development_guide.md)** - Contributing and development workflow
+- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
 - **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack

--- a/docs/content/multi-plugin/usage_guide.md
+++ b/docs/content/multi-plugin/usage_guide.md
@@ -289,5 +289,5 @@ kubectl multi get --help
 ## Next Steps
 
 - Learn about the internal [Architecture](architecture_guide.md)
-- Contribute to development with the [Development Guide](development_guide.md)
+- Contribute to development with the [Development Guide](/docs/multi-plugin/development_guide)
 - Check the [API Reference](api_reference.md) for technical details


### PR DESCRIPTION
Fixes #6122, Fixes #6123

Updates broken links to `development_guide` and `installation_guide` on the multi-plugin pages with correct absolute paths.

**Changes:**
- Updated all references from relative paths (`installation_guide.md`, `development_guide.md`) to absolute site paths (`/docs/multi-plugin/installation_guide`, `/docs/multi-plugin/development_guide`)
- Fixed links in 6 files across the multi-plugin documentation

These links were previously returning 404 errors on the kubestellar.io website.