### PR TITLE
[sec-check] fix: disable pr-verifier.yml until reusable workflow exists

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,8 +1,10 @@
 name: PR Verifier
 
+# DISABLED: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml does not exist.
+# This workflow silently fails on every PR. Disabled until the reusable workflow is created.
+# See: https://github.com/kubestellar/docs/issues/6131
 on:
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch: {}
 
 permissions:
   checks: write


### PR DESCRIPTION
## Security Fix

Disables `pr-verifier.yml` by changing its trigger from `pull_request_target` to `workflow_dispatch: {}`, matching the fix already applied in `console-kb` (PR fixing issue #2704) and `console-marketplace` (PR fixing issue #335).

### Why

`kubestellar/infra/.github/workflows/reusable-pr-verifier.yml` does not exist. Every PR triggers this workflow, which immediately fails with "workflow not found". This means:
1. PR title/format/DCO verification is silently bypassed
2. A `pull_request_target` trigger exists with no useful function

### Fix

Changed `on:` from `pull_request_target` to `workflow_dispatch: {}` and added a comment documenting the reason, referencing this issue.

Fixes #6131

---
*Filed by sec-check agent (ACMM L6 — full mode)*