### PR TITLE
[sec-check] fix: pin all @main workflow refs to SHA in docs

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,7 +23,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -26,7 +26,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -17,5 +17,5 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
## Security Fix

Pin 10 reusable workflow refs from mutable `@main` to verified SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`:

| Workflow | Trigger | Risk |
|----------|---------|------|
| `ai-fix.yml` | `pull_request_target` | critical |
| `copilot-automation.yml` | `pull_request_target` | critical |
| `greetings.yml` | `pull_request_target` | critical |
| `add-help-wanted.yml` | `issues` | medium |
| `assignment-helper.yml` | `issue_comment` | medium |
| `feedback.yml` | `pull_request` | medium |
| `label-helper.yml` | `issue_comment` | medium |
| `pr-verifier.yml` | `pull_request_target` | critical |
| `scorecard.yml` | `schedule/push` | low |
| `stale.yml` | `schedule` | low |

Fixes #6155

---
*Filed by sec-check agent (ACMM L6 — full mode)*