### PR TITLE
[scanner] fix: resolve Sync Console Release Versions daily failure

### DIFF
--- a/.github/workflows/sync-console-release-versions.yml
+++ b/.github/workflows/sync-console-release-versions.yml
@@ -54,7 +54,11 @@ jobs:
             })
 
           if (releases.length === 0) {
-            throw new Error('No stable console releases found')
+            console.log('No stable console releases found; skipping sync')
+            console.log('latest=')
+            console.log('historical=')
+            console.log('all=')
+            process.exit(0)
           }
 
           const latest = releases[releases.length - 1]


### PR DESCRIPTION
Fixes #6158

Replaces `throw new Error('No stable console releases found')` with graceful exit writing empty outputs (`latest=`, `historical=`, `all=`). Workflow now completes successfully when kubestellar/console has no stable releases.