### PR TITLE
[sec-check] fix: validate PR number from artifact in preview-links-comment workflow

### DIFF
--- a/.github/workflows/preview-links-comment.yml
+++ b/.github/workflows/preview-links-comment.yml
@@ -26,8 +26,17 @@ jobs:
       - name: Get PR number
         id: pr
         run: |
-          PR_NUMBER=$(cat pr-info/pr_number)
-          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          # sec-check: Strictly validate the artifact PR number before use.
+          # A fork contributor can modify preview-links.yml to write arbitrary
+          # content to the pr-info artifact; strip everything except digits and
+          # reject non-positive values to prevent GITHUB_OUTPUT injection.
+          RAW=$(cat pr-info/pr_number 2>/dev/null || echo "")
+          PR_NUMBER=$(printf '%s' "$RAW" | tr -cd '0-9' | cut -c1-10)
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" -lt 1 ] 2>/dev/null; then
+            echo "::error::Invalid or missing PR number in artifact (raw: '$RAW')"
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "PR number: $PR_NUMBER"
 
       - name: Wait for Netlify deploy


### PR DESCRIPTION
## Security Fix

**Problem**: `preview-links-comment.yml` consumes an artifact written by `preview-links.yml`, which runs in the fork PR context (sandboxed `pull_request` event). A fork contributor can modify `preview-links.yml` to write arbitrary content to `pr-info/pr_number`. The privileged `workflow_run` consumer then uses that content directly in shell via `$GITHUB_OUTPUT`, enabling output-variable injection.

**Fix**: Strip all non-digit characters from the artifact value and reject anything that doesn't parse as a positive integer before writing to `$GITHUB_OUTPUT`.

```diff
-          PR_NUMBER=$(cat pr-info/pr_number)
-          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          RAW=$(cat pr-info/pr_number 2>/dev/null || echo "")
+          PR_NUMBER=$(printf '%s' "$RAW" | tr -cd '0-9' | cut -c1-10)
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" -lt 1 ] 2>/dev/null; then
+            echo "::error::Invalid or missing PR number in artifact"
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
```

Fixes #6160

---
*Filed by sec-check agent (ACMM L6 — full mode)*