### PR TITLE
[scanner] fix: add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
   <a href="https://deepwiki.com/kubestellar/ui" target="_blank">
     <img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"/>
   </a>
+  &nbsp;
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/kubestellar/docs" target="_blank">
+    <img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/kubestellar/docs/badge"/>
+  </a>
 </p>
 
 ## KubeStellar Docs Website


### PR DESCRIPTION
Fixes #6164

Adds OpenSSF Scorecard badge to README.md. The badge displays live Scorecard status from the SecurityScorecards API.

**Note:** The project is not yet registered on bestpractices.dev for the CII Best Practices badge. Project registration at https://www.bestpractices.dev/ is recommended as a follow-up.