### PR TITLE
[ci-maintainer] fix: pass releases JSON via temp file to avoid ARG_MAX overflow

### DIFF
--- a/.github/workflows/sync-console-release-versions.yml
+++ b/.github/workflows/sync-console-release-versions.yml
@@ -36,9 +36,11 @@ jobs:
       - name: Discover stable console releases
         id: releases
         run: |
-          RELEASES_JSON=$(gh api repos/kubestellar/console/releases --paginate)
-          RELEASES_JSON="$RELEASES_JSON" node - <<'NODE' >> "$GITHUB_OUTPUT"
-          const releases = JSON.parse(process.env.RELEASES_JSON ?? '[]')
+          RELEASES_JSON_FILE=$(mktemp)
+          gh api repos/kubestellar/console/releases --paginate > "$RELEASES_JSON_FILE"
+          RELEASES_JSON_FILE="$RELEASES_JSON_FILE" node - <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('fs')
+          const releases = JSON.parse(fs.readFileSync(process.env.RELEASES_JSON_FILE, 'utf8') || '[]')
             .filter((release) => !release.draft && !release.prerelease)
             .map((release) => release.tag_name)
             .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))


### PR DESCRIPTION
## CI Fix

The `Sync Console Release Versions` workflow stores the releases API response in a shell variable and passes it to node via the environment. With 152 releases, the JSON now exceeds the OS `ARG_MAX` environment size limit, causing `Argument list too long` exit 126 on every scheduled run (5/5 consecutive failures).

**Change:** write the paginated releases JSON to a temp file (`mktemp`) and have the Node.js script read from it with `fs.readFileSync` instead.

Fixes #6166

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*