### PR TITLE
[scanner] fix: add read-all top-level permissions to remaining workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -1,5 +1,7 @@
 name: Add Help Wanted Label
 
+permissions: read-all  # default read; writes scoped to job below
+
 on:
   issues:
     types: [labeled]

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -1,5 +1,7 @@
 name: Assignment Helper
 
+permissions: read-all  # default read; writes scoped to job below
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -1,5 +1,7 @@
 name: Create Version Branch
 
+permissions: read-all  # default read; writes scoped to job below
+
 on:
   repository_dispatch:
     types: [create-version-branch]

--- a/.github/workflows/daily-team-status.lock.yml
+++ b/.github/workflows/daily-team-status.lock.yml
@@ -30,6 +30,9 @@
 # Effective stop-time: 2026-01-03 19:22:35
 
 name: "Daily Team Status"
+
+permissions: read-all  # default read; writes scoped to job below
+
 "on":
   schedule:
   - cron: "0 9 * * 1-5"

--- a/.github/workflows/devstats.lock.yml
+++ b/.github/workflows/devstats.lock.yml
@@ -30,6 +30,9 @@
 # Effective stop-time: 2026-01-16 19:38:33
 
 name: "Daily Team Status"
+
+permissions: read-all  # default read; writes scoped to job below
+
 "on":
   schedule:
   - cron: "0 9 * * 1-5"

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -1,5 +1,7 @@
 name: Feedback Wanted
 
+permissions: read-all  # default read; writes scoped to job below
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -1,5 +1,7 @@
 name: Generate Leaderboard Data
 
+permissions: read-all  # default read; writes scoped to job below
+
 on:
   schedule:
     - cron: '0 2,6,10,14,18,22 * * *'  # Every 4 hours (6x daily)

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -1,5 +1,7 @@
 name: Label Helper
 
+permissions: read-all  # default read; writes scoped to job below
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -50,6 +50,9 @@
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 name: "Link Checker"
+
+permissions: read-all  # default read; writes scoped to job below
+
 "on":
   schedule:
   - cron: "0 6 * * *"

--- a/.github/workflows/maintainer-metrics.invalid.yml
+++ b/.github/workflows/maintainer-metrics.invalid.yml
@@ -57,6 +57,9 @@
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 name: "Maintainer Metrics Tracker"
+
+permissions: read-all  # default read; writes scoped to job below
+
 "on":
   workflow_dispatch:
     inputs:

--- a/.github/workflows/maintainer-metrics.lock.yml
+++ b/.github/workflows/maintainer-metrics.lock.yml
@@ -54,7 +54,7 @@ name: "Maintainer Metrics Tracker"
         required: true
         type: choice
 
-permissions: {}
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}"

--- a/.github/workflows/markdownlint-cli2.yml
+++ b/.github/workflows/markdownlint-cli2.yml
@@ -9,8 +9,7 @@ on:
       - "docs/**/*.md"
       - "docs/**/*.mdx"
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   markdownlint:

--- a/.github/workflows/preview-links.yml
+++ b/.github/workflows/preview-links.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - 'docs/content/**/*.md'
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   collect-pr-info:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,10 +5,11 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/sync-console-release-versions.yml
+++ b/.github/workflows/sync-console-release-versions.yml
@@ -6,7 +6,8 @@ on:
     - cron: '17 5 * * *'
 
 
-permissions: {}
+permissions: read-all  # default read; writes scoped to job below
+
 jobs:
   sync-console-releases:
     permissions:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,8 +21,7 @@ on:
       - "tsconfig.json"
       - "eslint.config.*"
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   typecheck:

--- a/.github/workflows/typo-checker.lock.yml
+++ b/.github/workflows/typo-checker.lock.yml
@@ -61,7 +61,7 @@ on:
         required: false
         type: string
 
-permissions: {}
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}"

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -18,8 +18,7 @@ on:
       - "vitest.config.ts"
       - "next.config.*"
 
-permissions:
-  contents: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   test:


### PR DESCRIPTION
Fixes #6175

Adds top-level `permissions: read-all` to 19 workflows that were missing it, following the same pattern as PR #6174.

For workflows with specific write permissions at the workflow level, moved them to job level per Scorecard TokenPermissions best practice:
- scorecard.yml: moved security-events, contents, actions, id-token to job level
- stale.yml: moved issues write to job level

All other workflows either had `permissions: {}` or only `contents: read`, which are replaced with `read-all`.