### PR TITLE
[ci-maintainer] fix: remove duplicate permissions keys in workflow files

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -1,6 +1,5 @@
 name: Add Help Wanted Label
 
-permissions: read-all  # default read; writes scoped to job below
 
 on:
   issues:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -1,6 +1,5 @@
 name: Assignment Helper
 
-permissions: read-all  # default read; writes scoped to job below
 
 on:
   issue_comment:

--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -1,6 +1,5 @@
 name: Create Version Branch
 
-permissions: read-all  # default read; writes scoped to job below
 
 on:
   repository_dispatch:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -1,6 +1,5 @@
 name: Feedback Wanted
 
-permissions: read-all  # default read; writes scoped to job below
 
 on:
   pull_request:

--- a/.github/workflows/generate-leaderboard.yml
+++ b/.github/workflows/generate-leaderboard.yml
@@ -1,6 +1,5 @@
 name: Generate Leaderboard Data
 
-permissions: read-all  # default read; writes scoped to job below
 
 on:
   schedule:

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -1,6 +1,5 @@
 name: Label Helper
 
-permissions: read-all  # default read; writes scoped to job below
 
 on:
   issue_comment:

--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -51,7 +51,6 @@
 
 name: "Link Checker"
 
-permissions: read-all  # default read; writes scoped to job below
 
 "on":
   schedule:

--- a/.github/workflows/maintainer-metrics.invalid.yml
+++ b/.github/workflows/maintainer-metrics.invalid.yml
@@ -58,7 +58,6 @@
 
 name: "Maintainer Metrics Tracker"
 
-permissions: read-all  # default read; writes scoped to job below
 
 "on":
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- remove the duplicate top-level `permissions: read-all` entry from affected workflow files
- keep each workflow's intended specific top-level `permissions` block unchanged
- resolve GitHub Actions workflow validation failures caused by duplicate YAML keys

## Why
GitHub Actions rejects these workflows because `permissions` is defined twice at the top level.

Fixes #6177