### PR TITLE
📖 Sync console docs versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -189,8 +189,8 @@
     },
     "console": {
       "latest": {
-        "label": "v0.3.25 (Latest)",
-        "branch": "docs/console/0.3.25",
+        "label": "v0.3.32 (Latest)",
+        "branch": "docs/console/0.3.32",
         "isDefault": true
       },
       "main": {
@@ -227,6 +227,141 @@
       "0.1.0": {
         "label": "v0.1.0",
         "branch": "docs/console/0.1.0",
+        "isDefault": false
+      },
+      "0.3.0": {
+        "label": "v0.3.0",
+        "branch": "docs/console/0.3.0",
+        "isDefault": false
+      },
+      "0.3.1": {
+        "label": "v0.3.1",
+        "branch": "docs/console/0.3.1",
+        "isDefault": false
+      },
+      "0.3.2": {
+        "label": "v0.3.2",
+        "branch": "docs/console/0.3.2",
+        "isDefault": false
+      },
+      "0.3.3": {
+        "label": "v0.3.3",
+        "branch": "docs/console/0.3.3",
+        "isDefault": false
+      },
+      "0.3.4": {
+        "label": "v0.3.4",
+        "branch": "docs/console/0.3.4",
+        "isDefault": false
+      },
+      "0.3.5": {
+        "label": "v0.3.5",
+        "branch": "docs/console/0.3.5",
+        "isDefault": false
+      },
+      "0.3.7": {
+        "label": "v0.3.7",
+        "branch": "docs/console/0.3.7",
+        "isDefault": false
+      },
+      "0.3.8": {
+        "label": "v0.3.8",
+        "branch": "docs/console/0.3.8",
+        "isDefault": false
+      },
+      "0.3.9": {
+        "label": "v0.3.9",
+        "branch": "docs/console/0.3.9",
+        "isDefault": false
+      },
+      "0.3.10": {
+        "label": "v0.3.10",
+        "branch": "docs/console/0.3.10",
+        "isDefault": false
+      },
+      "0.3.11": {
+        "label": "v0.3.11",
+        "branch": "docs/console/0.3.11",
+        "isDefault": false
+      },
+      "0.3.12": {
+        "label": "v0.3.12",
+        "branch": "docs/console/0.3.12",
+        "isDefault": false
+      },
+      "0.3.13": {
+        "label": "v0.3.13",
+        "branch": "docs/console/0.3.13",
+        "isDefault": false
+      },
+      "0.3.14": {
+        "label": "v0.3.14",
+        "branch": "docs/console/0.3.14",
+        "isDefault": false
+      },
+      "0.3.15": {
+        "label": "v0.3.15",
+        "branch": "docs/console/0.3.15",
+        "isDefault": false
+      },
+      "0.3.16": {
+        "label": "v0.3.16",
+        "branch": "docs/console/0.3.16",
+        "isDefault": false
+      },
+      "0.3.17": {
+        "label": "v0.3.17",
+        "branch": "docs/console/0.3.17",
+        "isDefault": false
+      },
+      "0.3.18": {
+        "label": "v0.3.18",
+        "branch": "docs/console/0.3.18",
+        "isDefault": false
+      },
+      "0.3.21": {
+        "label": "v0.3.21",
+        "branch": "docs/console/0.3.21",
+        "isDefault": false
+      },
+      "0.3.22": {
+        "label": "v0.3.22",
+        "branch": "docs/console/0.3.22",
+        "isDefault": false
+      },
+      "0.3.25": {
+        "label": "v0.3.25",
+        "branch": "docs/console/0.3.25",
+        "isDefault": false
+      },
+      "0.3.26": {
+        "label": "v0.3.26",
+        "branch": "docs/console/0.3.26",
+        "isDefault": false
+      },
+      "0.3.27": {
+        "label": "v0.3.27",
+        "branch": "docs/console/0.3.27",
+        "isDefault": false
+      },
+      "0.3.28": {
+        "label": "v0.3.28",
+        "branch": "docs/console/0.3.28",
+        "isDefault": false
+      },
+      "0.3.29": {
+        "label": "v0.3.29",
+        "branch": "docs/console/0.3.29",
+        "isDefault": false
+      },
+      "0.3.30": {
+        "label": "v0.3.30",
+        "branch": "docs/console/0.3.30",
+        "isDefault": false
+      },
+      "0.3.31": {
+        "label": "v0.3.31",
+        "branch": "docs/console/0.3.31",
         "isDefault": false
       }
     },
@@ -267,7 +402,7 @@
     "console": {
       "name": "Console",
       "basePath": "console",
-      "currentVersion": "0.3.25"
+      "currentVersion": "0.3.32"
     },
     "hive": {
       "name": "Hive",
@@ -319,5 +454,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-06-28T06:36:20.552Z"
+  "updatedAt": "2026-07-03T06:29:34.144Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -238,8 +238,8 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // The console release sync workflow auto-updates this when a new release is detected.
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.3.25 (Latest)",
-    branch: "docs/console/0.3.25",
+    label: "v0.3.32 (Latest)",
+    branch: "docs/console/0.3.32",
     isDefault: true,
   },
   main: {
@@ -247,6 +247,141 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.3.31": {
+    label: "v0.3.31",
+    branch: "docs/console/0.3.31",
+    isDefault: false,
+  },
+  "0.3.30": {
+    label: "v0.3.30",
+    branch: "docs/console/0.3.30",
+    isDefault: false,
+  },
+  "0.3.29": {
+    label: "v0.3.29",
+    branch: "docs/console/0.3.29",
+    isDefault: false,
+  },
+  "0.3.28": {
+    label: "v0.3.28",
+    branch: "docs/console/0.3.28",
+    isDefault: false,
+  },
+  "0.3.27": {
+    label: "v0.3.27",
+    branch: "docs/console/0.3.27",
+    isDefault: false,
+  },
+  "0.3.26": {
+    label: "v0.3.26",
+    branch: "docs/console/0.3.26",
+    isDefault: false,
+  },
+  "0.3.25": {
+    label: "v0.3.25",
+    branch: "docs/console/0.3.25",
+    isDefault: false,
+  },
+  "0.3.22": {
+    label: "v0.3.22",
+    branch: "docs/console/0.3.22",
+    isDefault: false,
+  },
+  "0.3.21": {
+    label: "v0.3.21",
+    branch: "docs/console/0.3.21",
+    isDefault: false,
+  },
+  "0.3.18": {
+    label: "v0.3.18",
+    branch: "docs/console/0.3.18",
+    isDefault: false,
+  },
+  "0.3.17": {
+    label: "v0.3.17",
+    branch: "docs/console/0.3.17",
+    isDefault: false,
+  },
+  "0.3.16": {
+    label: "v0.3.16",
+    branch: "docs/console/0.3.16",
+    isDefault: false,
+  },
+  "0.3.15": {
+    label: "v0.3.15",
+    branch: "docs/console/0.3.15",
+    isDefault: false,
+  },
+  "0.3.14": {
+    label: "v0.3.14",
+    branch: "docs/console/0.3.14",
+    isDefault: false,
+  },
+  "0.3.13": {
+    label: "v0.3.13",
+    branch: "docs/console/0.3.13",
+    isDefault: false,
+  },
+  "0.3.12": {
+    label: "v0.3.12",
+    branch: "docs/console/0.3.12",
+    isDefault: false,
+  },
+  "0.3.11": {
+    label: "v0.3.11",
+    branch: "docs/console/0.3.11",
+    isDefault: false,
+  },
+  "0.3.10": {
+    label: "v0.3.10",
+    branch: "docs/console/0.3.10",
+    isDefault: false,
+  },
+  "0.3.9": {
+    label: "v0.3.9",
+    branch: "docs/console/0.3.9",
+    isDefault: false,
+  },
+  "0.3.8": {
+    label: "v0.3.8",
+    branch: "docs/console/0.3.8",
+    isDefault: false,
+  },
+  "0.3.7": {
+    label: "v0.3.7",
+    branch: "docs/console/0.3.7",
+    isDefault: false,
+  },
+  "0.3.5": {
+    label: "v0.3.5",
+    branch: "docs/console/0.3.5",
+    isDefault: false,
+  },
+  "0.3.4": {
+    label: "v0.3.4",
+    branch: "docs/console/0.3.4",
+    isDefault: false,
+  },
+  "0.3.3": {
+    label: "v0.3.3",
+    branch: "docs/console/0.3.3",
+    isDefault: false,
+  },
+  "0.3.2": {
+    label: "v0.3.2",
+    branch: "docs/console/0.3.2",
+    isDefault: false,
+  },
+  "0.3.1": {
+    label: "v0.3.1",
+    branch: "docs/console/0.3.1",
+    isDefault: false,
+  },
+  "0.3.0": {
+    label: "v0.3.0",
+    branch: "docs/console/0.3.0",
+    isDefault: false,
   },
   "0.3.23": {
     label: "v0.3.23",
@@ -335,7 +470,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "0.3.25",
+    currentVersion: "0.3.32",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker