### PR TITLE
[scanner] fix: standardize spelling of prerequisites

### DIFF
--- a/docs/content/kubestellar/core-chart-argocd.md
+++ b/docs/content/kubestellar/core-chart-argocd.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 - [Overview](#overview)
-- [Pre-requisites](#pre-requisites)
+- [Prerequisites](#prerequisites)
 - [Installing Argo CD using KubeStellar Core chart](#installing-argo-cd-using-kubestellar-core-chart)
 - [Deploying Argo CD applications](#deploying-argo-cd-applications)
 
@@ -16,11 +16,11 @@ This document explains how to use the KubeStellar core Helm chart to:
 
 For a detailed step-by-step installation guide with expected outputs, see [Step-by-Step Installation Guide](core-chart.md).
 
-## Pre-requisites
+## Prerequisites
 
 Before installing Argo CD with KubeStellar Core chart, ensure you have:
 
-- All prerequisites from [installing KubeStellar using the Core chart](core-chart.md#pre-requisites)
+- All prerequisites from [installing KubeStellar using the Core chart](core-chart.md#prerequisites)
 - A properly configured KubeFlex hosting cluster
 - Helm installed and configured
 - kubectl access to your cluster

--- a/docs/content/kubestellar/core-chart.md
+++ b/docs/content/kubestellar/core-chart.md
@@ -2,7 +2,7 @@
 
 ## 📚 Table of Contents
 
-- [Pre-requisites](#pre-requisites)
+- [Prerequisites](#prerequisites)
 - [KubeStellar Core Chart values](#kubestellar-core-chart-values)
 - [KubeStellar Core Chart Usage Step-by-Step](#kubestellar-core-chart-usage-step-by-step)
 - [Kubeconfig Files and Contexts for Control Planes](#kubeconfig-files-and-contexts-for-control-planes)
@@ -25,7 +25,7 @@ The information provided is specific for the following release:
 export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
 ```
 
-## Pre-requisites
+## Prerequisites
 
 To install the Helm chart the only requirement is [Helm](https://helm.sh/).
 However, additional executables may be required to create/manage the cluster(s) (_e.g._, Kind and kubectl),

--- a/docs/content/kubestellar/get-started.md
+++ b/docs/content/kubestellar/get-started.md
@@ -20,7 +20,7 @@ After [installing WSL](https://learn.microsoft.com/en-us/windows/wsl/install), i
 wsl --install FedoraLinux-43
 ```
 
-Afterwards, the pre-requisites needed by KubeStellar and the demo script can be installed using the command:
+Afterwards, the prerequisites needed by KubeStellar and the demo script can be installed using the command:
 
 ```shell
 bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v0.30.0/scripts/setup-wsl-fedora.sh)

--- a/docs/content/kubestellar/pre-reqs.md
+++ b/docs/content/kubestellar/pre-reqs.md
@@ -112,19 +112,19 @@ For example, list of prerequisites required by KubeStellar can be checked with t
 
 ```shell
 $ scripts/check_pre_req.sh
-Checking pre-requisites for using KubeStellar:
+Checking prerequisites for using KubeStellar:
 ✔ Docker (Docker version 27.2.1-rd, build cc0ee3e)
 ✔ kubectl (v1.29.2)
 ✔ KubeFlex (Kubeflex version: v0.6.3.672cc8a 2024-09-23T16:15:47Z)
 ✔ OCM CLI (:v0.9.0-0-g56e1fc8)
 ✔ Helm (v3.16.1)
 ✔ helm can fetch public charts
-Checking additional pre-requisites for running the examples:
+Checking additional prerequisites for running the examples:
 ✔ Kind (kind v0.22.0 go1.22.0 darwin/arm64)
 ✔ fs.inotify.max_user_watches is 524288
 ✔ fs.inotify.max_user_instances is 512
 ✔ ArgoCD CLI (v2.10.1+a79e0ea)
-Checking pre-requisites for building KubeStellar:
+Checking prerequisites for building KubeStellar:
 ✔ GNU Make (GNU Make 3.81)
 ✔ Go (go version go1.23.2 darwin/arm64)
 ✔ KO (0.16.0)
@@ -136,7 +136,7 @@ In another example, a specific list of prerequisites could be asserted by a high
 
 ```shell
 $ check_pre_req.sh --assert --verbose helm argo docker kind
-Checking KubeStellar pre-requisites:
+Checking KubeStellar prerequisites:
 ✔ Helm
   version (unstructured): version.BuildInfo{Version:"v3.14.0", GitCommit:"3fc9f4b2638e76f26739cd77c7017139be81d0ea", GitTreeState:"clean", GoVersion:"go1.21.5"}
      path: /usr/sbin/helm

--- a/docs/content/kubestellar/testing.md
+++ b/docs/content/kubestellar/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Make sure all pre-requisites are installed as described in [pre-reqs](pre-reqs.md).
+Make sure all prerequisites are installed as described in [pre-reqs](pre-reqs.md).
 
 ## Unit testing
 


### PR DESCRIPTION
Fixes #6181

Standardizes all instances of 'prerequisites' to use consistent spelling (no hyphen, lowercase).