### PR TITLE
📖 Sync console docs versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -194,8 +194,8 @@
     },
     "console": {
       "latest": {
-        "label": "v0.3.32 (Latest)",
-        "branch": "docs/console/0.3.32",
+        "label": "v0.3.33 (Latest)",
+        "branch": "docs/console/0.3.33",
         "isDefault": true
       },
       "main": {
@@ -368,6 +368,11 @@
         "label": "v0.3.31",
         "branch": "docs/console/0.3.31",
         "isDefault": false
+      },
+      "0.3.32": {
+        "label": "v0.3.32",
+        "branch": "docs/console/0.3.32",
+        "isDefault": false
       }
     },
     "hive": {
@@ -407,7 +412,7 @@
     "console": {
       "name": "Console",
       "basePath": "console",
-      "currentVersion": "0.3.32"
+      "currentVersion": "0.3.33"
     },
     "hive": {
       "name": "Hive",
@@ -459,5 +464,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-07-05T06:25:02.858Z"
+  "updatedAt": "2026-07-06T06:48:45.312Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -243,8 +243,8 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // The console release sync workflow auto-updates this when a new release is detected.
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.3.32 (Latest)",
-    branch: "docs/console/0.3.32",
+    label: "v0.3.33 (Latest)",
+    branch: "docs/console/0.3.33",
     isDefault: true,
   },
   main: {
@@ -252,6 +252,11 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.3.32": {
+    label: "v0.3.32",
+    branch: "docs/console/0.3.32",
+    isDefault: false,
   },
   "0.3.31": {
     label: "v0.3.31",
@@ -475,7 +480,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "0.3.32",
+    currentVersion: "0.3.33",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker