### PR TITLE
[ci-maintainer] fix: add missing opening quote in Run All Maintainer Audits echo statement

### DIFF
--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -46,7 +46,7 @@ jobs:
               --field maintainer="$maintainer"
             
             if [ $? -eq 0 ]; then
-              echo Successfully triggered audit for $maintainer" 
+              echo "Successfully triggered audit for $maintainer" 
             else
               echo "❌ Failed to trigger audit for $maintainer"
               exit 1


### PR DESCRIPTION
## CI Fix

The `Run All Maintainer Audits` workflow has been failing every Monday with:
```
unexpected EOF while looking for matching '"'
```

**Root cause:** Line 49 in `run-all-maintainer-audits.yml` is missing the opening double-quote:
```bash
# Broken (causes bash syntax error on every run):
echo Successfully triggered audit for $maintainer"

# Fixed:
echo "Successfully triggered audit for $maintainer"
```

This is a one-character fix. The workflow has silently failed 2 consecutive Mondays (2026-06-29, 2026-07-06).

Fixes #6189

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*