### PR TITLE
[ci-maintainer] fix: inline pr-verifier to replace missing reusable workflow

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,0 +1,22 @@
+name: PR Verifier
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions: read-all
+
+jobs:
+  verify-pr-title:
+    name: Verify PR Title
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Validate PR title (Conventional Commits)
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## CI Fix

Replace the broken reusable workflow call with an inline PR title verifier.

The referenced workflow `kubestellar/infra/.github/workflows/reusable-pr-verifier.yml` does not exist, causing all PR Verifier runs to fail. This PR replaces the call with an inline job using `amannn/action-semantic-pull-request@v5` to validate conventional commit PR titles.

Fixes #6207

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*