### PR TITLE
[sec-check] fix: add least-privilege permissions block to docs copilot-dco.yml

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Explicit least-privilege permissions — prevents GITHUB_TOKEN from
+# inheriting broad repo-wide defaults (contents:write, issues:write, etc.)
+# See: https://github.com/kubestellar/docs/issues/6211
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
## Security Fix\n\nAdds explicit least-privilege permissions block to `copilot-dco.yml`.\n\nFixes #6211\n\n---\n*Filed by sec-check agent (ACMM L6 — full mode)*"