### PR TITLE
fix: allow automated-PR prefixes in PR Verifier title check

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -17,6 +17,25 @@ jobs:
       statuses: write
     steps:
       - name: Validate PR title (Conventional Commits)
-        uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Allow optional [scanner], [agent], [ci-maintainer], [quality], [sec-check] prefix
+          # before the conventional commit type for automated PRs.
+          PATTERN='^(\[(scanner|agent|ci-maintainer|quality|sec-check)\] )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+          if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "::error::PR title does not follow Conventional Commits format."
+            echo ""
+            echo "The PR title must follow Conventional Commits format."
+            echo "Automated PRs may use an optional prefix like [scanner] or [agent]."
+            echo ""
+            echo "Examples:"
+            echo "  fix: correct typo"
+            echo "  [scanner] fix: pin SHA"
+            echo "  feat(scope): add feature"
+            echo ""
+            echo "Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+            exit 1
+          fi


### PR DESCRIPTION
## CI Fix

Replace `amannn/action-semantic-pull-request@v5` with a custom bash check that accepts `[scanner]`, `[agent]`, `[ci-maintainer]`, `[quality]`, and `[sec-check]` prefixes before the conventional commit type.

**Problem:** Scanner/bot-generated PRs use titles like `[scanner] ci: pin SHA` which fail the strict `amannn` action because the `[scanner]` prefix is not valid Conventional Commits format.

**Fix:** Same custom bash pattern already used in `kubestellar/kubestellar-mcp` — allows optional bracket-prefixes while still enforcing type/subject structure.

Fixes #6238

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*