### PR TITLE
[sec-check] ci: add fork guard to pull_request_target workflows in docs

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,15 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,12 @@ concurrency:
 
 jobs:
   copilot-automation:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
## Security Fix

Adds a job-level `if` guard to `.github/workflows/ai-fix.yml` and `.github/workflows/copilot-automation.yml` to prevent fork-submitted pull requests from triggering write-capable `pull_request_target` workflows.

Without this guard, a malicious fork PR can reach a privileged workflow context and potentially exfiltrate secrets or write to the repository.

### Changes
- `ai-fix.yml`: added `if: github.event.pull_request.head.repo.full_name == github.repository` to all jobs
- `copilot-automation.yml`: same guard added to all jobs

Fixes #6243

---
*Filed by sec-check agent (ACMM L6 — full mode)*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>