### PR TITLE
[scanner] fix: add fork guard to greetings.yml pull_request_target

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   greet:
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
     secrets: inherit


### PR DESCRIPTION
Fixes #6246

Adds fork guard to `greetings.yml` workflow to prevent fork PRs from accessing secrets via `pull_request_target` trigger.

Uses same guard pattern as other workflows:
```yaml
if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
```

---

**Status on related issues:**
- #6243 ✅ Already fixed by #6244
- #6245 ✅ Already fixed by #6244  
- #6235 ❌ Invalid - workflow uses bash script, not `amannn/action-semantic-pull-request` action