### PR TITLE
[scanner] fix: restrict nextra-rollout-sa RBAC to minimum permissions

### DIFF
--- a/cluster-objects/rbac.yaml
+++ b/cluster-objects/rbac.yaml
@@ -12,10 +12,10 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+    verbs: ["get", "list", "create", "patch", "delete"]
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+    verbs: ["get", "list", "create", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
@@ -24,7 +24,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
-    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+    verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Fixes #6251

Restricts the over-permissive RBAC for nextra-rollout-sa to minimum required permissions.