### PR TITLE
[scanner] fix: enable CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '0 4 * * 1' # Weekly Monday 04:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
Fixes #6257

## Changes

Renamed `.github/workflows/codeql.yml.disabled` → `.github/workflows/codeql.yml` to restore automated static code analysis.

## Impact

Restores automated detection of:
- XSS vulnerabilities
- Injection flaws  
- Path-traversal issues
- Security regressions in `sanitizeHtmlForMdx` and other TypeScript/JavaScript code

CodeQL will now run:
- On every push to `main`
- On every pull request
- Weekly on Mondays at 04:00 UTC