### PR TITLE
fix: restore DocsLayout wrapper on docs pages — unstyled markdown rendering

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -91,48 +91,56 @@ function readLocalFile(filePath: string, contentPath: string = docsContentPath):
   return null
 }
 
-async function getPageContent(slug: string[], projectId?: ProjectId): Promise<string | null> {
-  const filePath = slug.join('/') + '.md'
-  
-  const contentPath = projectId 
+type PageContent = {
+  content: string
+  // Path of the resolved source file, relative to the content directory.
+  // Used by the DocsLayout wrapper to build "edit this page" links.
+  filePath: string
+}
+
+async function getPageContent(slug: string[], projectId?: ProjectId): Promise<PageContent | null> {
+  const mdPath = slug.join('/') + '.md'
+
+  const contentPath = projectId
     ? getContentPath(projectId)
     : docsContentPath
 
   // Try .md first, then .mdx
-  let content = readLocalFile(filePath, contentPath)
-  if (!content) {
-    const mdxPath = slug.join('/') + '.mdx'
-    content = readLocalFile(mdxPath, contentPath)
-  }
+  let content = readLocalFile(mdPath, contentPath)
+  if (content) return { content, filePath: mdPath }
+
+  const mdxPath = slug.join('/') + '.mdx'
+  content = readLocalFile(mdxPath, contentPath)
+  if (content) return { content, filePath: mdxPath }
 
   // If direct lookup failed, consult the routeMap for nav-generated routes
-  if (!content) {
-    const mapProjectId = projectId || 'kubestellar'
-    const { routeMap } = buildPageMap(mapProjectId)
-    const routeKey = slug.join('/')
-    const mappedFile = routeMap[routeKey]
-    if (mappedFile) {
-      content = readLocalFile(mappedFile, contentPath)
-      if (!content) {
-        // Also try in the default docs content path (for general sections)
-        content = readLocalFile(mappedFile, docsContentPath)
-      }
+  const mapProjectId = projectId || 'kubestellar'
+  const { routeMap } = buildPageMap(mapProjectId)
+  const routeKey = slug.join('/')
+  const mappedFile = routeMap[routeKey]
+  if (mappedFile) {
+    content = readLocalFile(mappedFile, contentPath)
+    if (!content) {
+      // Also try in the default docs content path (for general sections)
+      content = readLocalFile(mappedFile, docsContentPath)
     }
+    if (content) return { content, filePath: mappedFile }
   }
-  
-  return content
+
+  return null
 }
 
-async function buildContent(slug: string[], projectId?: ProjectId): Promise<string | null> {
-  let content = await getPageContent(slug, projectId)
-  
-  if (!content) return null
-  
+async function buildContent(slug: string[], projectId?: ProjectId): Promise<PageContent | null> {
+  const page = await getPageContent(slug, projectId)
+
+  if (!page) return null
+
+  let content = page.content
   content = replaceTemplateVariables(content)
   content = removeCommentPatterns(content)
   content = sanitizeHtmlForMdx(content)
-  
-  return content
+
+  return { content, filePath: page.filePath }
 }
 
 function getProjectFromSlug(slug: string[]): { projectId: ProjectId | undefined; docSlug: string[] } {
@@ -151,14 +159,27 @@ function getProjectFromSlug(slug: string[]): { projectId: ProjectId | undefined;
 export default async function DocPage({ params }: Props) {
   const { slug } = await params
   const { projectId, docSlug } = getProjectFromSlug(slug)
-  
-  const content = await buildContent(docSlug, projectId)
-  
-  if (!content) {
+
+  const page = await buildContent(docSlug, projectId)
+
+  if (!page) {
     notFound()
   }
-  
-  let MDXContent: ReturnType<typeof evaluate>['default'] | null = null
+
+  const { content, filePath } = page
+
+  // Extract the layout wrapper (DocsLayout: prose typography, table of
+  // contents, edit-page actions) so it can be rendered explicitly around the
+  // MDX output. nextra's evaluate() does not apply the wrapper component
+  // itself — without this the page renders as unstyled markup.
+  const { wrapper: Wrapper, ...components } = getMDXComponents({
+    Callout,
+    Tabs,
+    Mermaid,
+    convertHtmlScriptsToJsxComments
+  })
+
+  let evaluated: ReturnType<typeof evaluate> | null = null
   let compilationFailed = false
   try {
     const compiled = await compileMdx(content, {
@@ -167,25 +188,24 @@ export default async function DocPage({ params }: Props) {
         rehypePlugins: []
       }
     })
-    
-    const components = getMDXComponents({
-      Callout,
-      Tabs,
-      Mermaid,
-      convertHtmlScriptsToJsxComments
-    })
-    
-    const evaluated = evaluate(compiled, components)
-    MDXContent = evaluated.default
+
+    evaluated = evaluate(compiled, components)
   } catch {
     // If MDX compilation fails, fall back to plain text rendering
     compilationFailed = true
   }
-  
+
+  const MDXContent = evaluated?.default
+
   return (
-    <div className="docs-content">
+    <Wrapper
+      toc={evaluated?.toc ?? []}
+      metadata={evaluated?.metadata}
+      filePath={filePath}
+      projectId={projectId ?? 'kubestellar'}
+    >
       {compilationFailed || !MDXContent ? <pre>{content}</pre> : <MDXContent />}
-    </div>
+    </Wrapper>
   )
 }
 


### PR DESCRIPTION
## Problem

Every page under kubestellar.io/docs has been rendering as **flat, unstyled text** since June 9: headings the same size as body text, no list bullets, collapsed tables, no right-hand table of contents, and no edit-page actions.

## Root cause

Commit 5186029b ("[sec-check] fix: harden script close tag regex + loop unclosed comment removal") did far more than its message says: it rewrote `src/app/docs/[...slug]/page.tsx` from 598 to 347 lines and **dropped the explicit `<Wrapper>` (DocsLayout) render** around the evaluated MDX content, replacing it with a bare `<div class="docs-content">`.

nextra's `evaluate()` does not apply the `wrapper` component itself, so the MDX output was never wrapped in `<article class="prose prose-slate dark:prose-invert ...">`. All the `.prose` typography rules still ship in the compiled CSS (verified on the live bundle) — the class was simply missing from the DOM. `.docs-content` has no styles anywhere in the codebase.

Evidence:
- Live HTML: `<div class="docs-content"><h1>...` with zero `prose` classes; live CSS bundle still contains the full `.prose h1/h2/ul/table/code` ruleset from `globals.css`.
- Wayback snapshot of 2026-04-12 (working era): `<article class="prose prose-slate dark:prose-invert max-w-none">` present.
- `page.tsx` history: wrapper refs go from 3 to 0 exactly at 5186029b.

## Fix

Restore the pre-June-9 rendering path while keeping every fix that landed since (routeMap fallback #6030, path containment #6083, extracted sanitizer #5860):

- Extract `wrapper` from `getMDXComponents()` and render it explicitly around `<MDXContent />`, passing `toc`, `metadata`, `filePath`, and `projectId` — this restores prose typography, the table of contents, and the edit-page buttons.
- `getPageContent`/`buildContent` now also return the resolved source file path so edit links point at the right file.
- The plain-text `<pre>` fallback for MDX compilation failures is kept, now inside the layout wrapper.

Fixes the broken docs formatting reported on kubestellar.io/docs.