### PR TITLE
[scanner] fix: repair broken installation link in User's Guide

### DIFF
--- a/docs/content/kubeflex/users.md
+++ b/docs/content/kubeflex/users.md
@@ -25,7 +25,7 @@ Kubeflex configuration is now stored as part of the kubeconfig extension data, h
 
 ## Installation
 
-Installation instructions are [here](quickstart.md).
+Installation instructions are [here](quick-start.md).
 
 ## Usage
 


### PR DESCRIPTION
Fixes #6263

Repairs broken link to installation page in User's Guide.