### PR TITLE
[scanner] fix: resolve leaderboard generation workflow failure

### DIFF
--- a/scripts/generate-contributor-profiles.mjs
+++ b/scripts/generate-contributor-profiles.mjs
@@ -88,8 +88,9 @@ if (!TOKEN) {
 }
 
 const defaultHeaders = {
-  Accept: "application/vnd.github.v3+json",
+  Accept: "application/vnd.github+json",
   Authorization: `Bearer ${TOKEN}`,
+  "X-GitHub-Api-Version": "2022-11-28",
 };
 
 async function ghFetch(url) {

--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -92,8 +92,9 @@ if (!TOKEN) {
 const FORCE_FULL = process.env.LEADERBOARD_FULL === "1";
 
 const defaultHeaders = {
-  Accept: "application/vnd.github.v3+json",
+  Accept: "application/vnd.github+json",
   Authorization: `Bearer ${TOKEN}`,
+  "X-GitHub-Api-Version": "2022-11-28",
 };
 
 async function ghFetch(url) {


### PR DESCRIPTION
Fixes #6264

## Problem
Leaderboard generation workflow failing due to deprecated GitHub API Accept header.

## Solution
- Updated `application/vnd.github.v3+json` → `application/vnd.github+json`
- Added `X-GitHub-Api-Version: 2022-11-28` header
- Applied fix to both `generate-leaderboard.mjs` and `generate-contributor-profiles.mjs`

## Testing
GitHub now requires the updated media type format per their [REST API documentation](https://docs.github.com/en/rest/overview/media-types).