### PR TITLE
chore: add ClusterFuzzLite config for Scorecard fuzzing detection

### DIFF
--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,17 @@
+# ClusterFuzzLite project configuration for OpenSSF Scorecard compliance.
+#
+# This repository uses a custom mutation-based fuzzer for the MDX sanitizer
+# (see .github/fuzzing/fuzz-mdx-sanitizer.ts and .github/workflows/fuzz-mdx.yml).
+# This file signals to Scorecard that fuzzing infrastructure exists.
+#
+# The custom fuzzer runs weekly and on relevant PRs, testing for XSS vulnerabilities
+# in HTML sanitization logic. See PR #6234 for implementation details.
+
+homepage: "https://github.com/kubestellar/docs"
+primary_contact: "security@kubestellar.io"
+language: typescript
+sanitizers: []
+
+# Note: We use a custom fuzzer harness instead of libFuzzer or AFL.
+# The fuzzer is executed via: npx tsx .github/fuzzing/fuzz-mdx-sanitizer.ts
+# This configuration file exists primarily for OpenSSF Scorecard detection.


### PR DESCRIPTION
Fixes #6269

## Summary
Adds `.clusterfuzzlite/project.yaml` to signal fuzzing infrastructure to OpenSSF Scorecard.

## Background
The repository already has a working custom mutation-based fuzzer for the MDX sanitizer:
- Fuzzer harness: `.github/fuzzing/fuzz-mdx-sanitizer.ts`
- Workflow: `.github/workflows/fuzz-mdx.yml`
- Added in PR #6234

The fuzzer runs weekly and on relevant PRs, testing for XSS vulnerabilities in HTML sanitization logic.

## Problem
OpenSSF Scorecard reports 0/10 for fuzzing because it only detects:
- OSS-Fuzz project files
- ClusterFuzzLite workflows calling `google/clusterfuzzlite`
- Go native fuzz tests (`func Fuzz*(*testing.F)`)

Our custom fuzzer is not recognized by these heuristics.

## Solution
Add minimal `.clusterfuzzlite/project.yaml` file for Scorecard detection. This file documents the custom fuzzing approach without changing the existing, working fuzzer implementation.

## Testing
- [ ] Scorecard will detect fuzzing infrastructure after merge
- [ ] Existing fuzzer workflow continues to run unchanged

## Notes
This is primarily for compliance/metrics. The actual fuzzing infrastructure was already implemented and is working.