### PR TITLE
[ci-maintainer] fix: activate CodeQL SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '0 4 * * 1' # Weekly Monday 04:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## CI Fix

PR #6274 created `.github/workflows/codeql.yml.disabled` instead of
`.github/workflows/codeql.yml`. GitHub Actions ignores `.disabled` files,
so SAST was never running despite the workflow being present.

This PR creates the correctly-named active workflow file with the same
content, enabling CodeQL SAST on push to `main` and all pull requests.

Fixes #6275

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*