### PR TITLE
docs: fix broken link quick-start.md → quickstart.md

### DIFF
--- a/docs/content/kubeflex/users.md
+++ b/docs/content/kubeflex/users.md
@@ -25,7 +25,7 @@ Kubeflex configuration is now stored as part of the kubeconfig extension data, h
 
 ## Installation
 
-Installation instructions are [here](quick-start.md).
+Installation instructions are [here](quickstart.md).
 
 ## Usage
 


### PR DESCRIPTION
Fixes #6280

## Fix

The broken link checker found that `docs/content/kubeflex/users.md` references `quick-start.md` (with hyphen) but the actual file is named `quickstart.md` (no hyphen).

Changed `[here](quick-start.md)` → `[here](quickstart.md)` on line 28.