### PR TITLE
[ci-maintainer] fix: disable automatic triggers on advanced CodeQL workflow (default setup conflict)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,14 @@
+# NOTE: Automatic triggers intentionally removed — the repository uses
+# GitHub's default Code Scanning setup (enabled in Security settings),
+# which already runs CodeQL analysis on push, pull_request, and schedule.
+# Running BOTH default setup AND an advanced workflow causes a conflict:
+#   "CodeQL analyses from advanced configurations cannot be processed
+#    when the default setup is enabled"
+# This file is retained with workflow_dispatch only for manual debugging.
+# See: https://github.com/kubestellar/docs/issues/6282
 name: CodeQL Analysis
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
-  schedule:
-    - cron: '0 4 * * 1' # Weekly Monday 04:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## CI Fix

The `CodeQL Analysis` workflow (`.github/workflows/codeql.yml`) fails on every push to `main` because the repository has **GitHub's default Code Scanning setup** enabled, and running both the advanced workflow and the default setup simultaneously is rejected:

> `Code Scanning could not process the submitted SARIF file: CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`

**4 consecutive failures on 2026-07-10** (runs #29088559933, #29102170095, #29115311533, #29127861719).

### Change

Remove `push`, `pull_request`, and `schedule` triggers from `codeql.yml`. Keep `workflow_dispatch` only so the workflow is still available for manual debugging. The default Code Scanning setup already provides full automated coverage on every push, PR, and on a weekly schedule.

This is the same root cause as #5899 (fixed June 2026, then reverted when #6257 was filed). A comment in the file now explains why automatic triggers are disabled, to prevent future re-enablement.

Fixes #6282

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*