### PR TITLE
docs(hive): add Security Model page and refresh hive docs to v2

### DIFF
--- a/docs/content/hive/architecture.md
+++ b/docs/content/hive/architecture.md
@@ -1,8 +1,30 @@
 # Architecture
 
+## Hive v2 (current)
+
+Hive v2 runs as a **single container with three processes**:
+
+- **Go binary** (`hive`) — orchestrates agent tmux sessions, runs the governor eval loop, serves the dashboard API, manages health checks and token tracking
+- **Node.js proxy** — reverse proxy for the dashboard frontend with SSE streaming
+- **ttyd** — web terminal for remote access to agent tmux sessions
+
+Agents run inside tmux sessions managed by the Go binary, each under its own Unix UID. The **governor** evaluates queue depth on a configurable interval and switches between four modes (SURGE, BUSY, QUIET, IDLE), each with per-agent cadences. A **deterministic pipeline** of shell scripts pre-processes all GitHub data before agents are kicked, and a default-on **GitHub policy proxy** enforces each agent's ACMM mode and the repo allowlist at the network layer (see the [Security Model](security-model.md)).
+
+All configuration lives in a single `hive.yaml`; persistent state (metrics, beads, logs, dashboard config overlay) lives on a PVC at `/data`. Agents talk to their backend via per-agent CLI processes — Claude, Copilot, Gemini, Goose — or, for self-hosted inference backends (litellm / vllm / llm-d), via an in-process Anthropic-to-OpenAI translator.
+
+Hives can register with the **Hive Hub** (`hive.kubestellar.io`): the hub authenticates dashboard users with GitHub OAuth, proxies spoke dashboards, receives authenticated heartbeats (health, version, token counts), and can provision fully hosted hives — one namespace, pod, and PVC per hive, with zero-downtime rolling upgrades.
+
+See the [Introduction](readme.md) for deployment options and configuration reference.
+
+---
+
+## Legacy v1 runtime: supervision patterns
+
+> **Note:** the rest of this page documents the original **v1 runtime** — shell scripts driven by systemd/launchd on a host, with agents supervised in tmux (`hive supervisor`, `/etc/hive/*.env`). The v1 tooling still exists in the repository root, but v2 (above) is the current, recommended way to run hive. The supervision patterns below remain useful reading if you run agents outside the v2 container.
+
 ## Two scheduling models
 
-hive supports two fundamentally different ways to drive an agent. Choose based on how much control you want to keep.
+hive v1 supports two fundamentally different ways to drive an agent. Choose based on how much control you want to keep.
 
 ### Model A — Self-scheduling (/loop cron)
 

--- a/docs/content/hive/macos.md
+++ b/docs/content/hive/macos.md
@@ -1,6 +1,8 @@
 # macOS Support (launchd)
 
-The hive runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
+> **Note:** on **hive v2** the easiest way to run on macOS is Docker Compose — `cd hive/v2 && docker compose up -d` (see the [Introduction](readme.md)). This page documents the legacy **v1** host runtime mapped to launchd, which remains useful if you want to supervise agents natively on a Mac without a container.
+
+The hive v1 runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
 
 This guide shows how to run a supervised agent on a Mac that stays on (Mac Mini, Mac Studio, always-on laptop, etc.).
 

--- a/docs/content/hive/overview/intro.md
+++ b/docs/content/hive/overview/intro.md
@@ -1,114 +1,133 @@
 # hive
 
-**One command starts everything. Your phone, Slack, or Discord buzzes if anything needs you.**
+**AI agent orchestration for open source projects. One container runs a team of AI agents that triage issues, write fixes, review PRs, and keep CI green — governed by queue depth and gated by maturity levels.**
 
-**hive dashboard** — See [hive repository](https://github.com/kubestellar/hive) for the latest documentation and screenshots.
+Hive is a single Go binary that enumerates GitHub issues and PRs, classifies them by complexity, and dispatches work to AI agents (Claude, Copilot, Gemini, Goose, or self-hosted inference backends) on adaptive cadences.
+
+Hive separates decisions into two layers: a **deterministic pipeline** of shell scripts handles filtering, classification, merge-gating, and enforcement before any LLM sees the work. Agents only handle judgment calls — reading code, reasoning about fixes, writing PRs.
+
+> Evaluating whether hive is safe to run against your repos and API keys? See the [Security Model](../security-model.md).
 
 ---
 
-**hive architecture** — See [hive repository](https://github.com/kubestellar/hive) for architecture diagrams and technical details.
-
----
-
-## Setup
+## Quick Start (Docker Compose)
 
 ```bash
-# 1. install tmux
-sudo apt install tmux
+git clone -b v2 https://github.com/kubestellar/hive.git
+cd hive/v2
 
-# 2. install hive
-# Installation script — see hive repository for current install method
-# curl -H "Cache-Control: no-cache" -fsSL https://github.com/kubestellar/hive/raw/v2/install.sh | sudo bash
-
-# 3. configure
-sudo nano /etc/hive/hive.conf
-
-# 4. start
-hive supervisor
+cp hive.yaml.example hive.yaml
+export HIVE_GITHUB_TOKEN=ghp_...
+docker compose up -d
 ```
 
-That's it. `hive supervisor` installs missing tools, starts all agents, sets the kick cadence, and launches the supervisor. No tmux knowledge needed.
+Dashboard at `http://localhost:3001`. The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`; run `docker compose build` first to build from source instead.
 
 ---
 
-## Commands
+## Deployment options
 
-```bash
-hive supervisor             # start everything
-hive status                 # live terminal dashboard (cached repo data)
-hive status --repos         # refresh repo issue/PR counts from GitHub API
-hive status --json          # machine-readable JSON output
-hive status --json --repos  # JSON with fresh repo data (used by dashboard slow path)
-hive status --watch 5       # auto-refresh every 5 seconds (in-place overwrite)
-hive dashboard              # launch web dashboard (port 3001)
-hive attach supervisor      # watch the supervisor  (Ctrl+B D to leave)
-hive attach scanner         # watch any agent
+| Option | How |
+|--------|-----|
+| **Docker Compose** | `docker compose up -d` in `v2/` — quickest way to evaluate |
+| **Kubernetes (self-hosted)** | Manifests in `v2/deploy/k8s/` — namespace, secrets, ConfigMap from `hive.yaml`, PVC, Deployment, Service, Ingress. The default PVC is `ReadWriteOnce` with a `Recreate` strategy; use an NFS-backed `ReadWriteMany` StorageClass for zero-downtime rolling upgrades. |
+| **Hosted (Hive Hub)** | [hive.kubestellar.io](https://hive.kubestellar.io) provisions and hosts a hive for you — OAuth-protected dashboard, public registry, cross-hive leaderboards. No cluster required. |
 
-hive kick all               # immediate kick to all agents
-hive kick scanner           # kick one agent
+### Ports
 
-hive switch scanner claude  # switch CLI backend (pins it)
-hive switch reviewer copilot
-hive unpin scanner          # let governor manage CLI again
+| Port | Purpose |
+|------|---------|
+| 3001 | Dashboard (supports auth token) |
+| 3002 | Internal API |
+| 7681 | ttyd web terminal |
 
-hive logs governor          # tail governor decisions
-hive logs scanner           # tail any agent's service log
+### Volumes
 
-hive stop all               # stop everything
-```
+| Mount Path | Purpose |
+|------------|---------|
+| `/etc/hive/hive.yaml` | Configuration (read-only, from ConfigMap) |
+| `/data` | Persistent state: metrics, beads, logs, dashboard config overlay |
+| `/secrets` | GitHub App key and other secrets (read-only) |
 
 ---
 
 ## Web Dashboard
 
-`hive dashboard` launches a real-time web dashboard on port 3001.
+The embedded dashboard (port 3001) is the primary control surface:
 
-- **Live updates** via SSE — agent states, governor mode, repo counts, and beads refresh every 5 seconds
-- **Sparkline history** — per-agent busy time and restart count sparklines with rolling history
-- **Restart tracking** — 24-hour restart count per agent with color-coded thresholds (yellow >0, red >5)
+- **Live updates via SSE** — agent states, governor mode, repo counts, and beads refresh continuously
+- **Getting Started dialog** — a welcome checklist that auto-checks steps as setup completes and deep-links into the relevant configuration; minimizes into the `?` button when dismissed
+- **Per-agent method + model dropdowns** — each agent card shows its current backend and model as the button label; models are **live-discovered** per backend (see below)
+- **Model pinning** — pin an agent's model so automatic reconciliation never changes it out from under you; an explicit switch on a pinned agent retargets the pin instead of failing
+- **Test Connection** — live probe of inference gateways that reports the gateway's actual response (including auth errors) instead of masking failures behind fallback aliases
+- **Real token tracking** — inference usage is captured from actual API responses per agent; totals surface on the dashboard and, for hub-registered hives, on the hub's My Hives page
 - **Kick buttons** — one-click kick for any agent
-- **Switch dropdown** — switch agent CLI backend from the UI (auto-pins to prevent governor override)
-- **CLI pinning** — `hive switch` pins the backend so the governor won't override it; `hive unpin` releases it
-- **Intensity gauge** — half-circle speedometer comparing recent vs trailing token rates (cooling → steady → surging)
-- **Coverage tracking** — shows test coverage progress toward the configured target
-- **Übersicht widget** — download a macOS desktop widget from the button in the header
-- **Fast/slow refresh** — agent status refreshes every 5s; GitHub repo data refreshes every 60s to avoid API rate limits
+- **ACMM level control** — apply a maturity level and the full agent roster that level defines is reconciled automatically
+- **Web terminal** — ttyd access to agent tmux sessions
 
-The dashboard runs as a systemd service (`hive-dashboard.service`) and auto-restarts on failure.
+### Model discovery
 
-```bash
-# Manual access
-open http://192.168.4.56:3001    # from LAN
-open http://localhost:3001       # from hive itself
+Model lists are discovered live per backend rather than hardcoded:
 
-# Install Übersicht widget (macOS)
-curl -sf http://192.168.4.56:3001/api/widget | tar xzf - -C "$HOME/Library/Application Support/Übersicht/widgets/"
-```
+| Backend | Discovery source |
+|---------|-----------------|
+| litellm / vllm / llm-d | The gateway's live `/v1/models` endpoint |
+| copilot | Live per-plan model list (including enterprise API host discovery) using the stored OAuth token |
+| gemini | Live models API when an API key is configured |
+| claude / goose | Maintained model lists (no machine-readable source) |
+
+Discovery is best-effort with caching and fallbacks, so dropdowns never come up empty. An agent's model is switched automatically in exactly one case: live discovery shows the currently selected model is no longer available (and the model is not pinned) — the agent moves to an available model and the dashboard shows a notice.
 
 ---
 
 ## How it works
 
-The **kick-governor** measures issue and PR backlog across your repos every 5 minutes and picks a mode:
+The **governor** evaluates issue/PR queue depth across your repos on a configurable interval (default 300s) and switches between four modes — **SURGE**, **BUSY**, **QUIET**, **IDLE** — each with per-agent cadences (or `pause`). Thresholds and cadences are all set in `hive.yaml`:
 
-| Mode | Trigger | Scanner | Reviewer | Architect | Outreach | Supervisor |
-|------|---------|---------|----------|-----------|----------|------------|
-| SURGE | queue > 20 | 10 min | 10 min | **paused** | **paused** | 5 min |
-| BUSY  | queue > 10 | 15 min | 15 min | **paused** | **paused** | 5 min |
-| QUIET | queue > 2  | 15 min | 30 min | 1 h        | 2 h        | 5 min |
-| IDLE  | queue ≤ 2  | 30 min | 1 h    | 30 min     | 30 min     | 5 min |
+```yaml
+governor:
+  eval_interval_s: 300
+  modes:
+    surge:
+      threshold: 20
+      scanner: 15m
+      reviewer: pause
+    busy:
+      threshold: 10
+      scanner: 15m
+      reviewer: 1h
+    quiet:
+      threshold: 2
+      scanner: 15m
+      reviewer: 45m
+    idle:
+      threshold: 0
+      scanner: 15m
+      reviewer: 15m
+```
 
-Architect and outreach are **opportunistic** — they fill idle cycles and pause entirely under load. Supervisor runs every 5 min regardless of mode.
-
-Cadences are tunable in `/etc/hive/governor.env` — no restart needed.
-
-### Restart tracking
-
-Each supervisor process tracks agent restarts in `/var/run/kick-governor/restarts_<session>`. The count is a rolling 24-hour window — old timestamps are pruned automatically. The dashboard and `hive status --json` both expose the `restarts` field per agent.
+Agents run inside tmux sessions managed by the Go binary. The container runs three processes: the `hive` binary (agent orchestration, governor loop, dashboard API, health and token tracking), a Node.js proxy (dashboard frontend with SSE), and ttyd (web terminal).
 
 ---
 
-## Deterministic Pipeline
+## ACMM levels
+
+Hive uses an **AI-native Capability Maturity Model** (ACMM) with six levels that control what agents are allowed to do:
+
+| Level | Name | Agents | What agents can do |
+|-------|------|--------|-------------------|
+| L1 | Assisted | 2 | Interactive advisor and project inception. Advisory beads only. |
+| L2 | Instructed | 5 | Observe and report findings as dashboard beads. No GitHub interaction. |
+| L3 | Measured | 6 | Quality agent opens issues and hold-gated PRs. Others remain advisory. |
+| L4 | Adaptive | 7 | All agents file issues. Quality, sec-check, and CI open hold-gated PRs. |
+| L5 | Semi-Automated | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
+| L6 | Fully Autonomous | 10 | Agents open PRs and auto-merge on green CI. No hold label required. |
+
+Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). Applying a level reconciles the entire agent roster that level defines — at L5 that is 9 agents, including architect and strategist.
+
+---
+
+## Deterministic pipeline
 
 Hive separates work into two layers:
 
@@ -117,201 +136,104 @@ Hive separates work into two layers:
 
 The rule: **if a human would give the same answer every time, it belongs in infrastructure, not in a prompt.**
 
-LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliably prevents an agent from closing a hold-labeled issue or merging an untested PR. The deterministic pipeline removes those decisions from the agent entirely.
-
-### Pipeline stages
-
-Each stage runs as a shell script, declared in `hive-project.yaml`, with explicit dependencies:
-
-| Category | What it does | Example |
-|----------|-------------|---------|
-| **Enumerator** | Fetches and filters the canonical work list | `enumerate-actionable.sh` — queries GitHub, excludes hold/exempt labels, filters by author |
-| **Classifier** | Enriches items with deterministic metadata | `issue-classifier.sh` — complexity, model tier, lane assignment based on label/title patterns |
-| **Gate** | Pre-checks eligibility before action | `merge-gate.sh` — CI green? Author authorized? Required reviews in? |
-| **Monitor** | Detects state in external systems | `ga4-anomaly-detector.sh` — production error spikes; `copilot-comment-checker.sh` — unaddressed review comments |
-| **Enforcer** | Blocks agents from forbidden operations | `gh` wrapper — prevents merging to main, closing hold issues, pushing to protected branches |
-
-Stages declare their consumers and dependencies. The pipeline runner resolves the DAG and executes in parallel where possible.
-
-### Adding a pipeline stage
-
-1. Add an entry to `pipeline.stages[]` in `hive-project.yaml`
-2. Write the script in `bin/`
-3. Declare `output`, `consumers`, `phase`, and `depends`
-4. The pipeline runner picks it up on the next kick cycle
-
-### Config-driven rules
-
-Classification patterns, clustering signals, severity keywords, and exempt labels all live in `hive-project.yaml`. Scripts read rules from config — they don't contain project-specific logic. Change the config, change the behavior.
-
----
-
-## Adapting for Your Project
-
-Hive is designed to be forked and configured, not hardcoded. All project-specific values live in `hive-project.yaml`.
-
-### Step by step
-
-1. **Copy the example config:**
-   
-   ```bash
-   sudo cp examples/kubestellar/hive-project.yaml /etc/hive/hive-project.yaml
-   ```
-
-2. **Edit the `project` section** — your org, repos, AI author account:
-   
-   ```yaml
-   project:
-     name: "My Project"
-     org: "my-org"
-     primary_repo: "my-org/my-repo"
-     repos:
-       - my-org/my-repo
-       - my-org/my-docs
-     ai_author: "my-bot-account"
-   ```
-
-3. **Edit `agents.enabled`** — pick which agents you need:
-   
-   ```yaml
-   agents:
-     enabled:
-       - supervisor
-       - scanner
-       - reviewer
-       # - architect    # optional
-       # - outreach     # optional
-       # - docs-agent   # add your own
-   ```
-
-4. **Edit `classification`** — your labels, lane patterns, complexity rules:
-   
-   ```yaml
-   classification:
-     complexity:
-       simple:
-         labels: ["typo", "docs"]
-         model: "haiku"
-       complex:
-         labels: ["architecture", "epic"]
-         model: "opus"
-       default_model: "sonnet"
-   ```
-
-5. **Copy and edit agent CLAUDE.md files** from `examples/kubestellar/agents/`. Template variables like `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, and `${PROJECT_AI_AUTHOR}` are substituted automatically at kick time — you don't need to hardcode your project values.
-
-6. **Set agent `.env` files** with your workdir and model preferences.
-
-7. **Start:**
-   
-   ```bash
-   hive supervisor
-   ```
-
-### Template variables
-
-Agent policy files (CLAUDE.md) support these template variables, substituted by `kick-agents.sh` at kick time:
-
-| Variable | Source in config | Example value |
-|----------|-----------------|---------------|
-| `${PROJECT_ORG}` | `project.org` | `kubestellar` |
-| `${PROJECT_PRIMARY_REPO}` | `project.primary_repo` | `kubestellar/console` |
-| `${PROJECT_AI_AUTHOR}` | `project.ai_author` | `clubanderson` |
-| `${PROJECT_REPOS_LIST}` | `project.repos` | `kubestellar/console kubestellar/docs ...` |
-| `${HIVE_REPO}` | `project.hive_repo` | `kubestellar/hive` |
-| `${GA4_PROPERTY_ID}` | `outreach.ga4.property_id` | `525401563` |
-| `${AGENTS_WORKDIR}` | `agents.workdir` | `/home/dev/my-project` |
-| `${BEADS_BASE}` | `agents.beads_base` | `/home/dev` |
+LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliably prevents an agent from closing a hold-labeled issue or merging an untested PR. The deterministic pipeline removes those decisions from the agent entirely — enumerators fetch and filter the canonical work list, classifiers enrich items with metadata, gates pre-check eligibility, and enforcers block forbidden operations before any agent acts.
 
 ---
 
 ## Backends
 
-Set `HIVE_BACKENDS` in `hive.conf`. `HIVE_AUTO_INSTALL=true` installs missing backends on startup.
+Each agent picks its backend in `hive.yaml` (`agents.<name>.backend`):
 
 | Backend | Type | Description |
 |---------|------|-------------|
 | `claude` | CLI | Anthropic's CLI — runs Claude models directly |
-| `gemini` | CLI | Google's CLI — runs Gemini models directly |
 | `copilot` | Aggregate | GitHub Copilot — routes to Claude, GPT, Gemini, and other vendor models |
-| `goose` | Aggregate | Block's Goose — routes to any model via config: qwen, deepseek, llama, and more (cloud or local) |
+| `gemini` | CLI | Google's CLI — runs Gemini models directly |
+| `goose` | Aggregate | Block's Goose — routes to any model via config (cloud or local) |
+| `litellm` / `vllm` / `llm-d` | Inference | Self-hosted OpenAI-compatible gateways — the agent CLI runs in bare mode and an in-process Anthropic-to-OpenAI translator forwards requests to your gateway |
 
-**Native backends** (`claude`, `gemini`) are single-vendor tools that run their own models directly. **Aggregate backends** (`copilot`, `goose`) are multi-vendor routers — they can call models from different providers through a single interface.
+For inference backends, the gateway API key is entered once in the dashboard (obfuscated after entry) and stored to a Kubernetes Secret and an owner-only file on the PVC — never written into `hive.yaml`. See the [Security Model](../security-model.md) for how agents are kept away from real keys.
 
-### Local models (optional)
+---
 
-Set `HIVE_MODEL_SERVICES="ollama litellm"` to run models on-device with no API costs.
+## Configuration
 
-```text
-ollama        → runs local models (llama3, codestral, qwen2.5-coder, ...)
-    └── litellm proxy :4000  ← unified OpenAI-compatible endpoint
-            └── goose        ← points here when AGENT_BACKEND=goose
+All config lives in a single `hive.yaml` with `${ENV_VAR}` interpolation for secrets. See `v2/hive.yaml.example` for the full reference.
+
+```yaml
+project:
+  org: your-org
+  repos:
+    - repo-one
+    - repo-two
+  primary_repo: repo-one
+  ai_author: your-bot-user
+
+agents:
+  scanner:
+    enabled: true
+    backend: claude
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/scanner
+    clear_on_kick: true
+
+github:
+  token: ${HIVE_GITHUB_TOKEN}
+
+hub:
+  enabled: true
+  url: https://hive.kubestellar.io
 ```
 
-Ollama and litellm start as background services before any agent session launches.
+On Kubernetes the file is mounted read-only from a ConfigMap; changes made in the dashboard are persisted as an overlay on the `/data` PVC so they survive pod restarts.
+
+### GitHub auth
+
+Use a personal access token, or a GitHub App (recommended for production — permissions are scoped to the repos you install it on):
+
+```yaml
+github:
+  app_id: 12345
+  installation_id: 67890
+  key_file: /secrets/gh-app-key.pem
+```
 
 ---
 
 ## Notifications
 
-hive sends alerts to any combination of ntfy, Slack, and Discord. Set whichever you use in `hive.conf` — all three fire simultaneously if configured.
+Configure any combination of channels in `hive.yaml`:
 
-| Channel | Config key | How to get it |
-|---------|-----------|---------------|
-| ntfy (phone push) | `NTFY_TOPIC` | Free at [ntfy.sh](https://ntfy.sh) — pick any topic string |
-| Slack | `SLACK_WEBHOOK` | api.slack.com/apps → Incoming Webhooks |
-| Discord | `DISCORD_WEBHOOK` | Channel Settings → Integrations → Webhooks |
-
----
-
-## Config
-
-`/etc/hive/hive.conf` — the only file you need to edit:
-
-```bash
-# Repos to watch (space-separated)
-HIVE_REPOS="owner/repo1 owner/repo2"
-
-# Agent CLI backends to use (space-separated)
-HIVE_BACKENDS="copilot"          # copilot claude gemini goose
-
-# Local model services (optional — needs GPU or fast CPU)
-# HIVE_MODEL_SERVICES="ollama litellm"
-
-# Auto-install missing backends on hive supervisor start
-HIVE_AUTO_INSTALL=true
-
-# Notifications — set any combination
-NTFY_TOPIC=your-secret-topic     # free at ntfy.sh
-# SLACK_WEBHOOK=https://hooks.slack.com/services/...
-# DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
+```yaml
+notifications:
+  ntfy:
+    server: https://ntfy.sh
+    topic: my-hive-alerts
+  # slack:
+  #   webhook: ${SLACK_WEBHOOK_URL}
+  # discord:
+  #   webhook: ${DISCORD_WEBHOOK_URL}
 ```
 
+An optional Discord bot (`discord.bot_token`) responds to `!hive` commands.
+
 ---
 
-## Troubleshooting
+## Contribute to a Hive
+
+Community members can contribute compute to any registered hive:
 
 ```bash
-hive status                  # check what's running
-hive logs governor           # why did it kick / not kick?
-hive logs scanner            # what is scanner doing?
-hive attach supervisor       # watch supervisor live
-journalctl -u claude-scanner # raw service log
+brew install just gh
+git clone -b v2 https://github.com/kubestellar/hive && cd hive
+just contribute-setup claude
+just contribute-hive
 ```
 
-### Common issues
+Supported CLIs: Claude Code, GitHub Copilot, Pi, Goose, Bob. Contributors start as newcomer (rate-limited) and auto-promote based on completed tasks. Your credentials never leave your machine.
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| All agents idle, no ntfy | Governor crashing (check `hive logs governor`) | See below |
-| Governor: `Permission denied` on `/var/run/kick-governor/` | Root-owned files from `sudo` operations | `sudo chown -R dev:dev /var/run/kick-governor/` |
-| Governor: `Slack: command not found` | Broken comments in `notify.sh` | Reinstall: `sudo cp bin/notify.sh /usr/local/bin/notify.sh` |
-| Governor: `$2: unbound variable` | `set -u` + missing arg defaults | Use `${N:-}` syntax in all function params |
-| Dashboard: agents show `stopped` / CLI `?` | Service running as root (can't see dev's tmux) | Add `User=dev` to `hive-dashboard.service` |
-| Dashboard: widget download 404 | Stale node process on port 3001 | `ss -tlnp \| grep 3001` → `kill <PID>` → restart service |
-| `bd dolt push` fails | Root-owned `.beads/` files | `sudo chown -R dev:dev ~/.beads/ /home/dev/scanner-beads/.beads/` |
-| Beads: `?` in status | `bd list` blocked by stale lock | `sudo killall -9 bd && rm -f /home/dev/scanner-beads/.beads/embeddeddolt/.lock` |
+See the [Hive Hub](https://hive.kubestellar.io) to browse registered hives, view leaderboards, and find hives accepting contributions.
 
 ---
 
-Apache 2.0  ·  [Architecture](../architecture.md)
+Apache 2.0  ·  [Architecture](../architecture.md)  ·  [Security Model](../security-model.md)

--- a/docs/content/hive/readme.md
+++ b/docs/content/hive/readme.md
@@ -1,114 +1,133 @@
 # hive
 
-**One command starts everything. Your phone, Slack, or Discord buzzes if anything needs you.**
+**AI agent orchestration for open source projects. One container runs a team of AI agents that triage issues, write fixes, review PRs, and keep CI green — governed by queue depth and gated by maturity levels.**
 
-**hive dashboard** — See [hive repository](https://github.com/kubestellar/hive) for the latest documentation and screenshots.
+Hive is a single Go binary that enumerates GitHub issues and PRs, classifies them by complexity, and dispatches work to AI agents (Claude, Copilot, Gemini, Goose, or self-hosted inference backends) on adaptive cadences.
+
+Hive separates decisions into two layers: a **deterministic pipeline** of shell scripts handles filtering, classification, merge-gating, and enforcement before any LLM sees the work. Agents only handle judgment calls — reading code, reasoning about fixes, writing PRs.
+
+> Evaluating whether hive is safe to run against your repos and API keys? See the [Security Model](security-model.md).
 
 ---
 
-**hive architecture** — See [hive repository](https://github.com/kubestellar/hive) for architecture diagrams and technical details.
-
----
-
-## Setup
+## Quick Start (Docker Compose)
 
 ```bash
-# 1. install tmux
-sudo apt install tmux
+git clone -b v2 https://github.com/kubestellar/hive.git
+cd hive/v2
 
-# 2. install hive
-# Installation script — see hive repository for current install method
-# curl -H "Cache-Control: no-cache" -fsSL https://github.com/kubestellar/hive/raw/v2/install.sh | sudo bash
-
-# 3. configure
-sudo nano /etc/hive/hive.conf
-
-# 4. start
-hive supervisor
+cp hive.yaml.example hive.yaml
+export HIVE_GITHUB_TOKEN=ghp_...
+docker compose up -d
 ```
 
-That's it. `hive supervisor` installs missing tools, starts all agents, sets the kick cadence, and launches the supervisor. No tmux knowledge needed.
+Dashboard at `http://localhost:3001`. The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`; run `docker compose build` first to build from source instead.
 
 ---
 
-## Commands
+## Deployment options
 
-```bash
-hive supervisor             # start everything
-hive status                 # live terminal dashboard (cached repo data)
-hive status --repos         # refresh repo issue/PR counts from GitHub API
-hive status --json          # machine-readable JSON output
-hive status --json --repos  # JSON with fresh repo data (used by dashboard slow path)
-hive status --watch 5       # auto-refresh every 5 seconds (in-place overwrite)
-hive dashboard              # launch web dashboard (port 3001)
-hive attach supervisor      # watch the supervisor  (Ctrl+B D to leave)
-hive attach scanner         # watch any agent
+| Option | How |
+|--------|-----|
+| **Docker Compose** | `docker compose up -d` in `v2/` — quickest way to evaluate |
+| **Kubernetes (self-hosted)** | Manifests in `v2/deploy/k8s/` — namespace, secrets, ConfigMap from `hive.yaml`, PVC, Deployment, Service, Ingress. The default PVC is `ReadWriteOnce` with a `Recreate` strategy; use an NFS-backed `ReadWriteMany` StorageClass for zero-downtime rolling upgrades. |
+| **Hosted (Hive Hub)** | [hive.kubestellar.io](https://hive.kubestellar.io) provisions and hosts a hive for you — OAuth-protected dashboard, public registry, cross-hive leaderboards. No cluster required. |
 
-hive kick all               # immediate kick to all agents
-hive kick scanner           # kick one agent
+### Ports
 
-hive switch scanner claude  # switch CLI backend (pins it)
-hive switch reviewer copilot
-hive unpin scanner          # let governor manage CLI again
+| Port | Purpose |
+|------|---------|
+| 3001 | Dashboard (supports auth token) |
+| 3002 | Internal API |
+| 7681 | ttyd web terminal |
 
-hive logs governor          # tail governor decisions
-hive logs scanner           # tail any agent's service log
+### Volumes
 
-hive stop all               # stop everything
-```
+| Mount Path | Purpose |
+|------------|---------|
+| `/etc/hive/hive.yaml` | Configuration (read-only, from ConfigMap) |
+| `/data` | Persistent state: metrics, beads, logs, dashboard config overlay |
+| `/secrets` | GitHub App key and other secrets (read-only) |
 
 ---
 
 ## Web Dashboard
 
-`hive dashboard` launches a real-time web dashboard on port 3001.
+The embedded dashboard (port 3001) is the primary control surface:
 
-- **Live updates** via SSE — agent states, governor mode, repo counts, and beads refresh every 5 seconds
-- **Sparkline history** — per-agent busy time and restart count sparklines with rolling history
-- **Restart tracking** — 24-hour restart count per agent with color-coded thresholds (yellow >0, red >5)
+- **Live updates via SSE** — agent states, governor mode, repo counts, and beads refresh continuously
+- **Getting Started dialog** — a welcome checklist that auto-checks steps as setup completes and deep-links into the relevant configuration; minimizes into the `?` button when dismissed
+- **Per-agent method + model dropdowns** — each agent card shows its current backend and model as the button label; models are **live-discovered** per backend (see below)
+- **Model pinning** — pin an agent's model so automatic reconciliation never changes it out from under you; an explicit switch on a pinned agent retargets the pin instead of failing
+- **Test Connection** — live probe of inference gateways that reports the gateway's actual response (including auth errors) instead of masking failures behind fallback aliases
+- **Real token tracking** — inference usage is captured from actual API responses per agent; totals surface on the dashboard and, for hub-registered hives, on the hub's My Hives page
 - **Kick buttons** — one-click kick for any agent
-- **Switch dropdown** — switch agent CLI backend from the UI (auto-pins to prevent governor override)
-- **CLI pinning** — `hive switch` pins the backend so the governor won't override it; `hive unpin` releases it
-- **Intensity gauge** — half-circle speedometer comparing recent vs trailing token rates (cooling → steady → surging)
-- **Coverage tracking** — shows test coverage progress toward the configured target
-- **Übersicht widget** — download a macOS desktop widget from the button in the header
-- **Fast/slow refresh** — agent status refreshes every 5s; GitHub repo data refreshes every 60s to avoid API rate limits
+- **ACMM level control** — apply a maturity level and the full agent roster that level defines is reconciled automatically
+- **Web terminal** — ttyd access to agent tmux sessions
 
-The dashboard runs as a systemd service (`hive-dashboard.service`) and auto-restarts on failure.
+### Model discovery
 
-```bash
-# Manual access
-open http://192.168.4.56:3001    # from LAN
-open http://localhost:3001       # from hive itself
+Model lists are discovered live per backend rather than hardcoded:
 
-# Install Übersicht widget (macOS)
-curl -sf http://192.168.4.56:3001/api/widget | tar xzf - -C "$HOME/Library/Application Support/Übersicht/widgets/"
-```
+| Backend | Discovery source |
+|---------|-----------------|
+| litellm / vllm / llm-d | The gateway's live `/v1/models` endpoint |
+| copilot | Live per-plan model list (including enterprise API host discovery) using the stored OAuth token |
+| gemini | Live models API when an API key is configured |
+| claude / goose | Maintained model lists (no machine-readable source) |
+
+Discovery is best-effort with caching and fallbacks, so dropdowns never come up empty. An agent's model is switched automatically in exactly one case: live discovery shows the currently selected model is no longer available (and the model is not pinned) — the agent moves to an available model and the dashboard shows a notice.
 
 ---
 
 ## How it works
 
-The **kick-governor** measures issue and PR backlog across your repos every 5 minutes and picks a mode:
+The **governor** evaluates issue/PR queue depth across your repos on a configurable interval (default 300s) and switches between four modes — **SURGE**, **BUSY**, **QUIET**, **IDLE** — each with per-agent cadences (or `pause`). Thresholds and cadences are all set in `hive.yaml`:
 
-| Mode | Trigger | Scanner | Reviewer | Architect | Outreach | Supervisor |
-|------|---------|---------|----------|-----------|----------|------------|
-| SURGE | queue > 20 | 10 min | 10 min | **paused** | **paused** | 5 min |
-| BUSY  | queue > 10 | 15 min | 15 min | **paused** | **paused** | 5 min |
-| QUIET | queue > 2  | 15 min | 30 min | 1 h        | 2 h        | 5 min |
-| IDLE  | queue ≤ 2  | 30 min | 1 h    | 30 min     | 30 min     | 5 min |
+```yaml
+governor:
+  eval_interval_s: 300
+  modes:
+    surge:
+      threshold: 20
+      scanner: 15m
+      reviewer: pause
+    busy:
+      threshold: 10
+      scanner: 15m
+      reviewer: 1h
+    quiet:
+      threshold: 2
+      scanner: 15m
+      reviewer: 45m
+    idle:
+      threshold: 0
+      scanner: 15m
+      reviewer: 15m
+```
 
-Architect and outreach are **opportunistic** — they fill idle cycles and pause entirely under load. Supervisor runs every 5 min regardless of mode.
-
-Cadences are tunable in `/etc/hive/governor.env` — no restart needed.
-
-### Restart tracking
-
-Each supervisor process tracks agent restarts in `/var/run/kick-governor/restarts_<session>`. The count is a rolling 24-hour window — old timestamps are pruned automatically. The dashboard and `hive status --json` both expose the `restarts` field per agent.
+Agents run inside tmux sessions managed by the Go binary. The container runs three processes: the `hive` binary (agent orchestration, governor loop, dashboard API, health and token tracking), a Node.js proxy (dashboard frontend with SSE), and ttyd (web terminal).
 
 ---
 
-## Deterministic Pipeline
+## ACMM levels
+
+Hive uses an **AI-native Capability Maturity Model** (ACMM) with six levels that control what agents are allowed to do:
+
+| Level | Name | Agents | What agents can do |
+|-------|------|--------|-------------------|
+| L1 | Assisted | 2 | Interactive advisor and project inception. Advisory beads only. |
+| L2 | Instructed | 5 | Observe and report findings as dashboard beads. No GitHub interaction. |
+| L3 | Measured | 6 | Quality agent opens issues and hold-gated PRs. Others remain advisory. |
+| L4 | Adaptive | 7 | All agents file issues. Quality, sec-check, and CI open hold-gated PRs. |
+| L5 | Semi-Automated | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
+| L6 | Fully Autonomous | 10 | Agents open PRs and auto-merge on green CI. No hold label required. |
+
+Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). Applying a level reconciles the entire agent roster that level defines — at L5 that is 9 agents, including architect and strategist.
+
+---
+
+## Deterministic pipeline
 
 Hive separates work into two layers:
 
@@ -117,201 +136,104 @@ Hive separates work into two layers:
 
 The rule: **if a human would give the same answer every time, it belongs in infrastructure, not in a prompt.**
 
-LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliably prevents an agent from closing a hold-labeled issue or merging an untested PR. The deterministic pipeline removes those decisions from the agent entirely.
-
-### Pipeline stages
-
-Each stage runs as a shell script, declared in `hive-project.yaml`, with explicit dependencies:
-
-| Category | What it does | Example |
-|----------|-------------|----------|
-| **Enumerator** | Fetches and filters the canonical work list | `enumerate-actionable.sh` — queries GitHub, excludes hold/exempt labels, filters by author |
-| **Classifier** | Enriches items with deterministic metadata | `issue-classifier.sh` — complexity, model tier, lane assignment based on label/title patterns |
-| **Gate** | Pre-checks eligibility before action | `merge-gate.sh` — CI green? Author authorized? Required reviews in? |
-| **Monitor** | Detects state in external systems | `ga4-anomaly-detector.sh` — production error spikes; `copilot-comment-checker.sh` — unaddressed review comments |
-| **Enforcer** | Blocks agents from forbidden operations | `gh` wrapper — prevents merging to main, closing hold issues, pushing to protected branches |
-
-Stages declare their consumers and dependencies. The pipeline runner resolves the DAG and executes in parallel where possible.
-
-### Adding a pipeline stage
-
-1. Add an entry to `pipeline.stages[]` in `hive-project.yaml`
-2. Write the script in `bin/`
-3. Declare `output`, `consumers`, `phase`, and `depends`
-4. The pipeline runner picks it up on the next kick cycle
-
-### Config-driven rules
-
-Classification patterns, clustering signals, severity keywords, and exempt labels all live in `hive-project.yaml`. Scripts read rules from config — they don't contain project-specific logic. Change the config, change the behavior.
-
----
-
-## Adapting for Your Project
-
-Hive is designed to be forked and configured, not hardcoded. All project-specific values live in `hive-project.yaml`.
-
-### Step by step
-
-1. **Copy the example config:**
-   
-   ```bash
-   sudo cp examples/kubestellar/hive-project.yaml /etc/hive/hive-project.yaml
-   ```
-
-2. **Edit the `project` section** — your org, repos, AI author account:
-   
-   ```yaml
-   project:
-     name: "My Project"
-     org: "my-org"
-     primary_repo: "my-org/my-repo"
-     repos:
-       - my-org/my-repo
-       - my-org/my-docs
-     ai_author: "my-bot-account"
-   ```
-
-3. **Edit `agents.enabled`** — pick which agents you need:
-   
-   ```yaml
-   agents:
-     enabled:
-       - supervisor
-       - scanner
-       - reviewer
-       # - architect    # optional
-       # - outreach     # optional
-       # - docs-agent   # add your own
-   ```
-
-4. **Edit `classification`** — your labels, lane patterns, complexity rules:
-   
-   ```yaml
-   classification:
-     complexity:
-       simple:
-         labels: ["typo", "docs"]
-         model: "haiku"
-       complex:
-         labels: ["architecture", "epic"]
-         model: "opus"
-       default_model: "sonnet"
-   ```
-
-5. **Copy and edit agent CLAUDE.md files** from `examples/kubestellar/agents/`. Template variables like `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, and `${PROJECT_AI_AUTHOR}` are substituted automatically at kick time — you don't need to hardcode your project values.
-
-6. **Set agent `.env` files** with your workdir and model preferences.
-
-7. **Start:**
-   
-   ```bash
-   hive supervisor
-   ```
-
-### Template variables
-
-Agent policy files (CLAUDE.md) support these template variables, substituted by `kick-agents.sh` at kick time:
-
-| Variable | Source in config | Example value |
-|----------|-----------------|---------------|
-| `${PROJECT_ORG}` | `project.org` | `kubestellar` |
-| `${PROJECT_PRIMARY_REPO}` | `project.primary_repo` | `kubestellar/console` |
-| `${PROJECT_AI_AUTHOR}` | `project.ai_author` | `clubanderson` |
-| `${PROJECT_REPOS_LIST}` | `project.repos` | `kubestellar/console kubestellar/docs ...` |
-| `${HIVE_REPO}` | `project.hive_repo` | `kubestellar/hive` |
-| `${GA4_PROPERTY_ID}` | `outreach.ga4.property_id` | `525401563` |
-| `${AGENTS_WORKDIR}` | `agents.workdir` | `/home/dev/my-project` |
-| `${BEADS_BASE}` | `agents.beads_base` | `/home/dev` |
+LLMs treat "NEVER" rules as suggestions. No amount of prompt engineering reliably prevents an agent from closing a hold-labeled issue or merging an untested PR. The deterministic pipeline removes those decisions from the agent entirely — enumerators fetch and filter the canonical work list, classifiers enrich items with metadata, gates pre-check eligibility, and enforcers block forbidden operations before any agent acts.
 
 ---
 
 ## Backends
 
-Set `HIVE_BACKENDS` in `hive.conf`. `HIVE_AUTO_INSTALL=true` installs missing backends on startup.
+Each agent picks its backend in `hive.yaml` (`agents.<name>.backend`):
 
 | Backend | Type | Description |
 |---------|------|-------------|
 | `claude` | CLI | Anthropic's CLI — runs Claude models directly |
-| `gemini` | CLI | Google's CLI — runs Gemini models directly |
 | `copilot` | Aggregate | GitHub Copilot — routes to Claude, GPT, Gemini, and other vendor models |
-| `goose` | Aggregate | Block's Goose — routes to any model via config: qwen, deepseek, llama, and more (cloud or local) |
+| `gemini` | CLI | Google's CLI — runs Gemini models directly |
+| `goose` | Aggregate | Block's Goose — routes to any model via config (cloud or local) |
+| `litellm` / `vllm` / `llm-d` | Inference | Self-hosted OpenAI-compatible gateways — the agent CLI runs in bare mode and an in-process Anthropic-to-OpenAI translator forwards requests to your gateway |
 
-**Native backends** (`claude`, `gemini`) are single-vendor tools that run their own models directly. **Aggregate backends** (`copilot`, `goose`) are multi-vendor routers — they can call models from different providers through a single interface.
+For inference backends, the gateway API key is entered once in the dashboard (obfuscated after entry) and stored to a Kubernetes Secret and an owner-only file on the PVC — never written into `hive.yaml`. See the [Security Model](security-model.md) for how agents are kept away from real keys.
 
-### Local models (optional)
+---
 
-Set `HIVE_MODEL_SERVICES="ollama litellm"` to run models on-device with no API costs.
+## Configuration
 
-```text
-ollama        → runs local models (llama3, codestral, qwen2.5-coder, ...)
-    └── litellm proxy :4000  ← unified OpenAI-compatible endpoint
-            └── goose        ← points here when AGENT_BACKEND=goose
+All config lives in a single `hive.yaml` with `${ENV_VAR}` interpolation for secrets. See `v2/hive.yaml.example` for the full reference.
+
+```yaml
+project:
+  org: your-org
+  repos:
+    - repo-one
+    - repo-two
+  primary_repo: repo-one
+  ai_author: your-bot-user
+
+agents:
+  scanner:
+    enabled: true
+    backend: claude
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/scanner
+    clear_on_kick: true
+
+github:
+  token: ${HIVE_GITHUB_TOKEN}
+
+hub:
+  enabled: true
+  url: https://hive.kubestellar.io
 ```
 
-Ollama and litellm start as background services before any agent session launches.
+On Kubernetes the file is mounted read-only from a ConfigMap; changes made in the dashboard are persisted as an overlay on the `/data` PVC so they survive pod restarts.
+
+### GitHub auth
+
+Use a personal access token, or a GitHub App (recommended for production — permissions are scoped to the repos you install it on):
+
+```yaml
+github:
+  app_id: 12345
+  installation_id: 67890
+  key_file: /secrets/gh-app-key.pem
+```
 
 ---
 
 ## Notifications
 
-hive sends alerts to any combination of ntfy, Slack, and Discord. Set whichever you use in `hive.conf` — all three fire simultaneously if configured.
+Configure any combination of channels in `hive.yaml`:
 
-| Channel | Config key | How to get it |
-|---------|-----------|---------------|
-| ntfy (phone push) | `NTFY_TOPIC` | Free at [ntfy.sh](https://ntfy.sh) — pick any topic string |
-| Slack | `SLACK_WEBHOOK` | api.slack.com/apps → Incoming Webhooks |
-| Discord | `DISCORD_WEBHOOK` | Channel Settings → Integrations → Webhooks |
-
----
-
-## Config
-
-`/etc/hive/hive.conf` — the only file you need to edit:
-
-```bash
-# Repos to watch (space-separated)
-HIVE_REPOS="owner/repo1 owner/repo2"
-
-# Agent CLI backends to use (space-separated)
-HIVE_BACKENDS="copilot"          # copilot claude gemini goose
-
-# Local model services (optional — needs GPU or fast CPU)
-# HIVE_MODEL_SERVICES="ollama litellm"
-
-# Auto-install missing backends on hive supervisor start
-HIVE_AUTO_INSTALL=true
-
-# Notifications — set any combination
-NTFY_TOPIC=your-secret-topic     # free at ntfy.sh
-# SLACK_WEBHOOK=https://hooks.slack.com/services/...
-# DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
+```yaml
+notifications:
+  ntfy:
+    server: https://ntfy.sh
+    topic: my-hive-alerts
+  # slack:
+  #   webhook: ${SLACK_WEBHOOK_URL}
+  # discord:
+  #   webhook: ${DISCORD_WEBHOOK_URL}
 ```
 
+An optional Discord bot (`discord.bot_token`) responds to `!hive` commands.
+
 ---
 
-## Troubleshooting
+## Contribute to a Hive
+
+Community members can contribute compute to any registered hive:
 
 ```bash
-hive status                  # check what's running
-hive logs governor           # why did it kick / not kick?
-hive logs scanner            # what is scanner doing?
-hive attach supervisor       # watch supervisor live
-journalctl -u claude-scanner # raw service log
+brew install just gh
+git clone -b v2 https://github.com/kubestellar/hive && cd hive
+just contribute-setup claude
+just contribute-hive
 ```
 
-### Common issues
+Supported CLIs: Claude Code, GitHub Copilot, Pi, Goose, Bob. Contributors start as newcomer (rate-limited) and auto-promote based on completed tasks. Your credentials never leave your machine.
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| All agents idle, no ntfy | Governor crashing (check `hive logs governor`) | See below |
-| Governor: `Permission denied` on `/var/run/kick-governor/` | Root-owned files from `sudo` operations | `sudo chown -R dev:dev /var/run/kick-governor/` |
-| Governor: `Slack: command not found` | Broken comments in `notify.sh` | Reinstall: `sudo cp bin/notify.sh /usr/local/bin/notify.sh` |
-| Governor: `$2: unbound variable` | `set -u` + missing arg defaults | Use `${N:-}` syntax in all function params |
-| Dashboard: agents show `stopped` / CLI `?` | Service running as root (can't see dev's tmux) | Add `User=dev` to `hive-dashboard.service` |
-| Dashboard: widget download 404 | Stale node process on port 3001 | `ss -tlnp \| grep 3001` → `kill <PID>` → restart service |
-| `bd dolt push` fails | Root-owned `.beads/` files | `sudo chown -R dev:dev ~/.beads/ /home/dev/scanner-beads/.beads/` |
-| Beads: `?` in status | `bd list` blocked by stale lock | `sudo killall -9 bd && rm -f /home/dev/scanner-beads/.beads/embeddeddolt/.lock` |
+See the [Hive Hub](https://hive.kubestellar.io) to browse registered hives, view leaderboards, and find hives accepting contributions.
 
 ---
 
-Apache 2.0  ·  [Architecture](architecture.md)
+Apache 2.0  ·  [Architecture](architecture.md)  ·  [Security Model](security-model.md)

--- a/docs/content/hive/security-model.md
+++ b/docs/content/hive/security-model.md
@@ -1,0 +1,101 @@
+# Security Model
+
+This page is for the evaluator asking: *is it safe to run hive — to host a hive on the hub, point agents at my repositories, and hand the system my AI subscription or API keys?*
+
+Hive's answer is architectural, not aspirational. The project's core design rule — *if a human would give the same answer every time, it belongs in infrastructure, not in a prompt* — applies doubly to security: the controls below are enforced by code (authentication middleware, a policy proxy, scoped tokens, file permissions), not by asking an LLM to behave. Every mechanism described here is verifiable in the [hive v2 source](https://github.com/kubestellar/hive/tree/v2).
+
+## What hive touches
+
+A running hive holds three things you care about:
+
+| Asset | How hive uses it |
+|-------|------------------|
+| **Your GitHub repositories** | Agents read issues/PRs and open branches, issues, and pull requests using a token or GitHub App you provide |
+| **Your AI subscriptions / API keys** | Agent CLIs (Claude, Copilot, Gemini, Goose) authenticate with your provider accounts; self-hosted inference backends (litellm / vllm / llm-d) use a gateway API key you enter |
+| **Your cluster (or the hosted platform)** | The hive pod runs agents, the dashboard, and persistent state on a PVC |
+
+The threats that matter: an unauthorized person reaching your dashboard, an agent (or a prompt-injected agent) exfiltrating credentials or touching repos it shouldn't, one agent reading another's credentials, and the hosted platform mixing tenants. Each layer below addresses one of these.
+
+---
+
+## Layer 1 — Dashboard access control (hub route)
+
+Hives hosted on or registered with the [Hive Hub](https://hive.kubestellar.io) are reached through `*.hive.kubestellar.io`, and every request passes the hub's authentication check before it reaches a spoke dashboard:
+
+- **GitHub OAuth.** Users sign in to the hub with GitHub (`read:user` scope). The session cookie is `HttpOnly`, `Secure`, `SameSite=Lax`.
+- **Per-user, per-hive authorization on every request.** The hub's auth-check endpoint (wired as an nginx `auth_request`) resolves the requesting user, looks up whether that specific hive is in the user's access map, and returns **403 if it isn't**. Only then does the request proceed to the spoke.
+- **Identity injection.** On success, the hub injects the verified identity into the proxied request as `X-Hive-User` and `X-Hive-Role` headers. The spoke's role-enforcement middleware then blocks all write operations for `read`-role users.
+- **Roles.** The hive owner has full read-write control. Owners can grant other GitHub users access to their hive; grants default to **read-only**. A grant can never confer a role equal to or higher than the granter's own.
+
+## Layer 2 — Direct-route spoke authentication
+
+Some hives run on clusters the hub cannot proxy (for example, an OpenShift route reached directly). These spokes cannot rely on the hub's auth check, so the dashboard enforces its own per-user authentication (shipped in [hive#1839](https://github.com/kubestellar/hive/pull/1839)):
+
+- **GitHub device-flow login with a per-hive allowlist.** At provisioning, the hub injects the authorized user list (owner plus any grants) into the spoke as `HIVE_AUTHORIZED_USERS`. When someone completes device-flow login, the spoke validates the GitHub identity and checks it against the allowlist — a non-allowlisted user receives **403 before any session or token is persisted**.
+- **Per-user opaque sessions.** Each authorized visitor gets their own session: a 256-bit cryptographically random session ID in an `HttpOnly` cookie, mapped server-side to their username and role. Two people viewing the same dashboard each see their own identity. The session deliberately does not store the user's GitHub token.
+- **Forged identity headers are stripped.** On direct routes there is no trusted hub in front, so incoming `X-Hive-User` / `X-Hive-Role` headers are deleted by the authentication middleware before any handler sees them. A client cannot claim an identity by setting headers.
+- **The shared bearer token grants no identity.** On direct-route spokes, the legacy shared dashboard token is not accepted for user authentication, and the endpoint that exposes it returns 404. Possessing the token does not let you impersonate a user.
+- **A viewer's login cannot clobber the owner's credentials.** The spoke only persists a GitHub token and updates its GitHub client when the *owner* logs in. A read-only viewer authenticating (or logging out) never touches the owner's stored write credentials.
+- **Write grants are deferred — and fail safe.** On direct routes, every non-owner grant is provisioned as **read-only**, even if the owner stored a read-write grant on the hub. Until per-user write credentials are implemented for direct routes, the system downgrades rather than over-granting.
+
+## Layer 3 — API keys and credential isolation
+
+The strongest isolation story is around inference-backend API keys — agents literally never possess them:
+
+- **Per-agent placeholder keys.** An agent using a self-hosted inference backend (litellm / vllm / llm-d) is launched with `ANTHROPIC_API_KEY=sk-hive-<agent-name>` — a placeholder that authenticates the agent only to a local translator proxy bound to `127.0.0.1` inside the pod. Nothing outside the pod accepts that string.
+- **Server-side key swap.** The translator identifies the agent from its placeholder, converts the request from Anthropic to OpenAI format, and attaches the **real** gateway key server-side before forwarding upstream. The real key never appears in any agent's environment, filesystem view, or prompt.
+- **Secret storage chain.** The real key is resolved from, in order: a configured key file → the Kubernetes Secret mount (`/secrets/litellm_api_key`) → an owner-only PVC file (`/data/secrets/litellm_api_key`, mode `0600` in a `0700` directory) → environment variable. When you enter a key in the dashboard it is written to the PVC file and patched into the hive's own Kubernetes Secret.
+- **Never in config files.** `hive.yaml` only ever records a key file *path* or an environment variable *name* — never a key value. The dashboard's persisted config overlay (`/data/hive.yaml.dashboard`) is secret-free by design: env-derived secrets are collapsed back to `${VAR}` references and the dashboard auth token is blanked before writing.
+- **Obfuscated in the UI.** Key entry uses a password field; after entry the API never returns the value — only whether a key exists, a masked tail hint, and which store it resolved from. A log-scrubbing handler additionally redacts GitHub-token and JWT patterns from all log output.
+
+**Honest scope:** this placeholder mechanism applies to inference backends. Agents using cloud CLI backends (Claude, Copilot, Gemini, Goose) authenticate with the provider credential you connected for that purpose — that credential is available to the CLI process, as it must be for the CLI to work. Cross-agent exposure of those credentials is limited by the sandboxing layer below.
+
+## Layer 4 — Agent sandboxing
+
+Agents are unprivileged, separated, and policed at the network layer:
+
+- **Per-agent Unix UIDs.** Each agent runs as its own user (UIDs allocated from base 2001) via `su-exec`, with its own tmux server on a per-agent socket. One agent cannot attach to another's session or signal its processes.
+- **Per-agent GitHub tokens, owner-readable only.** When GitHub App auth is used, each agent's scoped token is written to a per-agent cache file with `0600` permissions and `chown`ed to that agent's UID — if the chown fails, the file is deleted rather than left shared. Agents cannot read each other's GitHub tokens.
+- **Per-agent tool denylists.** Declarative per-agent tool rules in `hive.yaml` become hard CLI flags at launch (`--disallowed-tools` for Claude, `--deny-tool` for Copilot), and lower ACMM modes automatically add GitHub-write denials.
+- **A default-on GitHub policy proxy.** Every agent's `HTTPS_PROXY` points at an in-pod proxy that intercepts **GitHub API traffic** and enforces, deterministically, what the agent's current ACMM mode allows: REST method/path rules, GraphQL query-vs-mutation gating, and a **repository allowlist** — writes to any repo outside the hive's configured list are blocked with 403 at the network layer, regardless of what the agent was prompted (or prompt-injected) to do. The proxy inspects only GitHub API traffic; other destinations are tunneled without inspection. The same proxy also attributes traffic to agents by UID for token accounting.
+
+## Layer 5 — GitHub blast-radius controls
+
+What can agents actually do to your repositories? As little as you've dialed in:
+
+- **GitHub App scoping.** The recommended auth is a GitHub App — its reach is inherently limited to the repositories you installed it on. On top of that, hive mints **per-tier installation tokens** matched to each agent's autonomy mode: advisory agents get metadata/PR read-only tokens that *cannot* create issues; mid-tier agents get issues-only tokens with no code access; only trusted tiers get contents/PR write.
+- **Repo allowlist, enforced twice.** The configured repo list is enforced in the policy proxy (hard, network-level) and also injected into every agent kick as an explicit `AUTHORIZED REPOS` constraint (a prompt-level reinforcement of the hard control).
+- **ACMM maturity levels gate autonomy.** Six levels (L1–L6) map to per-agent policy modes enforced end-to-end by token tiers and proxy rules: advisory (observe only) → measured (file issues) → hold-gated PRs → full. At **L5**, agent policies label every PR `hold` so humans batch-review and approve; the underlying guarantee is that **merge permission simply is not granted below L6** — an L5 agent's token and proxy rules do not allow merging, whatever its prompt says. The system proposes; humans approve.
+- **DCO sign-off.** Agent policies require DCO-signed commits (`git commit -s`); pair this with a DCO check on your repos to make it a hard gate.
+
+## Layer 6 — Hub↔spoke channel
+
+Registered hives send periodic heartbeats to the hub:
+
+- Heartbeats are authenticated with a bearer secret (`HIVE_HUB_SECRET`, provisioned by the hub) and validated with a constant-time comparison.
+- The outbound payload carries operational telemetry only: health and cluster metrics, version/git info, agent and governor summaries, and 24-hour **token counts**. No API keys, GitHub tokens, or other credentials leave the spoke in heartbeats.
+- The response channel is how the hub delivers configuration to hives it manages (including GitHub App credentials for hub-provisioned hives) — hub-to-spoke, never spoke-to-hub.
+
+## Layer 7 — Hosted-platform isolation
+
+On the hosted platform, each hive is single-tenant by construction:
+
+- **One namespace, one pod, one PVC per hive.** Provisioning creates a dedicated `hive-hosted-<id>` namespace with its own PVC and a single-replica Deployment. There is no shared runtime between customers' hives.
+- **Least-privilege RBAC.** The per-hive Role is namespace-scoped and limited to the hive's own `hive-secrets` Secret by name — a hive pod cannot read other namespaces' secrets.
+- **Authenticated internal API.** Server-to-server calls inside the pod (the dashboard proxy to the Go API) carry an internal auth token header validated with a constant-time comparison; security headers (CSP, X-Frame-Options, etc.) are always active on the dashboard, and an optional bearer `auth_token` can be required on all API endpoints.
+- **Zero-downtime upgrades.** Hosted hives roll updates with `maxSurge=1` / `maxUnavailable=0` on ReadWriteMany PVCs, so upgrades don't create a window where a half-started replacement serves requests.
+
+---
+
+## Scope and limitations, stated plainly
+
+Security documentation that only lists strengths is marketing. The current, deliberate scoping:
+
+- **Direct-route write grants are deferred.** Non-owner grants on direct-route spokes are always provisioned read-only, even if granted read-write on the hub. This fails safe (under-granting, never over-granting) until per-user write credentials land.
+- **The heartbeat secret is hub-wide.** `HIVE_HUB_SECRET` authenticates spokes to the hub as a class, not per-hive. Heartbeat data is operational telemetry, not secrets, which bounds the impact.
+- **The policy proxy covers GitHub API traffic.** It is a GitHub-policy enforcement point, not a general egress firewall. If you need full egress control, apply Kubernetes NetworkPolicies around the hive pod.
+- **The L5 `hold` label is applied by agent policy;** the hard guarantee at L5 is the withheld merge permission (token tier + proxy rules), not the label itself.
+- **Cloud CLI credentials are shared with the CLI.** Claude/Copilot/Gemini/Goose agents necessarily run with the provider credential you connected. The placeholder-key isolation applies to inference-gateway keys.
+- **DCO is policy-driven** inside hive; enforce it repo-side (DCO check) for a hard guarantee.
+
+Found something? Security reports are welcome on the [hive repository](https://github.com/kubestellar/hive/issues) — or see the KubeStellar [security policy](/docs/contributing/security/policy) for private disclosure contacts.

--- a/docs/content/hive/troubleshooting.md
+++ b/docs/content/hive/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+> **Note:** most of this page covers the legacy **v1 runtime** (systemd/launchd host installs with `/etc/hive/agent.env`). On **v2**, start with the dashboard instead: the Getting Started dialog auto-checks setup steps, **Test Connection** live-probes inference gateways and reports the gateway's actual error, agent cards show live state, and the built-in web terminal (ttyd) gives direct access to agent tmux sessions. Check container logs with `docker compose logs -f` or `kubectl -n hive logs deploy/hive`.
+
 ## The `/loop` prompt never fires — the agent just sits at the prompt
 
 Cause: the supervisor's `AGENT_READY_MARKER` doesn't appear in the agent's TUI, so the supervisor gives up before sending `AGENT_LOOP_PROMPT`.

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -343,6 +343,12 @@ const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
     ]
   },
   {
+    title: 'Security',
+    items: [
+      { 'Security Model': 'security-model.md' },
+    ]
+  },
+  {
     title: 'Reference',
     items: [
       { 'Outreach Anti-Spam': 'outreach-antispam.md' },


### PR DESCRIPTION
## Summary

Two-part update to the hive docs section:

### New: Security Model page (`/docs/hive/security/security-model`)

A standalone security page for evaluators asking whether it is safe to run hive against their repos, API keys, and clusters. Every mechanism was verified against the hive v2 source before being documented:

- **Threat model** — what hive touches (GitHub repos, AI subscriptions/keys, cluster)
- **Layer 1** — hub GitHub OAuth + per-user/per-hive authorization with `X-Hive-User`/`X-Hive-Role` identity injection
- **Layer 2** — direct-route spoke auth (device flow + `HIVE_AUTHORIZED_USERS` allowlist, 403 before session creation, per-user opaque sessions, forged-header stripping, shared token grants no identity, viewer login cannot clobber owner credentials) — hive#1839
- **Layer 3** — inference API-key isolation: per-agent `sk-hive-<agent>` placeholder keys, server-side key swap in the localhost translator, Secret → PVC (`0600`/`0700`) → env resolution chain, secret-free config overlay, masked UI
- **Layer 4** — per-agent UID sandboxing, per-agent chowned GitHub token caches, tool denylists, default-on GitHub policy proxy (ACMM mode rules + repo allowlist enforced at the network layer)
- **Layer 5** — GitHub App scoping with per-tier least-privilege installation tokens, ACMM L1–L6 autonomy gating, L5 hold-gated workflow backed by withheld merge permission
- **Layer 6** — heartbeat channel auth and telemetry-only payload
- **Layer 7** — hosted-platform per-hive namespace/pod/PVC isolation, namespace-scoped RBAC, zero-downtime rolling upgrades
- **Scope and limitations** stated plainly (read-only direct-route grants, hub-wide heartbeat secret, GitHub-only proxy coverage, prompt-vs-enforced distinctions)

### Refresh: existing hive pages audited against v2

- **Introduction** (`readme.md` + `overview/intro.md`): rewritten from the retired v1 host runtime (`hive supervisor`, `/etc/hive/hive.conf`, systemd) to v2 — Docker Compose quick start, K8s + hosted-hub deployment, v2 dashboard capabilities (Getting Started dialog, live per-backend model discovery, model pinning, honest Test Connection, real inference token tracking, ACMM level roster reconciliation), config-driven governor, ACMM table, inference backends, `hive.yaml` reference
- **Architecture**: new v2 architecture overview section; existing supervision-pattern content labeled as legacy v1
- **macOS**: v2-on-macOS note (Docker Compose); launchd guide kept as legacy v1
- **Troubleshooting**: v2 pointer (dashboard checks, Test Connection, web terminal, container logs); host-runtime content kept for v1
- **Outreach Anti-Spam**: audited, still accurate — no change

Sidebar: new `Security` section in `NAV_STRUCTURE_HIVE` (`page-map.ts`), following the console section's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)