### PR TITLE
feat: resilient branded 403/404/error pages that never render unstyled

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,28 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
+# ---------------------------------------------------------------------------
+# Custom error pages
+#
+# public/404.html and public/403.html are fully self-contained branded error
+# pages (inline CSS, inline SVG logo, no external requests) so they render
+# correctly even mid-deploy when hashed asset bundles may be unavailable.
+#
+# - 404: Next.js serves src/app/not-found.tsx for app-routed misses.
+#   /404.html is additionally picked up automatically by Netlify as the
+#   custom 404 page for requests that never reach the Next.js handler
+#   (e.g. deploy propagation windows or origin failures).
+# - 403: Netlify returns 403 for blocked/restricted requests (firewall
+#   rules, protected paths). /403.html is the branded page for that case;
+#   reference it from any Netlify access-control/WAF custom-response
+#   configuration, and from any redirect rule that returns status = 403.
+#
+# NOTE: do NOT add a catch-all `from = "/*" to = "/404.html" status = 404`
+# rule here. With @netlify/plugin-nextjs, netlify.toml redirects take
+# precedence over Next.js routing, and a non-forced /* rule would shadow
+# every server-rendered route and 404 the whole site.
+# ---------------------------------------------------------------------------
+
 # Enable branch deploys for documentation versioning
 # Version branches follow the pattern: docs/{version}
 # Netlify will create deploy previews at: https://docs-X-Y-Z--kubestellar-docs.netlify.app

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Access denied (403) &middot; KubeStellar</title>
+<!--
+  Fully self-contained error page: all CSS is inlined and the logo is an
+  inline SVG, so this page renders correctly even when hashed asset bundles
+  are unavailable (e.g. mid-deploy propagation windows). Do not add external
+  stylesheets, fonts, scripts, or images to this file.
+-->
+<style>
+  :root {
+    /* KubeStellar palette (see src/app/globals.css / tailwind.config.ts) */
+    --bg: #0a0a0a;            /* space-dark */
+    --fg: #f3f4f6;
+    --muted: #9ca3af;
+    --card: rgba(255, 255, 255, 0.05);
+    --border: rgba(255, 255, 255, 0.12);
+    --accent: #3b82f6;
+    --accent-fg: #ffffff;
+    --grad-a: #667eea;
+    --grad-b: #764ba2;
+    --grad-c: #f093fb;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f8fafc;
+      --fg: #0f172a;
+      --muted: #475569;
+      --card: rgba(15, 23, 42, 0.04);
+      --border: rgba(15, 23, 42, 0.14);
+    }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    /* subtle starfield rendered purely in CSS -- no image requests */
+    background-image:
+      radial-gradient(1px 1px at 20% 30%, rgba(255,255,255,0.35) 50%, transparent 51%),
+      radial-gradient(1px 1px at 70% 20%, rgba(255,255,255,0.28) 50%, transparent 51%),
+      radial-gradient(1.5px 1.5px at 85% 65%, rgba(255,255,255,0.25) 50%, transparent 51%),
+      radial-gradient(1px 1px at 40% 80%, rgba(255,255,255,0.3) 50%, transparent 51%),
+      radial-gradient(1.5px 1.5px at 10% 70%, rgba(255,255,255,0.22) 50%, transparent 51%),
+      radial-gradient(1px 1px at 55% 45%, rgba(255,255,255,0.25) 50%, transparent 51%);
+  }
+  @media (prefers-color-scheme: light) {
+    body { background-image: none; }
+  }
+  header {
+    padding: 1.25rem 1.5rem;
+  }
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    text-decoration: none;
+    color: var(--fg);
+    font-weight: 600;
+    font-size: 1.05rem;
+    letter-spacing: 0.01em;
+  }
+  .brand svg { display: block; width: 28px; height: 28px; }
+  main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+    text-align: center;
+  }
+  .wrap { max-width: 44rem; }
+  .code {
+    font-size: clamp(4.5rem, 16vw, 8rem);
+    font-weight: 800;
+    line-height: 1;
+    background-image: linear-gradient(135deg, var(--grad-a) 0%, var(--grad-b) 50%, var(--grad-c) 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: var(--grad-b); /* fallback if background-clip:text unsupported */
+    margin-bottom: 1.25rem;
+  }
+  h1 {
+    font-size: clamp(1.4rem, 4vw, 2rem);
+    font-weight: 600;
+    margin-bottom: 0.9rem;
+  }
+  p.lede {
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin-bottom: 2.25rem;
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+  }
+  .btn {
+    display: inline-block;
+    padding: 0.7rem 1.6rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    text-decoration: none;
+    border: 1px solid var(--border);
+    color: var(--fg);
+    background: var(--card);
+  }
+  .btn:hover { border-color: var(--accent); }
+  .btn.primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-fg);
+  }
+  .btn.primary:hover { filter: brightness(1.1); }
+  footer {
+    padding: 1.25rem 1.5rem;
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  footer a { color: var(--muted); }
+</style>
+</head>
+<body>
+  <header>
+    <a class="brand" href="/">
+      <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true" focusable="false">
+        <defs>
+          <linearGradient id="ksg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#667eea"/>
+            <stop offset="0.5" stop-color="#764ba2"/>
+            <stop offset="1" stop-color="#f093fb"/>
+          </linearGradient>
+        </defs>
+        <path fill="url(#ksg)" d="M16 1l3.2 9.3a2.5 2.5 0 0 0 1.5 1.5L30 15l-9.3 3.2a2.5 2.5 0 0 0-1.5 1.5L16 29l-3.2-9.3a2.5 2.5 0 0 0-1.5-1.5L2 15l9.3-3.2a2.5 2.5 0 0 0 1.5-1.5L16 1z"/>
+        <circle fill="#3b82f6" cx="25.5" cy="6.5" r="2.5"/>
+      </svg>
+      <span>KubeStellar</span>
+    </a>
+  </header>
+  <main>
+    <div class="wrap">
+      <div class="code">403</div>
+      <h1>You don&rsquo;t have access to this page</h1>
+      <p class="lede">
+        Access to this page is restricted (HTTP 403). If you believe you
+        should have access, please reach out to the KubeStellar maintainers.
+        In the meantime, the documentation and main site are open to everyone.
+      </p>
+      <div class="actions">
+        <a class="btn primary" href="/docs">Browse the docs</a>
+        <a class="btn" href="/">KubeStellar home</a>
+        <a class="btn" href="https://github.com/kubestellar" rel="noopener">GitHub</a>
+      </div>
+    </div>
+  </main>
+  <footer>
+    KubeStellar &mdash; multi-cluster configuration management for Kubernetes
+  </footer>
+</body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Page not found (404) &middot; KubeStellar</title>
+<!--
+  Fully self-contained error page: all CSS is inlined and the logo is an
+  inline SVG, so this page renders correctly even when hashed asset bundles
+  are unavailable (e.g. mid-deploy propagation windows). Do not add external
+  stylesheets, fonts, scripts, or images to this file.
+-->
+<style>
+  :root {
+    /* KubeStellar palette (see src/app/globals.css / tailwind.config.ts) */
+    --bg: #0a0a0a;            /* space-dark */
+    --fg: #f3f4f6;
+    --muted: #9ca3af;
+    --card: rgba(255, 255, 255, 0.05);
+    --border: rgba(255, 255, 255, 0.12);
+    --accent: #3b82f6;
+    --accent-fg: #ffffff;
+    --grad-a: #667eea;
+    --grad-b: #764ba2;
+    --grad-c: #f093fb;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f8fafc;
+      --fg: #0f172a;
+      --muted: #475569;
+      --card: rgba(15, 23, 42, 0.04);
+      --border: rgba(15, 23, 42, 0.14);
+    }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    /* subtle starfield rendered purely in CSS -- no image requests */
+    background-image:
+      radial-gradient(1px 1px at 20% 30%, rgba(255,255,255,0.35) 50%, transparent 51%),
+      radial-gradient(1px 1px at 70% 20%, rgba(255,255,255,0.28) 50%, transparent 51%),
+      radial-gradient(1.5px 1.5px at 85% 65%, rgba(255,255,255,0.25) 50%, transparent 51%),
+      radial-gradient(1px 1px at 40% 80%, rgba(255,255,255,0.3) 50%, transparent 51%),
+      radial-gradient(1.5px 1.5px at 10% 70%, rgba(255,255,255,0.22) 50%, transparent 51%),
+      radial-gradient(1px 1px at 55% 45%, rgba(255,255,255,0.25) 50%, transparent 51%);
+  }
+  @media (prefers-color-scheme: light) {
+    body { background-image: none; }
+  }
+  header {
+    padding: 1.25rem 1.5rem;
+  }
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    text-decoration: none;
+    color: var(--fg);
+    font-weight: 600;
+    font-size: 1.05rem;
+    letter-spacing: 0.01em;
+  }
+  .brand svg { display: block; width: 28px; height: 28px; }
+  main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+    text-align: center;
+  }
+  .wrap { max-width: 44rem; }
+  .code {
+    font-size: clamp(4.5rem, 16vw, 8rem);
+    font-weight: 800;
+    line-height: 1;
+    background-image: linear-gradient(135deg, var(--grad-a) 0%, var(--grad-b) 50%, var(--grad-c) 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: var(--grad-b); /* fallback if background-clip:text unsupported */
+    margin-bottom: 1.25rem;
+  }
+  h1 {
+    font-size: clamp(1.4rem, 4vw, 2rem);
+    font-weight: 600;
+    margin-bottom: 0.9rem;
+  }
+  p.lede {
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin-bottom: 2.25rem;
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+  }
+  .btn {
+    display: inline-block;
+    padding: 0.7rem 1.6rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    text-decoration: none;
+    border: 1px solid var(--border);
+    color: var(--fg);
+    background: var(--card);
+  }
+  .btn:hover { border-color: var(--accent); }
+  .btn.primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-fg);
+  }
+  .btn.primary:hover { filter: brightness(1.1); }
+  footer {
+    padding: 1.25rem 1.5rem;
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  footer a { color: var(--muted); }
+</style>
+</head>
+<body>
+  <header>
+    <a class="brand" href="/">
+      <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true" focusable="false">
+        <defs>
+          <linearGradient id="ksg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#667eea"/>
+            <stop offset="0.5" stop-color="#764ba2"/>
+            <stop offset="1" stop-color="#f093fb"/>
+          </linearGradient>
+        </defs>
+        <path fill="url(#ksg)" d="M16 1l3.2 9.3a2.5 2.5 0 0 0 1.5 1.5L30 15l-9.3 3.2a2.5 2.5 0 0 0-1.5 1.5L16 29l-3.2-9.3a2.5 2.5 0 0 0-1.5-1.5L2 15l9.3-3.2a2.5 2.5 0 0 0 1.5-1.5L16 1z"/>
+        <circle fill="#3b82f6" cx="25.5" cy="6.5" r="2.5"/>
+      </svg>
+      <span>KubeStellar</span>
+    </a>
+  </header>
+  <main>
+    <div class="wrap">
+      <div class="code">404</div>
+      <h1>Page not found</h1>
+      <p class="lede">
+        Sorry, the page you are looking for does not exist or may have moved.
+        Try the documentation, or use the search on any docs page to find what
+        you need.
+      </p>
+      <div class="actions">
+        <a class="btn primary" href="/docs">Browse the docs</a>
+        <a class="btn" href="/">KubeStellar home</a>
+        <a class="btn" href="https://github.com/kubestellar" rel="noopener">GitHub</a>
+      </div>
+    </div>
+  </main>
+  <footer>
+    KubeStellar &mdash; multi-cluster configuration management for Kubernetes
+  </footer>
+</body>
+</html>

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,21 +1,11 @@
-import { Footer, GridLines, Navbar, StarField } from "@/components";
 import NotFoundUI from "@/components/NotFoundUI";
 
+// NOTE: this page deliberately does NOT render Navbar / GridLines / StarField.
+// The 404 page is served during deploy propagation windows when the previous
+// deploy's hashed CSS bundle can 404; those components rely entirely on
+// Tailwind classes (including unsized inline SVGs) and render broken without
+// CSS. NotFoundUI is fully self-contained (inline styles only) so it can
+// never render unstyled. See src/components/NotFoundUI.tsx.
 export default function LocaleNotFound() {
-  return (
-    <div className="min-h-screen bg-black text-white relative overflow-hidden">
-      <div className="absolute inset-0 z-0">
-        <GridLines />
-        <StarField />
-      </div>
-
-      <div className="relative z-10">
-        <Navbar />
-        <div className="flex justify-center items-center min-h-screen">
-          <NotFoundUI />
-        </div>
-        <Footer />
-      </div>
-    </div>
-  );
+  return <NotFoundUI />;
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+// Root-level error boundary (catches errors thrown by root layouts too).
+// Like the 404 pages, this uses inline styles ONLY and English-only strings:
+// when this boundary renders, the app (and possibly its CSS bundle and i18n
+// message loading) has already failed, so it must not depend on anything
+// external. Please keep it free of Tailwind classes and external assets.
+
+// KubeStellar brand palette (mirrors src/app/globals.css / tailwind.config.ts)
+const SPACE_DARK = "#0a0a0a";
+const ACCENT_BLUE = "#3b82f6";
+const GRADIENT =
+  "linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%)";
+const GRADIENT_FALLBACK = "#764ba2"; // if background-clip: text is unsupported
+const TEXT_PRIMARY = "#f3f4f6";
+const TEXT_MUTED = "#9ca3af";
+const SUBTLE_BG = "rgba(255, 255, 255, 0.05)";
+const SUBTLE_BORDER = "1px solid rgba(255, 255, 255, 0.12)";
+
+const styles: Record<string, CSSProperties> = {
+  body: {
+    margin: 0,
+    minHeight: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: SPACE_DARK,
+    color: TEXT_PRIMARY,
+    textAlign: "center",
+    padding: "3rem 1.5rem",
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  },
+  wrap: { maxWidth: "44rem" },
+  code: {
+    fontSize: "clamp(3.5rem, 12vw, 6rem)",
+    fontWeight: 800,
+    lineHeight: 1,
+    backgroundImage: GRADIENT,
+    WebkitBackgroundClip: "text",
+    backgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+    color: GRADIENT_FALLBACK,
+    marginBottom: "1.25rem",
+  },
+  heading: {
+    fontSize: "1.75rem",
+    fontWeight: 600,
+    margin: "0 0 0.9rem",
+  },
+  message: {
+    fontSize: "1.05rem",
+    color: TEXT_MUTED,
+    lineHeight: 1.6,
+    margin: "0 0 2.25rem",
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "0.75rem",
+    justifyContent: "center",
+  },
+  buttonPrimary: {
+    display: "inline-block",
+    padding: "0.75rem 2rem",
+    borderRadius: "0.5rem",
+    fontSize: "1rem",
+    fontWeight: 500,
+    textDecoration: "none",
+    color: "#ffffff",
+    backgroundColor: ACCENT_BLUE,
+    border: `1px solid ${ACCENT_BLUE}`,
+    cursor: "pointer",
+    fontFamily: "inherit",
+  },
+  buttonSecondary: {
+    display: "inline-block",
+    padding: "0.75rem 2rem",
+    borderRadius: "0.5rem",
+    fontSize: "1rem",
+    fontWeight: 500,
+    textDecoration: "none",
+    color: TEXT_PRIMARY,
+    backgroundColor: SUBTLE_BG,
+    border: SUBTLE_BORDER,
+  },
+};
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body style={styles.body}>
+        <main style={styles.wrap}>
+          <div style={styles.code}>Oops</div>
+          <h1 style={styles.heading}>Something went wrong</h1>
+          <p style={styles.message}>
+            An unexpected error occurred while loading this page. It may be a
+            temporary problem &mdash; trying again usually fixes it.
+          </p>
+          <div style={styles.actions}>
+            <button type="button" onClick={reset} style={styles.buttonPrimary}>
+              Try again
+            </button>
+            <a href="/" style={styles.buttonSecondary}>
+              KubeStellar home
+            </a>
+            <a href="/docs" style={styles.buttonSecondary}>
+              Browse the docs
+            </a>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -108,9 +108,14 @@ export default function GlobalError({
             <button type="button" onClick={reset} style={styles.buttonPrimary}>
               Try again
             </button>
+            {/* Plain <a> is deliberate here: when the global error boundary
+                renders, the app (router included) has already crashed, so a
+                full-page navigation is the most reliable way out. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a href="/" style={styles.buttonSecondary}>
               KubeStellar home
             </a>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a href="/docs" style={styles.buttonSecondary}>
               Browse the docs
             </a>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,27 +1,19 @@
-import { Footer, GridLines, Navbar, StarField } from "@/components";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import NotFoundUI from "@/components/NotFoundUI";
 
+// NOTE: this page deliberately does NOT render Navbar / GridLines / StarField.
+// The 404 page is served during deploy propagation windows when the previous
+// deploy's hashed CSS bundle can 404; those components rely entirely on
+// Tailwind classes (including unsized inline SVGs) and render broken without
+// CSS. NotFoundUI is fully self-contained (inline styles only) so it can
+// never render unstyled. See src/components/NotFoundUI.tsx.
 export default async function NotFound() {
   const locale = await getLocale();
   const messages = await getMessages();
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <div className="min-h-screen bg-black text-white relative overflow-hidden">
-        <div className="absolute inset-0 z-0">
-          <GridLines />
-          <StarField />
-        </div>
-
-        <div className="relative z-10">
-          <Navbar />
-          <div className="flex justify-center items-center min-h-screen">
-            <NotFoundUI />
-          </div>
-          <Footer />
-        </div>
-      </div>
+      <NotFoundUI />
     </NextIntlClientProvider>
   );
 }

--- a/src/components/NotFoundUI.tsx
+++ b/src/components/NotFoundUI.tsx
@@ -3,48 +3,205 @@
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+import type { CSSProperties } from "react";
+
+// This component intentionally uses INLINE STYLES ONLY (no Tailwind classes
+// for layout/color) and explicit width/height attributes on the SVG mark.
+//
+// Why: the 404 page is exactly what users see during deploy propagation
+// windows, when the previous deploy's hashed CSS bundle can 404. A 404 page
+// styled via external CSS then renders unstyled -- unsized inline SVGs blow
+// up to full viewport width (the "giant blue glyph" incident). Inline styles
+// and sized SVGs cannot fail to load, so this page always renders correctly.
+// Please keep it free of Tailwind classes and external assets.
+
+// KubeStellar brand palette (mirrors src/app/globals.css / tailwind.config.ts)
+const SPACE_DARK = "#0a0a0a";
+const ACCENT_BLUE = "#3b82f6";
+const GRADIENT =
+  "linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%)";
+const GRADIENT_FALLBACK = "#764ba2"; // if background-clip: text is unsupported
+const TEXT_PRIMARY = "#f3f4f6";
+const TEXT_MUTED = "#9ca3af";
+const PATH_ACCENT = "#c084fc";
+const SUBTLE_BG = "rgba(255, 255, 255, 0.05)";
+const SUBTLE_BORDER = "1px solid rgba(255, 255, 255, 0.12)";
+
+const styles: Record<string, CSSProperties> = {
+  page: {
+    minHeight: "100vh",
+    display: "flex",
+    flexDirection: "column",
+    backgroundColor: SPACE_DARK,
+    color: TEXT_PRIMARY,
+    fontFamily:
+      'var(--font-inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif)',
+  },
+  header: { padding: "1.25rem 1.5rem" },
+  brand: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.6rem",
+    textDecoration: "none",
+    color: TEXT_PRIMARY,
+    fontWeight: 600,
+    fontSize: "1.05rem",
+  },
+  main: {
+    flex: 1,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "3rem 1.5rem",
+    textAlign: "center",
+  },
+  wrap: { maxWidth: "44rem" },
+  code: {
+    fontSize: "clamp(4.5rem, 16vw, 8rem)",
+    fontWeight: 800,
+    lineHeight: 1,
+    backgroundImage: GRADIENT,
+    WebkitBackgroundClip: "text",
+    backgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+    color: GRADIENT_FALLBACK,
+    marginBottom: "1.25rem",
+  },
+  description: {
+    fontSize: "1.25rem",
+    color: TEXT_PRIMARY,
+    lineHeight: 1.6,
+    marginBottom: "1.5rem",
+  },
+  pathBox: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.5rem",
+    padding: "0.5rem 1rem",
+    borderRadius: "0.5rem",
+    backgroundColor: SUBTLE_BG,
+    border: SUBTLE_BORDER,
+    marginBottom: "1.5rem",
+    maxWidth: "100%",
+  },
+  pathLabel: { fontSize: "0.875rem", color: TEXT_MUTED },
+  pathValue: {
+    fontSize: "0.875rem",
+    color: PATH_ACCENT,
+    fontFamily:
+      "var(--font-jetbrains-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
+    overflowWrap: "anywhere",
+  },
+  message: {
+    fontSize: "1.05rem",
+    color: TEXT_MUTED,
+    lineHeight: 1.6,
+    marginBottom: "2.5rem",
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "0.75rem",
+    justifyContent: "center",
+  },
+  buttonPrimary: {
+    display: "inline-block",
+    padding: "0.75rem 2rem",
+    borderRadius: "0.5rem",
+    fontSize: "1rem",
+    fontWeight: 500,
+    textDecoration: "none",
+    color: "#ffffff",
+    backgroundColor: ACCENT_BLUE,
+    border: `1px solid ${ACCENT_BLUE}`,
+  },
+  buttonSecondary: {
+    display: "inline-block",
+    padding: "0.75rem 2rem",
+    borderRadius: "0.5rem",
+    fontSize: "1rem",
+    fontWeight: 500,
+    textDecoration: "none",
+    color: TEXT_PRIMARY,
+    backgroundColor: SUBTLE_BG,
+    border: SUBTLE_BORDER,
+  },
+};
+
+const LOGO_SIZE = 28; // px; explicit size so the SVG can never render unsized
+
+function BrandMark() {
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      width={LOGO_SIZE}
+      height={LOGO_SIZE}
+      aria-hidden="true"
+      focusable="false"
+      style={{ display: "block", width: LOGO_SIZE, height: LOGO_SIZE }}
+    >
+      <defs>
+        <linearGradient id="ks-nf-grad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#667eea" />
+          <stop offset="0.5" stopColor="#764ba2" />
+          <stop offset="1" stopColor="#f093fb" />
+        </linearGradient>
+      </defs>
+      <path
+        fill="url(#ks-nf-grad)"
+        d="M16 1l3.2 9.3a2.5 2.5 0 0 0 1.5 1.5L30 15l-9.3 3.2a2.5 2.5 0 0 0-1.5 1.5L16 29l-3.2-9.3a2.5 2.5 0 0 0-1.5-1.5L2 15l9.3-3.2a2.5 2.5 0 0 0 1.5-1.5L16 1z"
+      />
+      <circle fill={ACCENT_BLUE} cx="25.5" cy="6.5" r="2.5" />
+    </svg>
+  );
+}
 
 export default function NotFoundUI() {
   const t = useTranslations("notFound");
   const pathname = usePathname();
 
   return (
-    <section className="px-4 py-32 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-4xl text-center">
-        <h1 className="text-8xl font-bold mb-8">
-          <span className="block text-gradient-animated">404</span>
-        </h1>
+    <div style={styles.page}>
+      <header style={styles.header}>
+        <Link href="/" style={styles.brand}>
+          <BrandMark />
+          <span>KubeStellar</span>
+        </Link>
+      </header>
 
-        <p className="text-xl sm:text-2xl text-gray-300 mb-8 max-w-3xl mx-auto leading-relaxed">
-          {t("description")}
-        </p>
+      <main style={styles.main}>
+        <section style={styles.wrap}>
+          <div style={styles.code}>404</div>
 
-        {pathname && (
-          <div className="mb-8 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 border border-white/10 backdrop-blur-sm">
-            <span className="text-sm text-gray-500">{t("requestedPath")}</span>
-            <code className="text-sm text-purple-400 font-mono">{pathname}</code>
+          <p style={styles.description}>{t("description")}</p>
+
+          {pathname && (
+            <div style={styles.pathBox}>
+              <span style={styles.pathLabel}>{t("requestedPath")}</span>
+              <code style={styles.pathValue}>{pathname}</code>
+            </div>
+          )}
+
+          <p style={styles.message}>{t("message")}</p>
+
+          <div style={styles.actions}>
+            <Link href="/" style={styles.buttonPrimary}>
+              {t("homeButton")}
+            </Link>
+            <Link href="/docs" style={styles.buttonSecondary}>
+              {t("docsButton")}
+            </Link>
+            <a
+              href="https://github.com/kubestellar"
+              rel="noopener noreferrer"
+              target="_blank"
+              style={styles.buttonSecondary}
+            >
+              GitHub
+            </a>
           </div>
-        )}
-
-        <p className="text-lg text-gray-400 max-w-2xl mx-auto mb-16">
-          {t("message")}
-        </p>
-
-        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-          <Link
-            href="/"
-            className="inline-flex items-center justify-center px-8 py-3 text-base font-medium text-white bg-[#3b82f6] rounded-lg transition-all duration-300 hover:scale-105 hover:shadow-lg hover:shadow-blue-500/25"
-          >
-            {t("homeButton")}
-          </Link>
-          <Link
-            href="/docs"
-            className="inline-flex items-center justify-center px-8 py-3 text-base font-medium text-gray-300 bg-white/5 border border-white/10 rounded-lg transition-all duration-300 hover:scale-105 backdrop-blur-sm"
-          >
-            {t("docsButton")}
-          </Link>
-        </div>
-      </div>
-    </section>
+        </section>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

During a deploy propagation window a user hit a docs URL and got a broken error surface: a giant unstyled blue glyph filling the viewport with only the KubeStellar logo visible top-left.

**Root cause:** the 404 route (`not-found.tsx` -> `NotFoundUI` + `Navbar`/`GridLines`/`StarField`) is styled entirely by Tailwind classes from the hashed CSS bundle. Mid-deploy, the old bundle 404s and the page renders unstyled. The Navbar's inline SVG icons are sized only via `className="w-5 h-5"` with `stroke="currentColor"` inside links -- with no CSS, an SVG with only a viewBox expands to 100% container width, and `currentColor` inside an unstyled `<a>` is default link blue. That is the giant blue glyph. The logo survived because it is an `<img>` with explicit dimensions.

## Changes

| File | Change |
|---|---|
| `public/404.html` | **New.** Branded static 404, fully self-contained: inline CSS, inline SVG logo, system fonts, CSS-only starfield, `prefers-color-scheme` light/dark, responsive, zero external asset requests. Netlify picks up `/404.html` automatically for requests that never reach the Next.js handler. |
| `public/403.html` | **New.** Same treatment for "You don't have access to this page (403)" -- for Netlify-blocked/restricted paths (firewall, protected routes); directly linkable and usable from any WAF/access-control custom-response config. |
| `src/components/NotFoundUI.tsx` | Rewritten with **inline styles only** and explicitly sized SVGs so the Next.js 404 can never render unstyled. Keeps i18n strings and the requested-path readout; adds GitHub link. |
| `src/app/not-found.tsx`, `src/app/[locale]/not-found.tsx` | Drop CSS-bundle-dependent `Navbar`/`GridLines`/`StarField` from the 404 route (the fragility source). |
| `src/app/global-error.tsx` | **New** root error boundary (was absent), same self-contained discipline, with a Try-again reset button. |
| `netlify.toml` | Documents the error-page wiring, incl. why a catch-all `/* -> /404.html 404` rule must NOT be added with `@netlify/plugin-nextjs` (it would shadow every SSR route). |

## Error-path coverage after this PR

- **404 (app-routed miss):** Next.js `not-found.tsx` -- now unstyled-proof
- **404 (request never reaches Next, e.g. mid-deploy):** static `/404.html`
- **403 (blocked/restricted):** static `/403.html`
- **Runtime render error:** `global-error.tsx` boundary

## Verification

Both static pages parse clean, contain no external stylesheet/script/font/image requests, and were render-checked in headless Chrome (branded dark space theme with gradient status code and working links to /docs, /, and GitHub; `prefers-color-scheme` light variant included).
