### PR TITLE
docs: sync console release versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -464,5 +464,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-07-11T06:02:41.397Z"
+  "updatedAt": "2026-07-12T06:15:51.814Z"
 }


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker