### PR TITLE
fix: address typos from typo-check run #29183313939

### DIFF
--- a/docs/content/community/kubecon/eu2025/contribfest.md
+++ b/docs/content/community/kubecon/eu2025/contribfest.md
@@ -2,7 +2,7 @@
 
 ![KubeStellar Contribfest KubeCon EU 2025 London, UK](./contribfest-2025.jpg)
 
-We’re thrilled to be hosting a Contribfest session at KubeCon + CloudNativeCon Europe 2025 in London, UK! Join us on Thursday, April 3, 2025, from 4:00pm to 5:15pm BST in ExceL London, Level 3 | ICC Capital Suite 1.
+We’re thrilled to be hosting a Contribfest session at KubeCon + CloudNativeCon Europe 2025 in London, UK! Join us on Thursday, April 3, 2025, from 4:00pm to 5:15pm BST in ExCeL London, Level 3 | ICC Capital Suite 1.
 
 As a Sandbox CNCF project, KubeStellar is at an exciting stage of growth, and there’s never been a better time to get involved as an open-source contributor. In this post, we’ll explain what Contribfest is, highlight some beginner-friendly issues, and show you how you can join the fun, whether you're attending in London or contributing remotely.
 

--- a/docs/content/kubestellar/argo-to-wds1.md
+++ b/docs/content/kubestellar/argo-to-wds1.md
@@ -30,7 +30,7 @@ sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
 rm argocd-linux-amd64
 ```
 
-Check the [ArgoCD releases](https://github.com/argoproj/argo-cd/releases) page for the obtaining the latest 
+Check the [ArgoCD releases](https://github.com/argoproj/argo-cd/releases) page for obtaining the latest 
 stable release for other architectures and operating systems.
 
 Configure Argo to work with the ingress installed in the hosting cluster:


### PR DESCRIPTION
Fixes #6295

- Fix 'ExceL London' to 'ExCeL London' in contribfest.md
- Fix 'for the obtaining the' to 'for obtaining the' in argo-to-wds1.md