### PR TITLE
fix: repair broken links

### DIFF
--- a/docs/content/hive/agent-configuration.md
+++ b/docs/content/hive/agent-configuration.md
@@ -252,8 +252,8 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 
 ## What to read next
 
-- **[Introduction](/docs/hive/overview/introduction)** — what hive is, setup, and the command surface.
-- **[Architecture](/docs/hive/overview/architecture)** — the two scheduling models and how the supervisor drives agents.
-- **[macOS Setup](/docs/hive/getting-started/macos-setup)** — run a hive locally.
-- **[Troubleshooting](/docs/hive/getting-started/troubleshooting)** — stuck sessions, login expiry, restart loops.
+- **[Introduction](/docs/hive/overview/intro)** — what hive is, setup, and the command surface.
+- **[Architecture](/docs/hive/architecture)** — the two scheduling models and how the supervisor drives agents.
+- **[macOS Setup](/docs/hive/macos)** — run a hive locally.
+- **[Troubleshooting](/docs/hive/troubleshooting)** — stuck sessions, login expiry, restart loops.
 - **[ACMM policy matrix](https://github.com/kubestellar/hive/blob/v2/v2/docs/acmm-policy-matrix.md)** — the full per-level, per-agent policy table in the hive repo.

--- a/docs/content/hive/security-model.md
+++ b/docs/content/hive/security-model.md
@@ -98,4 +98,4 @@ Security documentation that only lists strengths is marketing. The current, deli
 - **Cloud CLI credentials are shared with the CLI.** Claude/Copilot/Gemini/Goose agents necessarily run with the provider credential you connected. The placeholder-key isolation applies to inference-gateway keys.
 - **DCO is policy-driven** inside hive; enforce it repo-side (DCO check) for a hard guarantee.
 
-Found something? Security reports are welcome on the [hive repository](https://github.com/kubestellar/hive/issues) — or see the KubeStellar [security policy](/docs/contributing/security/policy) for private disclosure contacts.
+Found something? Security reports are welcome on the [hive repository](https://github.com/kubestellar/hive/issues) — or see the KubeStellar [security policy](/docs/contributing/security) for private disclosure contacts.


### PR DESCRIPTION
Fixes #6296

## Changes

This PR repairs 5 broken internal links detected in link checker run 29183547874.

### Fixed Links

**docs/content/hive/agent-configuration.md** (lines 255-258):
- `/docs/hive/overview/introduction` → `/docs/hive/overview/intro`
- `/docs/hive/overview/architecture` → `/docs/hive/architecture`
- `/docs/hive/getting-started/macos-setup` → `/docs/hive/macos`
- `/docs/hive/getting-started/troubleshooting` → `/docs/hive/troubleshooting`

**docs/content/hive/security-model.md** (line 101):
- `/docs/contributing/security/policy` → `/docs/contributing/security`

All links now point to existing documentation files at their correct paths.