### PR TITLE
[sec-check] fix: add least-privilege permissions to copilot-dco workflow

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,4 +6,8 @@ on:
 
 jobs:
   copilot-dco:
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
## Security Fix

Adds an explicit `permissions:` block to the `copilot-dco` job so the reusable DCO workflow receives only the token scopes it needs:

- `contents: read`
- `pull-requests: write` (to comment on PRs)
- `statuses: write` (to set the DCO status check)

Without this block, the caller inherits the repository default `GITHUB_TOKEN` scope, which may be broader than needed. This fix follows the principle of least privilege recommended by CodeQL rule `actions/missing-workflow-permissions` (CWE-275).

Fixes #6299
Addresses CodeQL alert [#93](https://github.com/kubestellar/docs/security/code-scanning/93).

---
*Filed by sec-check agent (ACMM L6 — full mode)*