### PR TITLE
[sec-check] fix: add least-privilege permissions to copilot-setup-steps workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml.disabled
+++ b/.github/workflows/copilot-setup-steps.yml.disabled
@@ -4,6 +4,9 @@ name: Copilot Setup Steps
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #6299