### PR TITLE
[scanner] fix: repair broken links (docs#6303)

### DIFF
--- a/docs/content/hive/agent-configuration.md
+++ b/docs/content/hive/agent-configuration.md
@@ -252,8 +252,8 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 
 ## What to read next
 
-- **[Introduction](/docs/hive/overview/intro)** — what hive is, setup, and the command surface.
-- **[Architecture](/docs/hive/architecture)** — the two scheduling models and how the supervisor drives agents.
-- **[macOS Setup](/docs/hive/macos)** — run a hive locally.
-- **[Troubleshooting](/docs/hive/troubleshooting)** — stuck sessions, login expiry, restart loops.
+- **[Introduction](overview/intro.md)** — what hive is, setup, and the command surface.
+- **[Architecture](architecture.md)** — the two scheduling models and how the supervisor drives agents.
+- **[macOS Setup](macos.md)** — run a hive locally.
+- **[Troubleshooting](troubleshooting.md)** — stuck sessions, login expiry, restart loops.
 - **[ACMM policy matrix](https://github.com/kubestellar/hive/blob/v2/v2/docs/acmm-policy-matrix.md)** — the full per-level, per-agent policy table in the hive repo.

--- a/docs/content/hive/console-starter-install.md
+++ b/docs/content/hive/console-starter-install.md
@@ -75,7 +75,7 @@ overlay instead:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubestellar/console/deploy/kustomize/overlays/starter?ref=main
+  - https://github.com/kubestellar/console/tree/main/deploy/kustomize/overlays/starter
 images:
   - name: ghcr.io/kubestellar/console
     newTag: v0.3.34-nightly.20260709   # or: weekly

--- a/docs/content/hive/security-model.md
+++ b/docs/content/hive/security-model.md
@@ -98,4 +98,4 @@ Security documentation that only lists strengths is marketing. The current, deli
 - **Cloud CLI credentials are shared with the CLI.** Claude/Copilot/Gemini/Goose agents necessarily run with the provider credential you connected. The placeholder-key isolation applies to inference-gateway keys.
 - **DCO is policy-driven** inside hive; enforce it repo-side (DCO check) for a hard guarantee.
 
-Found something? Security reports are welcome on the [hive repository](https://github.com/kubestellar/hive/issues) — or see the KubeStellar [security policy](/docs/contributing/security) for private disclosure contacts.
+Found something? Security reports are welcome on the [hive repository](https://github.com/kubestellar/hive/issues) — or see the KubeStellar [security policy](../contributing/security.md) for private disclosure contacts.

--- a/docs/content/multi-plugin/getting-started.md
+++ b/docs/content/multi-plugin/getting-started.md
@@ -27,10 +27,10 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
+- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](development_guide.md)** - Contributing and development workflow
 - **[API Reference](api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack

--- a/docs/content/multi-plugin/installation_guide.md
+++ b/docs/content/multi-plugin/installation_guide.md
@@ -204,4 +204,4 @@ make uninstall
 After successful installation:
 1. Read the [Usage Guide](usage_guide.md) for detailed examples
 2. Check the [Architecture Guide](architecture_guide.md) to understand how it works
-3. See [Development Guide](/docs/multi-plugin/development_guide) if you want to contribute
+3. See [Development Guide](development_guide.md) if you want to contribute

--- a/docs/content/multi-plugin/overview/introduction.md
+++ b/docs/content/multi-plugin/overview/introduction.md
@@ -27,10 +27,10 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
+- **[Installation Guide](../installation_guide.md)** - How to install and set up kubectl-multi
+- **[Usage Guide](../usage_guide.md)** - Detailed usage examples and commands
+- **[Architecture Guide](../architecture_guide.md)** - Technical architecture and how it works
+- **[Development Guide](../development_guide.md)** - Contributing and development workflow
 - **[API Reference](../api_reference.md)** - Code organization and technical implementation
 
 ## Tech Stack

--- a/docs/content/multi-plugin/usage_guide.md
+++ b/docs/content/multi-plugin/usage_guide.md
@@ -289,5 +289,5 @@ kubectl multi get --help
 ## Next Steps
 
 - Learn about the internal [Architecture](architecture_guide.md)
-- Contribute to development with the [Development Guide](/docs/multi-plugin/development_guide)
+- Contribute to development with the [Development Guide](development_guide.md)
 - Check the [API Reference](api_reference.md) for technical details


### PR DESCRIPTION
Fixes #6303

## Summary

Repairs all broken links detected in the link checker run [29231734556](https://github.com/kubestellar/docs/actions/runs/29231734556).

### External link fixed

- `docs/content/hive/console-starter-install.md`: Changed kustomize resource URL from `https://github.com/kubestellar/console/deploy/kustomize/overlays/starter?ref=main` (404) to `https://github.com/kubestellar/console/tree/main/deploy/kustomize/overlays/starter` (valid GitHub tree URL that kustomize also accepts)

### Internal links fixed (converted absolute → relative paths)

The broken internal links all used absolute `/docs/...` paths which the link checker could not resolve. Converted to relative links:

- `docs/content/hive/agent-configuration.md`: Fixed 4 links in "What to read next" section (`/docs/hive/overview/intro` → `overview/intro.md`, etc.)
- `docs/content/hive/security-model.md`: Fixed `/docs/contributing/security` → `../contributing/security.md`
- `docs/content/multi-plugin/getting-started.md`: Fixed 4 documentation links
- `docs/content/multi-plugin/installation_guide.md`: Fixed `/docs/multi-plugin/development_guide` → `development_guide.md`
- `docs/content/multi-plugin/overview/introduction.md`: Fixed 4 documentation links (with `../` prefix for subdirectory)
- `docs/content/multi-plugin/usage_guide.md`: Fixed `/docs/multi-plugin/development_guide` → `development_guide.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>