### PR TITLE
[scanner] fix: render embedded images instead of alt text (Fixes #6305)

### DIFF
--- a/src/__tests__/rewriteImagePaths.test.ts
+++ b/src/__tests__/rewriteImagePaths.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { rewriteRelativeImagePaths } from '@/lib/rewriteImagePaths'
+
+describe('rewriteRelativeImagePaths', () => {
+  it('rewrites a bare relative image path with a baseDir', () => {
+    const md = '![Main Dashboard](images/main-dashboard.png)'
+    expect(rewriteRelativeImagePaths(md, 'console')).toBe(
+      '![Main Dashboard](/docs-images/console/images/main-dashboard.png)'
+    )
+  })
+
+  it('rewrites a ./ relative image path', () => {
+    const md = '![Figure 1 - High Level Architecture](./images/high-level-architecture.svg)'
+    expect(rewriteRelativeImagePaths(md, 'kubestellar')).toBe(
+      '![Figure 1 - High Level Architecture](/docs-images/kubestellar/images/high-level-architecture.svg)'
+    )
+  })
+
+  it('rewrites multiple images in the same document', () => {
+    const md = [
+      '![Figure 1](./images/fig1.svg)',
+      'Some text in between.',
+      '![Figure 2](./images/fig2.svg)',
+    ].join('\n')
+    const result = rewriteRelativeImagePaths(md, 'kubestellar')
+    expect(result).toContain('/docs-images/kubestellar/images/fig1.svg')
+    expect(result).toContain('/docs-images/kubestellar/images/fig2.svg')
+  })
+
+  it('leaves absolute /docs-images paths untouched', () => {
+    const md = '![Foo](/docs-images/console/images/foo.png)'
+    expect(rewriteRelativeImagePaths(md, 'console')).toBe(md)
+  })
+
+  it('leaves https:// URLs untouched', () => {
+    const md = '![Ext](https://example.com/img.png)'
+    expect(rewriteRelativeImagePaths(md, 'console')).toBe(md)
+  })
+
+  it('leaves http:// URLs untouched', () => {
+    const md = '![Ext](http://example.com/img.png)'
+    expect(rewriteRelativeImagePaths(md, 'console')).toBe(md)
+  })
+
+  it('leaves data: URIs untouched', () => {
+    const md = '![Inline](data:image/png;base64,abc123)'
+    expect(rewriteRelativeImagePaths(md, 'console')).toBe(md)
+  })
+
+  it('leaves anchor-only hrefs untouched', () => {
+    const md = '![link](#section)'
+    expect(rewriteRelativeImagePaths(md, 'console')).toBe(md)
+  })
+
+  it('works with an empty baseDir (file at docs/content root)', () => {
+    const md = '![Logo](images/logo.png)'
+    expect(rewriteRelativeImagePaths(md, '')).toBe(
+      '![Logo](/docs-images/images/logo.png)'
+    )
+  })
+
+  it('handles subdirectory filePath in baseDir', () => {
+    const md = '![Diagram](diagrams/overview.svg)'
+    expect(rewriteRelativeImagePaths(md, 'kubestellar/setup')).toBe(
+      '![Diagram](/docs-images/kubestellar/setup/diagrams/overview.svg)'
+    )
+  })
+
+  it('does not double-rewrite already-absolute paths on a second pass', () => {
+    const md = '![Foo](images/foo.png)'
+    const once = rewriteRelativeImagePaths(md, 'console')
+    const twice = rewriteRelativeImagePaths(once, 'console')
+    expect(twice).toBe(once)
+  })
+})

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { evaluate } from 'nextra/evaluate'
 import { useMDXComponents as getMDXComponents } from '../../../../mdx-components'
 import { convertHtmlScriptsToJsxComments } from '@/lib/transformMdx'
 import { sanitizeHtmlForMdx, removeCommentPatterns } from '@/lib/sanitizeHtml'
+import { rewriteRelativeImagePaths } from '@/lib/rewriteImagePaths'
 import { buildPageMap, docsContentPath, getContentPath } from '../page-map'
 import { CURRENT_VERSION, type ProjectId } from '@/config/versions'
 import fs from 'fs'
@@ -130,6 +131,28 @@ async function getPageContent(slug: string[], projectId?: ProjectId): Promise<Pa
   return null
 }
 
+// Rewrite relative image paths in Markdown content to absolute /docs-images/ API paths.
+// Relative paths like `images/foo.png` or `./images/foo.png` fail to load when served
+// from a docs route because the browser resolves them against the page URL instead of
+// the filesystem location of the source file.  The /docs-images/* rewrite rule
+// (next.config.ts) proxies `/docs-images/<path>` → `/api/docs-image/<path>` which
+// serves files from docs/content/.  We compute the directory of the source file
+// relative to docs/content/ and use it as the base for the rewritten URL.
+function rewriteImagePaths(content: string, filePath: string, projectId: ProjectId | undefined): string {
+  // The content root for this project (e.g. docs/content/console for projectId='console').
+  const contentRoot = projectId ? getContentPath(projectId) : docsContentPath
+
+  // Prefix from docs/content/ to the content root (e.g. 'console', 'a2a', or '').
+  const contentPrefix = path.relative(docsContentPath, contentRoot).replace(/\\/g, '/')
+
+  // Directory of the source file, relative to docs/content/.
+  const fullRelPath = contentPrefix ? `${contentPrefix}/${filePath}` : filePath
+  const fileDir = path.posix.dirname(fullRelPath)
+  const baseDir = fileDir === '.' ? '' : fileDir
+
+  return rewriteRelativeImagePaths(content, baseDir)
+}
+
 async function buildContent(slug: string[], projectId?: ProjectId): Promise<PageContent | null> {
   const page = await getPageContent(slug, projectId)
 
@@ -137,6 +160,7 @@ async function buildContent(slug: string[], projectId?: ProjectId): Promise<Page
 
   let content = page.content
   content = replaceTemplateVariables(content)
+  content = rewriteImagePaths(content, page.filePath, projectId)
   content = removeCommentPatterns(content)
   content = sanitizeHtmlForMdx(content)
 

--- a/src/lib/rewriteImagePaths.ts
+++ b/src/lib/rewriteImagePaths.ts
@@ -1,0 +1,34 @@
+/**
+ * Rewrites relative image paths in Markdown content to absolute /docs-images/ API paths.
+ *
+ * Relative paths like `images/foo.png` or `./images/foo.png` fail to load when the page
+ * is served from a docs route because the browser resolves them against the page URL
+ * instead of the filesystem location of the source file.  The /docs-images/* rewrite
+ * rule in next.config.ts proxies these requests to /api/docs-image/* which serves
+ * static assets from docs/content/.
+ *
+ * @param content  Raw Markdown/MDX source string.
+ * @param baseDir  Directory of the source file relative to docs/content/ (e.g. "console"
+ *                 or "kubestellar").  Pass an empty string when the file lives directly
+ *                 under docs/content/.
+ */
+export function rewriteRelativeImagePaths(content: string, baseDir: string): string {
+  return content.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    (match, alt: string, src: string) => {
+      const trimmed = src.trim()
+      // Leave absolute URLs, absolute paths, data URIs, and anchor-only refs unchanged.
+      if (
+        trimmed.startsWith('/') ||
+        /^https?:\/\//.test(trimmed) ||
+        trimmed.startsWith('data:') ||
+        trimmed.startsWith('#')
+      ) {
+        return match
+      }
+      const normalised = trimmed.replace(/^\.\//, '')
+      const apiPath = baseDir ? `/docs-images/${baseDir}/${normalised}` : `/docs-images/${normalised}`
+      return `![${alt}](${apiPath})`
+    }
+  )
+}


### PR DESCRIPTION
Fixes #6305

## Root Cause

Markdown files in `docs/content` use relative image paths (e.g. `images/main-dashboard.png` or `./images/high-level-architecture.svg`). When Next.js serves a docs page at `/docs/console/readme`, the browser resolves those relative refs against the **page URL**, producing paths like `/docs/console/readme/images/main-dashboard.png` — which do not exist. The image fails to load and only the alt text is rendered.

The `/docs-images/*` → `/api/docs-image/*` rewrite rule in `next.config.ts` already exists to serve `docs/content/` assets, but image `src` values were never rewritten to use it.

## Fix

Added `rewriteRelativeImagePaths()` in `src/lib/rewriteImagePaths.ts` that converts relative Markdown image references to absolute `/docs-images/<baseDir>/<src>` paths before MDX compilation. Called from `buildContent()` in the docs `[...slug]` page after template-variable substitution.

**Affected pages from the issue:**
- `/docs/console/readme` — `images/main-dashboard.png`
- `/docs/overview/architecture` — `./images/high-level-architecture.svg`, `./images/main-modules.svg`, `./images/binding-controller.svg`

## Tests

Added `src/__tests__/rewriteImagePaths.test.ts` with 10 unit tests covering bare relative paths, `./`-prefixed paths, multiple images in one document, absolute URLs, `https://` URLs, `data:` URIs, anchor refs, empty baseDir, subdirectory baseDirs, and idempotency (no double-rewrite).