### PR TITLE
🐛 fix: kill white border on 404 page when CSS bundle is unavailable

### DIFF
--- a/src/components/NotFoundUI.tsx
+++ b/src/components/NotFoundUI.tsx
@@ -159,6 +159,12 @@ export default function NotFoundUI() {
 
   return (
     <div style={styles.page}>
+      {/* Inline styles can't reach <html>/<body>. When the hashed CSS bundle
+          is unavailable (the exact scenario this page is built for), there is
+          no Tailwind preflight, so the UA default body margin (8px) shows as
+          a white border around the dark page. This inline <style> ships with
+          the markup and cannot fail to load. */}
+      <style>{`html,body{margin:0;padding:0;background:${SPACE_DARK}}`}</style>
       <header style={styles.header}>
         <Link href="/" style={styles.brand}>
           <BrandMark />


### PR DESCRIPTION
The 404 page is inline-styled precisely so it renders correctly when the previous deploy's hashed CSS bundle 404s — but inline styles can't reach `<html>`/`<body>`. With no stylesheet there's no Tailwind preflight, so the UA default `body { margin: 8px }` insets the dark page and shows a white border all the way around (report: kubestellar.io `/docs/this-page-does-not-exist-999`, Safari dark mode).

Fix: an inline `<style>` tag shipped with the component markup — `html,body{margin:0;padding:0;background:#0a0a0a}` — which cannot fail to load, matching the page's existing self-containment philosophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)