### PR TITLE
🌱 fix: add minimal top-level permissions block to copilot-dco.yml (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   copilot-dco:
     permissions:


### PR DESCRIPTION
Fixes #6310

## Summary

Adds a top-level `permissions: contents: read` block to `.github/workflows/copilot-dco.yml`.

The workflow already had job-level permissions (`contents: read`, `pull-requests: write`, `statuses: write`) but was missing the top-level block that OpenSSF Scorecard Token-Permissions check requires. Without a top-level `permissions:` block, the workflow-level default scope could allow elevated access if new jobs are added.

The other 9 workflows flagged in the issue already have top-level permissions blocks (fixed by prior commits).

## Change

- `.github/workflows/copilot-dco.yml`: Added `permissions: contents: read` at workflow top-level (default); job-level permissions remain unchanged for the specific elevated scopes needed by the DCO check.

## Security Impact

Closes the remaining Scorecard Token-Permissions alert (#233/#232). The next scheduled Scorecard run will auto-close these alerts once merged.