### PR TITLE
🌱 fix: pin click to >=8.3.3 in cluster-objects/requirements

### DIFF
--- a/cluster-objects/requirements.in
+++ b/cluster-objects/requirements.in
@@ -1,2 +1,3 @@
 cryptography>=48.0.1
+click>=8.3.3
 oci-cli==3.86.0

--- a/cluster-objects/requirements.txt
+++ b/cluster-objects/requirements.txt
@@ -104,9 +104,8 @@ circuitbreaker==2.1.3 \
     --hash=sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084 \
     --hash=sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1
     # via oci
-click==8.1.2 \
-    --hash=sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e \
-    --hash=sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72
+click==8.3.3 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via oci-cli
 crc32c==2.7.1 \
     --hash=sha256:03a92551a343702629af91f78d205801219692b6909f8fa126b830e332bfb0e0 \


### PR DESCRIPTION
Fixes #6309

Upgrades click from vulnerable version 8.1.2 to 8.3.3 to address PYSEC-2026-2132. This is a security vulnerability affecting CLI entry point input handling.

Changes:
- Added explicit constraint `click>=8.3.3` to `requirements.in`
- Updated `requirements.txt` with the patched version and correct hash