### PR TITLE
[scanner] fix: broken documentation links #6334 #6335

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -187,14 +187,14 @@ export default function Footer() {
                   </Link>
                 </li>
                 <li>
-                  <Link
-                    href={getLocalizedUrl(
-                      "https://kubestellar.io/docs/kubestellar/release-notes"
-                    )}
+                  <a
+                    href="https://github.com/kubestellar/kubestellar/releases"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-gray-400 hover:text-white transition-colors duration-200 text-xs sm:text-sm inline-block"
                   >
                     {t("releasesNotes")}
-                  </Link>
+                  </a>
                 </li>
               </ul>
             </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -596,7 +596,7 @@ export default function Navbar() {
                     </span>
                   </a>
                   <a
-                    href="https://github.com/kubestellar/console/watchers"
+                    href="https://github.com/kubestellar/console/stargazers"
                     className="flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-emerald-900/30 rounded transition-all duration-200 hover:text-emerald-300 hover:shadow-md"
                   >
                     <svg
@@ -1082,7 +1082,7 @@ export default function Navbar() {
 
                   {/* Watchers */}
                   <a
-                    href="https://github.com/kubestellar/console/watchers"
+                    href="https://github.com/kubestellar/console/stargazers"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center justify-between px-3 py-2 rounded-lg  max-w-xs"


### PR DESCRIPTION
Fixes #6334
Fixes #6335

This PR fixes two broken links in the documentation:

- **Issue #6334**: Broken link `https://kubestellar.io/docs/kubestellar/release-notes` → Replaced with `https://github.com/kubestellar/kubestellar/releases` (GitHub releases page)
- **Issue #6335**: Broken link `https://github.com/kubestellar/console/watchers` → Replaced with `https://github.com/kubestellar/console/stargazers`

## Changes
- `src/components/Footer.tsx`: Updated the release notes link to point to GitHub releases
- `src/components/Navbar.tsx`: Updated the console watchers link to stargazers (GitHub removed /watchers endpoint)

Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>