### PR TITLE
[scanner] chore(security): add explicit top-level permissions to workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,12 +13,14 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,10 +11,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +19,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/generate-acmm-history.yml
+++ b/.github/workflows/generate-acmm-history.yml
@@ -6,7 +6,8 @@ on:
     - cron: '0 2 * * 0,1,3,5'
   workflow_dispatch: {}
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   generate:

--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -6,7 +6,8 @@ on:
     # Run every Monday at 12:00 PM Eastern (17:00 UTC)
     - cron: "0 17 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   audit-all:

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -67,7 +67,8 @@ name: "technical-doc-writer"
         description: Issue number to process
         required: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"


### PR DESCRIPTION
Fixes #6330

- Set top-level permissions to `contents: read` for all workflows
- Move write-scoped permissions (contents, issues, pull-requests, statuses, actions) to job level only
- Applies principle of least privilege to GITHUB_TOKEN exposure

This addresses the OpenSSF Scorecard Token-Permissions cluster of security alerts.