### PR TITLE
[scanner] fix(security): add Token-Permissions to workflows

### DIFF
--- a/.github/workflows/generate-acmm-history.yml
+++ b/.github/workflows/generate-acmm-history.yml
@@ -12,10 +12,9 @@ permissions:
 jobs:
   generate:
     permissions:
-      # contents:write required to commit ACMM history data
-      contents: write
-      # issues:write required to create failure tracking issues
-      issues: write
+      # App token used for all write operations; GITHUB_TOKEN only needs read
+      contents: read
+      issues: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/sync-console-release-versions.yml
+++ b/.github/workflows/sync-console-release-versions.yml
@@ -11,9 +11,9 @@ permissions: read-all  # default read; writes scoped to job below
 jobs:
   sync-console-releases:
     permissions:
-      # Required: creates version branches and PRs to sync console release metadata
-      contents: write
-      pull-requests: write
+      # WORKFLOW_SYNC_TOKEN used for all write operations; GITHUB_TOKEN only needs read
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}


### PR DESCRIPTION
Fixes #6339

Reduces job-level GITHUB_TOKEN permissions for workflows that use custom tokens for their write operations. These workflows use app-token or WORKFLOW_SYNC_TOKEN for pushes/commits, so the default GITHUB_TOKEN only needs read scope.

Workflows updated:
- generate-acmm-history.yml
- sync-console-release-versions.yml