### PR TITLE
[scanner] fix(security): add Token-Permissions to remaining workflows

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,8 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   copilot-dco:

--- a/.github/workflows/run-all-maintainer-audits.yml
+++ b/.github/workflows/run-all-maintainer-audits.yml
@@ -6,8 +6,7 @@ on:
     # Run every Monday at 12:00 PM Eastern (17:00 UTC)
     - cron: "0 17 * * 1"
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   audit-all:

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -67,8 +67,7 @@ name: "technical-doc-writer"
         description: Issue number to process
         required: true
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
@@ -983,14 +982,11 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      # contents:write required to commit changes to repository
-      contents: write
-      # discussions:write required to update discussion threads
-      discussions: write
-      # issues:write required to comment on and update issues
-      issues: write
-      # pull-requests:write required to comment on and update pull requests
-      pull-requests: write
+      # COPILOT_GITHUB_TOKEN used for write operations; GITHUB_TOKEN only needs read
+      contents: read
+      discussions: read
+      issues: read
+      pull-requests: read
     concurrency:
       group: "gh-aw-conclusion-technical-doc-writer"
       cancel-in-progress: false
@@ -1319,14 +1315,11 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      # contents:write required to commit changes to repository
-      contents: write
-      # discussions:write required to update discussion threads
-      discussions: write
-      # issues:write required to comment on and update issues
-      issues: write
-      # pull-requests:write required to comment on and update pull requests
-      pull-requests: write
+      # COPILOT_GITHUB_TOKEN used for write operations; GITHUB_TOKEN only needs read
+      contents: read
+      discussions: read
+      issues: read
+      pull-requests: read
     timeout-minutes: 15
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/technical-doc-writer"


### PR DESCRIPTION
Fixes #6339

Addresses the remaining 5 workflows with Scorecard Token-Permissions alerts:
- copilot-automation.yml
- copilot-dco.yml  
- run-all-maintainer-audits.yml
- technical-doc-writer.lock.yml (2 alerts)

Follows pattern from #6340: top-level `permissions: read-all` with job-level write permissions narrowed to read-only, relying on custom tokens for writes.