### PR TITLE
fix: update pr-verifier workflow to fix broken reusable reference

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -7,8 +7,42 @@ on:
 permissions:
   checks: write
   pull-requests: read
+  packages: read
 
 jobs:
-  verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit
+  verify-pr:
+    name: verify PR contents
+    # Skip verification for dependabot PRs - they use different title conventions
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      checks: write
+      pull-requests: read
+      packages: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull verifier image
+        run: docker pull ghcr.io/kubestellar/pr-verifier:v0.4.3
+
+      - name: Verifier action
+        id: verifier
+        continue-on-error: true
+        run: |
+          docker run --rm \
+            -e INPUT_GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -e GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
+            -e GITHUB_EVENT_PATH="/github/event.json" \
+            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
+            -e GITHUB_SHA="$GITHUB_SHA" \
+            -e GITHUB_REF="$GITHUB_REF" \
+            -e GITHUB_WORKSPACE="/github/workspace" \
+            -v "$GITHUB_EVENT_PATH:/github/event.json:ro" \
+            -v "$GITHUB_WORKSPACE:/github/workspace:ro" \
+            ghcr.io/kubestellar/pr-verifier:v0.4.3


### PR DESCRIPTION
Fixes #6336

## Summary
- Inline the PR verifier job that was previously provided by the deleted `kubestellar/infra/.github/workflows/reusable-pr-verifier.yml` reusable workflow.
- Add the required `packages: read` permission so the job can pull `ghcr.io/kubestellar/pr-verifier:v0.4.3`.

## Why
The reusable workflow was removed from `kubestellar/infra`, so the docs workflow would fail when triggered because its `uses:` target no longer exists.