### PR TITLE
docs(hive): add Governor and Variable Substitution reference pages

### DIFF
--- a/docs/content/hive/acmm-policy-matrix.md
+++ b/docs/content/hive/acmm-policy-matrix.md
@@ -1,0 +1,109 @@
+# ACMM Policy Matrix
+
+## Policy Modes
+
+Each agent runs in one of four modes, controlling what actions it can take on GitHub.
+
+| Mode | Suffix | Beads | Issues | PRs | Merge | GH Auth |
+|------|--------|-------|--------|-----|-------|---------|
+| **Advisory** | `-advisory.md` | Yes | No | No | No | No |
+| **Measured** | `-measured.md` | Yes | Yes | No | No | Yes |
+| **Holdgated** | `-holdgated.md` | Yes | Yes | Yes + `hold` label | No | Yes |
+| **Full** | `-full.md` | Yes | Yes | Yes | Yes (auto on green CI) | Yes |
+
+- **Advisory**: Agent observes and records findings as beads on the dashboard. No GitHub interaction.
+- **Measured**: Agent can file GitHub issues to make findings visible to the team. No code changes.
+- **Holdgated**: Agent can write code and open PRs, but every PR gets a `hold` label. A human must review and remove `hold` before merge. Agent never merges.
+- **Full**: Agent operates autonomously — opens PRs and merges on green CI. Highest trust level.
+
+## ACMM Levels
+
+### L1 — Assisted (2 agents)
+
+A single interactive advisor helps with repo setup and architecture decisions. Guide agent makes advisory beads. Brainstorm agent handles project inception — turning raw ideas into structured KB facts and scaffold. No feedback loops.
+
+| Agent | Mode | Template |
+|-------|------|----------|
+| guide | advisory | `guide-advisory.md` |
+| brainstorm | advisory | `brainstorm-inception.md` |
+
+### L2 — Instructed (5 agents)
+
+Agents observe and report findings as advisory beads on the dashboard and tracking issue. No GitHub issues or PRs created. Humans decide what to act on.
+
+| Agent | Mode | Template |
+|-------|------|----------|
+| supervisor | advisory | `supervisor-advisory.md` |
+| scanner | advisory | `scanner-advisory.md` |
+| quality | advisory | `quality-advisory.md` |
+| guide | advisory | `guide-advisory.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
+
+### L3 — Measured (6 agents)
+
+Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI workflows. All other agents remain advisory. CI-maintainer joins to monitor build health. Key artifact: measurement infrastructure.
+
+| Agent | Mode | Template |
+|-------|------|----------|
+| supervisor | advisory | `supervisor-advisory.md` |
+| scanner | advisory | `scanner-advisory.md` |
+| ci-maintainer | advisory | `ci-maintainer-advisory.md` |
+| **quality** | **holdgated** | `quality-holdgated.md` |
+| guide | advisory | `guide-advisory.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
+
+### L4 — Adaptive (7 agents)
+
+All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins. Closed-loop feedback: agents act on their own findings.
+
+| Agent | Mode | Template |
+|-------|------|----------|
+| supervisor | advisory | `supervisor-advisory.md` |
+| scanner | measured | `scanner-issues.md` |
+| ci-maintainer | holdgated | `ci-maintainer-holdgated.md` |
+| **quality** | **holdgated** | `quality-holdgated.md` |
+| guide | measured | `guide-issues.md` |
+| **sec-check** | **holdgated** | `sec-check-holdgated.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
+
+### L5 — Semi-Automated (9 agents)
+
+Agents open issues AND pull requests. All PRs get a hold label — humans batch-review and approve. Architect produces RFCs, strategist coordinates across agents. The system proposes; it does not merge autonomously.
+
+| Agent | Mode | Template |
+|-------|------|----------|
+| supervisor | advisory | `supervisor-advisory.md` |
+| scanner | holdgated | `scanner-holdgated.md` |
+| ci-maintainer | holdgated | `ci-maintainer-holdgated.md` |
+| quality | holdgated | `quality-holdgated.md` |
+| guide | holdgated | `guide-holdgated.md` |
+| sec-check | holdgated | `sec-check-holdgated.md` |
+| architect | holdgated | `architect-holdgated.md` |
+| strategist | holdgated | `strategist-holdgated.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
+
+### L6 — Fully Autonomous (10 agents)
+
+Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outreach agent handles community engagement (highest trust — external-facing). Governor at fastest cadence.
+
+| Agent | Mode | Template |
+|-------|------|----------|
+| supervisor | advisory | `supervisor-advisory.md` |
+| scanner | full | `scanner-automerge.md` |
+| ci-maintainer | full | `ci-maintainer-full.md` |
+| quality | full | `quality-full.md` |
+| guide | full | `guide-full.md` |
+| sec-check | full | `sec-check-full.md` |
+| architect | full | `architect-full.md` |
+| strategist | full | `strategist-full.md` |
+| outreach | full | `outreach-full.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
+
+## Key Rules
+
+1. **All PRs are holdgated below L6.** No agent can auto-merge unless running at L6 (Fully Autonomous).
+2. **Advisory agents never get GH auth.** The `${GH_AUTH}` template variable is only injected into measured, holdgated, and full templates.
+3. **Supervisor uses advisory mode.** At every level, supervisor uses `supervisor-advisory.md` — it monitors agent health, not code.
+4. **Mode escalation is per-agent.** At L4, some agents are measured (issues only) while others are holdgated (issues + PRs). The level defines the mix.
+5. **Knowledge priming works at all levels.** The `${KNOWLEDGE}` template variable injects relevant facts from git sources and wiki layers regardless of the agent's mode.
+6. **Brainstorm is always advisory.** It produces KB facts and beads, never GitHub issues or PRs. Its role evolves from inception (L1) to ongoing ideation (L2+), but its mode stays advisory at all levels.

--- a/docs/content/hive/agent-configuration.md
+++ b/docs/content/hive/agent-configuration.md
@@ -172,7 +172,7 @@ Pin a model when reproducibility matters more than the governor's budget optimiz
 
 ## Cadences and the governor
 
-Agents don't schedule themselves. The **governor** evaluates the work queue every `eval_interval_s` (default 300s), computes a mode from queue depth — **idle → quiet → busy → surge** (default thresholds: quiet > 2, busy > 10, surge > 20; override with `threshold:`) — and kicks each agent on the cadence that mode assigns it:
+Agents don't schedule themselves. The **governor** evaluates the work queue every `eval_interval_s` (default 300s), computes a mode from queue depth — **idle → quiet → busy → surge** (default thresholds: quiet > 2, busy > 10, surge > 20; override with `threshold:`) — and kicks each agent on the cadence that mode assigns it. For the full reference — the evaluation cycle, the budget system, and tuning — see [Governor](governor.md).
 
 ```yaml
 governor:
@@ -226,7 +226,7 @@ At L5, every agent PR gets a `hold` label automatically. The system proposes; it
 
 ## Kick templates: what an agent is told to do
 
-`kick_template` names a Markdown file resolved from the hive's policies checkout (`/data/policies/examples/kubestellar/agents/`, or the directory your `policies:` config points at), falling back to the defaults embedded in the binary (`v2/pkg/policies/defaults/`). It is the agent's **periodic work prompt**: on every kick, the template is loaded, variables like `${ISSUE_LIST}`, `${PR_LIST}`, `${AGENT_NAME}`, `${PROJECT_ORG}`, and `${KNOWLEDGE}` are substituted, and the result is dispatched to the agent's session.
+`kick_template` names a Markdown file resolved from the hive's policies checkout (`/data/policies/examples/kubestellar/agents/`, or the directory your `policies:` config points at), falling back to the defaults embedded in the binary (`v2/pkg/policies/defaults/`). It is the agent's **periodic work prompt**: on every kick, the template is loaded, variables like `${ISSUE_LIST}`, `${PR_LIST}`, `${AGENT_NAME}`, `${PROJECT_ORG}`, and `${KNOWLEDGE}` are substituted, and the result is dispatched to the agent's session. For the full list of template variables and how to define your own, see [Variable Substitution](variable-substitution.md).
 
 Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM pack's template for that agent at the current level; otherwise convention — `/data/agents/<name>/CLAUDE.md`, then `<name>.md` in the policies checkout, then the embedded default. Pack templates carry the level's policy in their names — `scanner-holdgated.md` is scanner-at-L5; the same scanner at L6 gets `scanner-automerge.md`.
 

--- a/docs/content/hive/governor.md
+++ b/docs/content/hive/governor.md
@@ -1,0 +1,142 @@
+# Governor
+
+**The governor is hive's scheduler. It watches the GitHub work queue and decides, on a fixed interval, which agents to kick and how often — running agents harder when there is more work and easing off when the queue is quiet.**
+
+Agents do not schedule themselves. Every enabled agent is driven by the governor: on each evaluation cycle the governor measures the queue, picks a mode, and kicks each agent on the cadence that mode assigns it. This page is the full reference. For the agent-side view — cadence syntax in an agent's own config — see [Agent Configuration](agent-configuration.md#cadences-and-the-governor).
+
+---
+
+## The evaluation cycle
+
+Once per `eval_interval_s` (default **300** seconds), the governor:
+
+1. Enumerates actionable GitHub work across `project.repos` — open issues, open PRs, held items, and SLA violations.
+2. Refreshes the token budget from lifetime usage and fires any budget alerts.
+3. Computes a **mode** from the actionable-issue count.
+4. For each enabled, non-`on_demand` agent, checks whether its per-mode cadence has elapsed since its last kick, and kicks it if so.
+
+The cycle runs continuously as one of the container's processes. Changing `eval_interval_s` at runtime (including via an ACMM pack apply) takes effect on the next tick — the ticker resets itself. The valid range is **10–86400** seconds.
+
+> **Note:** mode is driven by the **actionable-issue count only**. Open PRs, held items, and SLA violations are recorded and shown on the dashboard, but they do not change the mode.
+
+---
+
+## Modes and thresholds
+
+The governor has four modes. Queue depth (actionable issues) selects the highest mode whose threshold it exceeds:
+
+| Mode | Default threshold | Meaning |
+|---|---|---|
+| `surge` | depth > 20 | queue is deep — kick agents most aggressively |
+| `busy` | depth > 10 | steady workload |
+| `quiet` | depth > 2 | light workload |
+| `idle` | depth ≤ 2 | little or no work; slowest cadences |
+
+Thresholds are overridable per mode. A threshold left unset (or set to `0`) falls back to its built-in default, so an unset value never accidentally makes the queue surge:
+
+```yaml
+governor:
+  eval_interval_s: 300
+  modes:
+    busy:
+      threshold: 16        # queue depth that activates this mode
+      supervisor: 5m       # per-agent kick interval in this mode
+      scanner: 15m
+      ci-maintainer: 1h
+      architect: pause     # suspend kicks for this agent in this mode
+```
+
+---
+
+## Per-mode, per-agent cadences
+
+Inside each mode block, every entry other than `threshold` is a **cadence** for one agent: `agent-name: duration`. The duration is anything Go's duration parser accepts — `5m`, `30m`, `2h`, `4h`.
+
+- An agent listed under a mode is kicked on that interval while the hive is in that mode.
+- An agent with no entry for the current mode is not kicked in that mode.
+- Cadences are independent per mode, so an agent can be busy in `surge` and slow in `idle`.
+
+An agent is **due** for a kick when the time since its last kick is at least its cadence interval. At startup every eligible agent is kicked once so the hive doesn't idle waiting out a full cadence.
+
+### Pausing an agent in a mode
+
+The value `pause` (or `paused`) suspends kicks for that agent **in that mode only**:
+
+```yaml
+governor:
+  modes:
+    surge:
+      architect: pause     # don't kick architect while the queue is deep
+```
+
+> **Note:** `pause` here only stops governor kicks. It is not a process pause and it does not disable the agent — the agent stays running and can still be triggered by other means. To keep an agent configured but off entirely, use `enabled: false` in the agent's config.
+
+---
+
+## On-demand agents
+
+An agent with `on_demand: true` is skipped by the governor timer completely. It runs only when something triggers it explicitly — for example, the inception workflow drives the `brainstorm` agent this way. On-demand agents never appear in a mode's cadence list. See the agent `channels:` block in [Agent Configuration](agent-configuration.md#declarative-extensions) for the other non-timer trigger types (webhook, schedule, bead).
+
+---
+
+## The budget system
+
+The governor enforces a rolling **token budget** so a hive cannot run up unbounded API cost. It is off by default.
+
+```yaml
+governor:
+  budget:
+    total_tokens: 50000000   # 0 (the default) disables budgeting entirely
+    period_days: 7
+    critical_pct: 90
+```
+
+- **Window.** Spend accrues over a rolling 7-day window. When the window rolls over, spend re-baselines and the one-shot alerts reset.
+- **Warn.** At 90% of the limit the governor emits a one-time warning for the window.
+- **Exhaustion.** At 100%, kicks are suppressed hive-wide until the window rolls over — the queue keeps filling, but agents stop being kicked.
+
+| Signal | Threshold | Effect |
+|---|---|---|
+| warn | 90% of limit | one-time warning alert |
+| exhausted | 100% of limit | kicks suppressed for all non-exempt agents |
+| rollover | window elapses | spend re-baselines, alerts reset |
+
+Two escape hatches keep critical agents running under exhaustion:
+
+- **Ignored agents** — a per-agent exemption. Exempt agents keep getting kicked even when the budget is exhausted.
+- **Ignore-all** — a global toggle that opens the kick gate for everyone while keeping the limit, window, and alerts intact (useful for a temporary override without discarding budget tracking).
+
+The budget also interacts with model selection: for an **unpinned** agent, the governor may auto-select a cheaper model as spend grows. Pin the model to opt out — see [model pinning](agent-configuration.md#model-pinning-and-auto-switching).
+
+---
+
+## ACMM pack integration
+
+You rarely hand-write the `governor:` block. The six [ACMM packs](acmm-policy-matrix.md) ship governor tuning alongside their agent rosters, and the tuning tightens as the level rises:
+
+| Level | `eval_interval_s` | Posture |
+|---|---|---|
+| L1 | 600 | advisory only — `quiet`/`idle` cadences, no surge |
+| L3 | 300 | full four modes, hold-gated PRs |
+| L6 | 120 | fastest cadences, lowest thresholds, auto-merge |
+
+Applying a level reconciles the governor config: a fresh apply or level change writes the pack's `eval_interval_s`, thresholds, and cadences; a merge onto an existing roster fills only the gaps, preserving your customizations. See the [ACMM Policy Matrix](acmm-policy-matrix.md) for the full per-level cadence table and the L5 worked example.
+
+---
+
+## Tuning guidance
+
+- **Keep `stale_timeout` above the longest cadence.** An agent kicked every 4h with a 30-minute stale timeout looks dead between kicks. The shipped packs use "longest cadence × 2."
+- **Match cadence to repo velocity.** A hot repo may want `scanner: 15m`; a quiet one `4h`.
+- **Pause the noisy agent at depth.** If an agent adds churn exactly when the queue is deep, `pause` it in `surge` and let the workers drain the backlog.
+- **Adjust thresholds, not just cadences.** Lower the `surge` threshold to reach maximum cadence sooner on a busy project; raise it to hold steady longer.
+
+---
+
+## See also
+
+- [Agent Configuration](agent-configuration.md) — the agent-side config, including the cadence and kick-template fields the governor drives.
+- [ACMM Policy Matrix](acmm-policy-matrix.md) — per-level, per-agent policy and cadence tables.
+- [Variable Substitution](variable-substitution.md) — how kick prompts are built each cycle.
+- [Architecture](architecture.md) — where the governor sits among the container's processes.
+- [Troubleshooting](troubleshooting.md) — stuck sessions and agents that look dead between kicks.

--- a/docs/content/hive/variable-substitution.md
+++ b/docs/content/hive/variable-substitution.md
@@ -1,0 +1,162 @@
+# Variable Substitution
+
+**Hive substitutes `${VAR}` references in two different places: in `hive.yaml` at load time, and in an agent's kick prompt every time it is kicked. This page covers both, and how to add your own variables via config.**
+
+The two systems share the `${VAR}` syntax but are otherwise independent — people conflate them, so it helps to see them side by side first.
+
+| System | Where | Syntax | Resolved when | Example |
+|---|---|---|---|---|
+| Config interpolation | `hive.yaml` | `${ENV}` | at config load | `token: ${HIVE_GITHUB_TOKEN}` |
+| Kick-template variables | policy `.md` templates | `${VAR}` | on every kick | `${ISSUE_LIST}`, `${AGENT_NAME}` |
+
+---
+
+## Config `${VAR}` — environment interpolation
+
+When hive loads `hive.yaml`, it replaces `${VAR}` references with environment variables before parsing. This is how secrets and per-deployment endpoints get into the config without being written into it:
+
+```yaml
+github:
+  token: ${HIVE_GITHUB_TOKEN}
+notifications:
+  slack_webhook: ${SLACK_WEBHOOK_URL}
+```
+
+An **unset** variable is left as the literal text `${VAR}` — substitution never blanks a value it can't resolve. A variable that is set but empty resolves to the empty string.
+
+### The env-name-not-value rule
+
+This is the load-bearing security invariant of hive's config:
+
+> **Note:** `hive.yaml` stores only environment-variable *names* (`api_key_env`) and key-file *paths* (`api_key_file`) — never secret values. Because `Config.Save()` rewrites the whole file to disk, a literal secret in YAML would be persisted in plaintext, so the code refuses the pattern.
+
+Where the values actually live:
+
+- `/data/secrets/` — secrets entered through the dashboard (writable PVC).
+- `/secrets/` — secrets from Kubernetes Secret mounts (read-only).
+
+Inference backends follow the same rule: you configure a key *reference* (env var name or file path), and hive resolves it at runtime. See the [Security Model](security-model.md) for the full treatment.
+
+> **Note:** never inline a secret value in `hive.yaml`. Use `${ENV}` or a `*_env` / `*_file` reference.
+
+---
+
+## Kick-template variables
+
+An agent's [kick template](agent-configuration.md#kick-templates-what-an-agent-is-told-to-do) is its periodic work prompt. Every time the governor kicks the agent, hive loads the template, substitutes its variables from live runtime state, and dispatches the result to the agent's session. These variables are computed fresh on each kick — they are not environment variables.
+
+The most-used variables:
+
+| Variable | Injected value | Availability |
+|---|---|---|
+| `${AGENT_NAME}` | the agent's name | always |
+| `${AGENT_DISPLAY_NAME}` | the agent's dashboard label | always |
+| `${ISSUE_LIST}` | the open issues in this agent's lane | always |
+| `${PR_LIST}` | the open pull requests | always |
+| `${QUEUE_ISSUES}` / `${QUEUE_PRS}` / `${QUEUE_HOLD}` | current queue counts | always |
+| `${SLA_VIOLATIONS}` | count of aged issues | always |
+| `${KNOWLEDGE}` | relevant facts primed from git sources and the wiki | all levels |
+| `${GH_AUTH}` | GitHub auth instructions for the agent | measured, hold-gated, and full templates only |
+| `${PROJECT_ORG}` / `${PROJECT_NAME}` / `${PROJECT_PRIMARY_REPO}` / `${PROJECT_REPOS_LIST}` | project identity | always |
+| `${AUTHORIZED_REPOS}` | the repo list the agent may act on | always |
+| `${MERGE_ELIGIBLE}` / `${CI_FAILING}` | PRs ready to merge / with red CI | always |
+| `${TIMESTAMP}` | the current time | always |
+
+Additional variables cover the agent roster (`${AGENT_LIST}`, `${AGENT_ROLES}`, `${ENABLED_AGENTS}`) and the inception workflow (`${INCEPTION_IDEA}`, `${INCEPTION_PHASE}`, and related). See the [ACMM Policy Matrix](acmm-policy-matrix.md) for how variable availability tracks an agent's level.
+
+### Template resolution order
+
+Which template file a kick uses is resolved in order: the agent's explicit `kick_template` wins; otherwise the ACMM pack's template for that agent at the current level; otherwise convention (`/data/agents/<name>/CLAUDE.md`, then `<name>.md` in the policies checkout); otherwise the embedded default. This is covered in full under [Kick templates](agent-configuration.md#kick-templates-what-an-agent-is-told-to-do).
+
+---
+
+## Adding your own variables
+
+> **Note:** the `variables:` block is new. The `env` and `static` variable types described below are available now. The `script` and `http` types are being rolled out; treat their syntax here as the shape under implementation.
+
+You can define your own `${VAR}`s in a top-level `variables:` block in `hive.yaml`, without editing hive's code. A defined variable can be used in kick templates and — with the right scope — in the config itself.
+
+```yaml
+variables:
+  defs:
+    DEPLOY_ENV:
+      type: static
+      value: production
+      scope: both
+    REGION:
+      type: env
+      env: HIVE_REGION
+      default: us-east-1     # used only when HIVE_REGION is unset
+```
+
+Each definition has:
+
+- **`type`** — the resolver: `env`, `static`, `script`, or `http`.
+- **`scope`** — where the variable applies: `template` (default, per-kick prompts), `config` (`hive.yaml` load), or `both`.
+- **`default`** — a fallback used when the resolver would otherwise leave the variable unresolved (for `env`, when the variable is unset).
+
+Built-in kick-template variables (the table above) always take precedence over a custom variable of the same name, so you cannot accidentally shadow `${ISSUE_LIST}`.
+
+### `static` — a fixed value
+
+```yaml
+variables:
+  defs:
+    DEPLOY_ENV: { type: static, value: production, scope: both }
+```
+
+### `env` — an environment variable, with an optional default
+
+```yaml
+variables:
+  defs:
+    REGION: { type: env, env: HIVE_REGION, default: us-east-1 }
+```
+
+This also gives config interpolation the default-value behavior plain `${VAR}` never had.
+
+### `script` — the output of a command (preview)
+
+```yaml
+variables:
+  security:
+    allow_exec: true          # required; disabled by default
+    exec_timeout_s: 3
+  defs:
+    BUILD_SHA:
+      type: script
+      command: [git, rev-parse, --short, HEAD]   # argv, not a shell string
+      scope: template
+```
+
+### `http` — a value fetched from a web service (preview)
+
+```yaml
+variables:
+  security:
+    allow_http: true                          # required; disabled by default
+    http_allowlist: [vault.internal.example.com]
+  defs:
+    DB_HOST:
+      type: http
+      url: "https://vault.internal.example.com/v1/config/db-host"
+      headers: { Authorization: "Bearer ${HIVE_VAULT_TOKEN}" }
+      scope: config
+```
+
+### Security model for `script` and `http`
+
+Because a resolver can execute a command or reach the network, the `script` and `http` types are **disabled by default** and gated behind `variables.security.allow_exec` / `allow_http`.
+
+> **Note:** the `variables.security` block is honored only from the trusted config seed, never from the dashboard overlay. Because the overlay is user-writable, letting it enable execution would be a code-execution path — so an overlay can add `static`/`env` variables but can never turn on `script`/`http`.
+
+Additional guardrails: `script` runs an argv slice (never a shell string, so there is no shell injection) under a timeout, with a non-zero exit leaving the variable unresolved rather than failing the kick. `http` is GET-only, restricted to a host allowlist, blocks private/loopback addresses, caps the response size, and times out. An unresolvable custom variable, like any other, is left as its literal `${VAR}`.
+
+---
+
+## See also
+
+- [Agent Configuration](agent-configuration.md) — kick templates and the agent config surface.
+- [Governor](governor.md) — how kick prompts are built each cycle; budget-driven model selection is a related automatic substitution.
+- [Security Model](security-model.md) — the secret-handling and trust model in full.
+- [ACMM Policy Matrix](acmm-policy-matrix.md) — per-level template-variable availability.

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -341,6 +341,8 @@ const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
     title: 'Configuration',
     items: [
       { 'Agent Configuration': 'agent-configuration.md' },
+      { 'Governor': 'governor.md' },
+      { 'Variable Substitution': 'variable-substitution.md' },
     ]
   },
   {
@@ -352,6 +354,7 @@ const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
   {
     title: 'Reference',
     items: [
+      { 'ACMM Policy Matrix': 'acmm-policy-matrix.md' },
       { 'Outreach Anti-Spam': 'outreach-antispam.md' },
     ]
   }


### PR DESCRIPTION
## What

Adds two reference pages to the hive docs section, which documented agents but had no dedicated coverage of the **governor** or of hive's **`${VAR}` substitution** (both were only touched at overview depth inside `agent-configuration.md`).

- **`governor.md`** — the evaluation cycle (`eval_interval_s`), the four modes and their thresholds (idle/quiet/busy/surge), per-mode/per-agent cadences, pausing an agent in a mode (kick-suppress, not a process pause), on-demand agents, the token **budget** system (rolling window, warn/exhaust/rollover, ignored + ignore-all, unpinned-model down-select), ACMM pack integration, and tuning guidance.
- **`variable-substitution.md`** — the two `${VAR}` systems side by side: **config interpolation** in `hive.yaml` (the env-name-not-value secret rule + where values live) and **per-kick template variables** (with an availability table), plus **how to define your own variables** via a `variables:` block.

## Extensible variables

The "adding your own variables" section documents the new pluggable `variables:` block. `env` and `static` types are available now (kubestellar/hive #1898); `script` and `http` are marked as the shape under implementation, with the seed-only security model spelled out (the `variables.security` block is honored only from the trusted config seed, never the user-writable dashboard overlay).

## Also

- Copies `acmm-policy-matrix.md` into `docs/content/hive/` (it was cross-referenced but not present in the repo) and registers all three in `NAV_STRUCTURE_HIVE` — Governor + Variable Substitution under **Configuration**, ACMM Policy Matrix under **Reference**.
- Adds reciprocal links from `agent-configuration.md`'s governor and kick-template sections to the new deep-dive pages.

## Verification

- New pages follow the existing hive-page conventions (H1, no front-matter, blockquote callouts, fenced `yaml`/`shell`, GFM tables, no emojis).
- `page-map.ts` edit typechecks clean (no new `tsc` errors; the only repo-wide errors are pre-existing in `vitest.config.ts`).
- MDX hazard scan clean — no unescaped `<...>` outside code fences in either page.
- Routes resolve to `/docs/hive/configuration/governor`, `/docs/hive/configuration/variable-substitution`, `/docs/hive/reference/acmm-policy-matrix`.

Full Nextra build validation runs in CI (local build blocked by a missing `tsx`/eslint dev-dep in the workspace, unrelated to this change).