### PR TITLE
🐛 fix: remove .md extensions from internal documentation links

### DIFF
--- a/docs/content/multi-plugin/api_reference.md
+++ b/docs/content/multi-plugin/api_reference.md
@@ -435,4 +435,4 @@ func buildHeader(resourceType string, allNamespaces, showLabels bool) string {
 }
 ```
 
-This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](usage_guide.md), and for architectural details, see the [Architecture Guide](architecture_guide.md).
+This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](usage_guide), and for architectural details, see the [Architecture Guide](architecture_guide).

--- a/docs/content/multi-plugin/getting-started.md
+++ b/docs/content/multi-plugin/getting-started.md
@@ -27,11 +27,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](development_guide.md)** - Contributing and development workflow
-- **[API Reference](api_reference.md)** - Code organization and technical implementation
+- **[Installation Guide](installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](development_guide)** - Contributing and development workflow
+- **[API Reference](api_reference)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/installation_guide.md
+++ b/docs/content/multi-plugin/installation_guide.md
@@ -202,6 +202,6 @@ make uninstall
 ## Next Steps
 
 After successful installation:
-1. Read the [Usage Guide](usage_guide.md) for detailed examples
-2. Check the [Architecture Guide](architecture_guide.md) to understand how it works
-3. See [Development Guide](development_guide.md) if you want to contribute
+1. Read the [Usage Guide](usage_guide) for detailed examples
+2. Check the [Architecture Guide](architecture_guide) to understand how it works
+3. See [Development Guide](development_guide) if you want to contribute

--- a/docs/content/multi-plugin/overview.md
+++ b/docs/content/multi-plugin/overview.md
@@ -79,11 +79,11 @@ kubectl multi get pods -A
 
 Complete documentation for kubectl-multi:
 
-- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](development_guide.md)** - Contributing and development workflow
-- **[API Reference](api_reference.md)** - Code organization and technical implementation
+- **[Installation Guide](installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](development_guide)** - Contributing and development workflow
+- **[API Reference](api_reference)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/overview/introduction.md
+++ b/docs/content/multi-plugin/overview/introduction.md
@@ -27,11 +27,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](../installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](../usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](../architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](../development_guide.md)** - Contributing and development workflow
-- **[API Reference](../api_reference.md)** - Code organization and technical implementation
+- **[Installation Guide](../installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](../usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](../architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](../development_guide)** - Contributing and development workflow
+- **[API Reference](../api_reference)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/readme.md
+++ b/docs/content/multi-plugin/readme.md
@@ -77,11 +77,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](installation_guide.md)** - How to install and set up kubectl-multi
-- **[Usage Guide](usage_guide.md)** - Detailed usage examples and commands
-- **[Architecture Guide](architecture_guide.md)** - Technical architecture and how it works
-- **[Development Guide](development_guide.md)** - Contributing and development workflow
-- **[API Reference](api_reference.md)** - Code organization and technical implementation
+- **[Installation Guide](installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](development_guide)** - Contributing and development workflow
+- **[API Reference](api_reference)** - Code organization and technical implementation
 
 ## Tech Stack
 

--- a/docs/content/multi-plugin/reference.md
+++ b/docs/content/multi-plugin/reference.md
@@ -435,4 +435,4 @@ func buildHeader(resourceType string, allNamespaces, showLabels bool) string {
 }
 ```
 
-This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](usage_guide.md), and for architectural details, see the [Architecture Guide](architecture_guide.md).
+This API reference provides a comprehensive overview of the kubectl-multi codebase. For usage examples, see the [Usage Guide](usage_guide), and for architectural details, see the [Architecture Guide](architecture_guide).

--- a/docs/content/multi-plugin/usage_guide.md
+++ b/docs/content/multi-plugin/usage_guide.md
@@ -288,6 +288,6 @@ kubectl multi get --help
 
 ## Next Steps
 
-- Learn about the internal [Architecture](architecture_guide.md)
-- Contribute to development with the [Development Guide](development_guide.md)
-- Check the [API Reference](api_reference.md) for technical details
+- Learn about the internal [Architecture](architecture_guide)
+- Contribute to development with the [Development Guide](development_guide)
+- Check the [API Reference](api_reference) for technical details


### PR DESCRIPTION
Fixes #6358
Fixes #6359
Fixes #6360
Fixes #6361

## Summary
Fixed broken documentation links in the kubectl-multi section by removing `.md` extensions from internal markdown links. The link checker was detecting broken URLs to `https://kubestellar.io/development_guide` (etc.) because the markdown files contained links like `[Development Guide](development_guide.md)`. When rendered by Nextra, these were becoming `<a href="/development_guide.md">`, which don't match the actual page routes at `/docs/multi-plugin/development_guide`.

## Changes
Removed `.md` extensions from the following links across 8 markdown files:
- `installation_guide.md` → `installation_guide`
- `usage_guide.md` → `usage_guide`
- `architecture_guide.md` → `architecture_guide`
- `development_guide.md` → `development_guide`
- `api_reference.md` → `api_reference`

Files modified:
- `docs/content/multi-plugin/api_reference.md`
- `docs/content/multi-plugin/getting-started.md`
- `docs/content/multi-plugin/installation_guide.md`
- `docs/content/multi-plugin/usage_guide.md`
- `docs/content/multi-plugin/overview.md`
- `docs/content/multi-plugin/overview/introduction.md`
- `docs/content/multi-plugin/readme.md`
- `docs/content/multi-plugin/reference.md`