### PR TITLE
🐛 fix: repair broken kubestellar.io guide links

### DIFF
--- a/docs/content/multi-plugin/overview/introduction.md
+++ b/docs/content/multi-plugin/overview/introduction.md
@@ -27,11 +27,11 @@ kubectl multi get pods -A
 
 ## Documentation
 
-- **[Installation Guide](../installation_guide)** - How to install and set up kubectl-multi
-- **[Usage Guide](../usage_guide)** - Detailed usage examples and commands
-- **[Architecture Guide](../architecture_guide)** - Technical architecture and how it works
-- **[Development Guide](../development_guide)** - Contributing and development workflow
-- **[API Reference](../api_reference)** - Code organization and technical implementation
+- **[Installation Guide](/docs/multi-plugin/installation_guide)** - How to install and set up kubectl-multi
+- **[Usage Guide](/docs/multi-plugin/usage_guide)** - Detailed usage examples and commands
+- **[Architecture Guide](/docs/multi-plugin/architecture_guide)** - Technical architecture and how it works
+- **[Development Guide](/docs/multi-plugin/development_guide)** - Contributing and development workflow
+- **[API Reference](/docs/multi-plugin/api_reference)** - Code organization and technical implementation
 
 ## Tech Stack
 


### PR DESCRIPTION
Fixes #6358
Fixes #6359
Fixes #6360
Fixes #6361

## Root cause

`docs/content/multi-plugin/overview/introduction.md` used relative `../` links for the four guide pages:

```markdown
- [Installation Guide](../installation_guide)
- [Usage Guide](../usage_guide)
- [Architecture Guide](../architecture_guide)
- [Development Guide](../development_guide)
```

This page is served at two URLs:
- **Canonical:** `/docs/multi-plugin/overview/introduction` — here `../` correctly resolves to `/docs/multi-plugin/installation_guide` etc.
- **Redirected:** `/docs/multi-plugin` (Netlify 302 → canonical) — link checkers resolve relative URLs against the *pre-redirect* URL, so `../installation_guide` from `/docs/multi-plugin` resolves to `/installation_guide` (404).

## Fix

Replace the four `../guide` relative links with absolute `/docs/multi-plugin/guide` paths. Absolute paths resolve identically from any URL, so the links work correctly whether the page is accessed directly or via the redirect.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>