### PR TITLE
📖 Update kubestellar-mcp docs to v0.9.6

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -146,8 +146,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.9.4 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.9.4",
+        "label": "v0.9.6 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.9.6",
         "isDefault": true
       },
       "main": {
@@ -189,6 +189,11 @@
       "0.9.3": {
         "label": "v0.9.3",
         "branch": "docs/kubestellar-mcp/0.9.3",
+        "isDefault": false
+      },
+      "0.9.4": {
+        "label": "v0.9.4",
+        "branch": "docs/kubestellar-mcp/0.9.4",
         "isDefault": false
       }
     },
@@ -407,7 +412,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.9.4"
+      "currentVersion": "0.9.6"
     },
     "console": {
       "name": "Console",
@@ -464,5 +469,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-07-18T05:59:17.276Z"
+  "updatedAt": "2026-07-19T06:06:03.066Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.9.4 (Latest)",
-    branch: "docs/kubestellar-mcp/0.9.4",
+    label: "v0.9.6 (Latest)",
+    branch: "docs/kubestellar-mcp/0.9.6",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.9.4": {
+    label: "v0.9.4",
+    branch: "docs/kubestellar-mcp/0.9.4",
+    isDefault: false,
   },
   "0.9.3": {
     label: "v0.9.3",
@@ -472,7 +477,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.9.4",
+    currentVersion: "0.9.6",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.9.6.

- Created branch: `docs/kubestellar-mcp/0.9.6`
- Source: kubestellar/kubestellar-mcp@v0.9.6

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release