### PR TITLE
📖 Sync console docs versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -199,8 +199,8 @@
     },
     "console": {
       "latest": {
-        "label": "v0.3.33 (Latest)",
-        "branch": "docs/console/0.3.33",
+        "label": "v0.3.34 (Latest)",
+        "branch": "docs/console/0.3.34",
         "isDefault": true
       },
       "main": {
@@ -378,6 +378,11 @@
         "label": "v0.3.32",
         "branch": "docs/console/0.3.32",
         "isDefault": false
+      },
+      "0.3.33": {
+        "label": "v0.3.33",
+        "branch": "docs/console/0.3.33",
+        "isDefault": false
       }
     },
     "hive": {
@@ -417,7 +422,7 @@
     "console": {
       "name": "Console",
       "basePath": "console",
-      "currentVersion": "0.3.33"
+      "currentVersion": "0.3.34"
     },
     "hive": {
       "name": "Hive",
@@ -469,5 +474,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-07-19T06:12:59.415Z"
+  "updatedAt": "2026-07-20T06:23:53.994Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -248,8 +248,8 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // The console release sync workflow auto-updates this when a new release is detected.
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.3.33 (Latest)",
-    branch: "docs/console/0.3.33",
+    label: "v0.3.34 (Latest)",
+    branch: "docs/console/0.3.34",
     isDefault: true,
   },
   main: {
@@ -257,6 +257,11 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.3.33": {
+    label: "v0.3.33",
+    branch: "docs/console/0.3.33",
+    isDefault: false,
   },
   "0.3.32": {
     label: "v0.3.32",
@@ -485,7 +490,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "0.3.33",
+    currentVersion: "0.3.34",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker