### PR TITLE
🌱 Workflow hardening: Add continue-on-error to Postmark email step

### DIFF
--- a/.github/workflows/maintainer-metrics.lock.yml
+++ b/.github/workflows/maintainer-metrics.lock.yml
@@ -6750,6 +6750,7 @@ jobs:
           find "/tmp/gh-aw/safe-jobs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_ENV"
       - name: Send via Postmark
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           POSTMARK_API_TOKEN: ${{ secrets.POSTMARK_API_TOKEN }}


### PR DESCRIPTION
Fixes #6384

## Summary

Adds `continue-on-error: true` to the "Send via Postmark" step in the Maintainer Metrics Tracker workflow. This allows the workflow to complete successfully even if email delivery fails.

## Problem

The Postmark API 401 error (invalid/expired server token) was failing the entire workflow, preventing the successful metrics collection and analysis from being recorded. The metrics data pipeline (agent, fetch-data, detection, conclusion jobs) all succeed, but the workflow fails at the email notification step.

## Solution

Since the metrics data collection and analysis already succeeded before the email step, email delivery failures should not cause the entire workflow to fail. This change allows:
- Metrics data to be successfully captured and analyzed
- Workflow to complete with a success status even if Postmark email delivery fails
- The separate secret rotation fix (updating `POSTMARK_API_TOKEN`) to resolve actual email delivery once the token is rotated

## Implementation

Added `continue-on-error: true` to the "Send via Postmark" step in `.github/workflows/maintainer-metrics.lock.yml`. This is a non-breaking change that improves workflow resilience.

Related to optional hardening recommended in #6384.