### PR TITLE
[scanner] fix: reduce recurring agentic-workflow failure noise

### DIFF
--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -17,6 +17,7 @@ network:
     - github
 
 safe-outputs:
+  report-failure-as-issue: false
   noop:
     report-as-issue: false
   create-issue:

--- a/.github/workflows/typo-checker.md
+++ b/.github/workflows/typo-checker.md
@@ -14,6 +14,7 @@ permissions: read-all
 network: defaults
 
 safe-outputs:
+  report-failure-as-issue: false
   noop:
     report-as-issue: false
   create-issue:


### PR DESCRIPTION
Fixes #6428, Fixes #6429

## Root Cause

Both issues are caused by `awf-squid exited (1)` — an infrastructure-level container startup failure in the agentic-workflow engine. The `copilot` engine terminates before producing any output, which then auto-files a GitHub issue.

This is not a bug in the typo-checker or link-checker logic — it's a transient runner environment failure that cannot be fixed in repository code.

## Fix

Add `report-failure-as-issue: false` to the `safe-outputs` frontmatter of both agentic workflow definitions:

- `.github/workflows/typo-checker.md`
- `.github/workflows/link-checker.md`

This setting (documented in the issue tip) prevents engine/container startup failures from auto-creating GitHub issues. Actual workflow logic failures (typos found, broken links detected) are still reported via the `create-issue` / `close-issue` safe-outputs as before.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>