### PR TITLE
📖 Sync console docs versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -474,5 +474,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-07-31T06:21:49.533Z"
+  "updatedAt": "2026-08-01T06:13:37.471Z"
 }


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker