### PR TITLE
✨ docs(hive): rename ACMM levels to capability names

### DIFF
--- a/docs/content/hive/acmm-policy-matrix.md
+++ b/docs/content/hive/acmm-policy-matrix.md
@@ -18,7 +18,7 @@ Each agent runs in one of four modes, controlling what actions it can take on Gi
 
 ## ACMM Levels
 
-### L1 — Assisted (2 agents)
+### L1 — Inception (Assisted) — 2 agents
 
 A single interactive advisor helps with repo setup and architecture decisions. Guide agent makes advisory beads. Brainstorm agent handles project inception — turning raw ideas into structured KB facts and scaffold. No feedback loops.
 
@@ -27,7 +27,7 @@ A single interactive advisor helps with repo setup and architecture decisions. G
 | guide | advisory | `guide-advisory.md` |
 | brainstorm | advisory | `brainstorm-inception.md` |
 
-### L2 — Instructed (5 agents)
+### L2 — Advisory (Instructed) — 5 agents
 
 Agents observe and report findings as advisory beads on the dashboard and tracking issue. No GitHub issues or PRs created. Humans decide what to act on.
 
@@ -39,7 +39,7 @@ Agents observe and report findings as advisory beads on the dashboard and tracki
 | guide | advisory | `guide-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L3 — Measured (6 agents)
+### L3 — Quality-Gated (Measured) — 6 agents
 
 Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI workflows. All other agents remain advisory. CI-maintainer joins to monitor build health. Key artifact: measurement infrastructure.
 
@@ -52,7 +52,7 @@ Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI w
 | guide | advisory | `guide-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L4 — Adaptive (7 agents)
+### L4 — Security-Aware (Adaptive) — 7 agents
 
 All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins. Closed-loop feedback: agents act on their own findings.
 
@@ -66,7 +66,7 @@ All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnera
 | **sec-check** | **holdgated** | `sec-check-holdgated.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L5 — Semi-Automated (9 agents)
+### L5 — Semi-Autonomous (Semi-Automated) — 9 agents
 
 Agents open issues AND pull requests. All PRs get a hold label — humans batch-review and approve. Architect produces RFCs, strategist coordinates across agents. The system proposes; it does not merge autonomously.
 
@@ -82,7 +82,7 @@ Agents open issues AND pull requests. All PRs get a hold label — humans batch-
 | strategist | holdgated | `strategist-holdgated.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L6 — Fully Autonomous (10 agents)
+### L6 — Fully Autonomous — 10 agents
 
 Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outreach agent handles community engagement (highest trust — external-facing). Governor at fastest cadence.
 

--- a/docs/content/hive/agent-configuration.md
+++ b/docs/content/hive/agent-configuration.md
@@ -201,11 +201,11 @@ You don't have to design a roster. Hive ships six **ACMM packs** (`level-1.yaml`
 
 | Level | Name | Posture |
 |---|---|---|
-| L1 | Assisted | inception: brainstorm + guide, everything conversational |
-| L2 | Instructed | advisory beads only; agents observe, humans act |
-| L3 | Measured | quality opens issues and hold-gated test PRs; the rest stay advisory |
-| L4 | Adaptive | all agents open issues — no PRs yet |
-| L5 | Semi-Automated | issues **and** hold-gated PRs; humans batch-approve |
+| L1 | Inception (Assisted) | inception: brainstorm + guide, everything conversational |
+| L2 | Advisory (Instructed) | advisory beads only; agents observe, humans act |
+| L3 | Quality-Gated (Measured) | quality opens issues and hold-gated test PRs; the rest stay advisory |
+| L4 | Security-Aware (Adaptive) | all agents open issues — no PRs yet |
+| L5 | Semi-Autonomous (Semi-Automated) | issues **and** hold-gated PRs; humans batch-approve |
 | L6 | Fully Autonomous | auto-merge on green CI, no hold label |
 
 Applying a level **reconciles the whole roster**, not just the diff: missing agents are created (as overlay files in `/data/agent-configs/`), existing agents are merged — pack values fill blanks, but your explicit `backend:`, `model:`, and `enabled: false` always win — and the level's `kick_template` and `mode` are updated so the agent's *policy* matches the level. A failed agent doesn't abort the rest; the level is only recorded as cleanly applied when every agent reconciled.

--- a/docs/content/hive/manual-provisioning.md
+++ b/docs/content/hive/manual-provisioning.md
@@ -99,7 +99,7 @@ The generated ID is `hosted-<org>-<primary_repo>-<4char>`.
 |---|---|
 | `org`, `repos` | **Required, non-empty.** `repos` is comma-separated. |
 | `primary_repo` | Hosts the advisory issue and default markings. |
-| `acmm_level` | Starting autonomy. **Default new hives to `2`** (Instructed / advisory-only). |
+| `acmm_level` | Starting autonomy. **Default new hives to `2`** (Advisory — beads only, no GitHub writes). |
 | `cluster_id` | `hive-oke` (the `defaultClusterID`). |
 | `auth_method` | `app` or a token. |
 | `app_id` / `installation_id` / `app_private_key` | Three auth shapes: **token** (`github_token` starts `ghp_`/`github_pat_`); **app now** (all three set); **app later** — `app_id` set, `installation_id` **and** `app_private_key` **empty**. The last is the placeholder case: the hive provisions, then 401s until the owner installs the App from the dashboard. |

--- a/docs/content/hive/overview/intro.md
+++ b/docs/content/hive/overview/intro.md
@@ -116,11 +116,11 @@ Hive uses an **AI-native Capability Maturity Model** (ACMM) with six levels that
 
 | Level | Name | Agents | What agents can do |
 |-------|------|--------|-------------------|
-| L1 | Assisted | 2 | Interactive advisor and project inception. Advisory beads only. |
-| L2 | Instructed | 5 | Observe and report findings as dashboard beads. No GitHub interaction. |
-| L3 | Measured | 6 | Quality agent opens issues and hold-gated PRs. Others remain advisory. |
-| L4 | Adaptive | 7 | All agents file issues. Quality, sec-check, and CI open hold-gated PRs. |
-| L5 | Semi-Automated | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
+| L1 | Inception (Assisted) | 2 | Interactive advisor and project inception. Advisory beads only. |
+| L2 | Advisory (Instructed) | 5 | Observe and report findings as dashboard beads. No GitHub interaction. |
+| L3 | Quality-Gated (Measured) | 6 | Quality agent opens issues and hold-gated PRs. Others remain advisory. |
+| L4 | Security-Aware (Adaptive) | 7 | All agents file issues. Quality, sec-check, and CI open hold-gated PRs. |
+| L5 | Semi-Autonomous (Semi-Automated) | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
 | L6 | Fully Autonomous | 10 | Agents open PRs and auto-merge on green CI. No hold label required. |
 
 Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). Applying a level reconciles the entire agent roster that level defines — at L5 that is 9 agents, including architect and strategist.

--- a/docs/content/hive/readme.md
+++ b/docs/content/hive/readme.md
@@ -116,11 +116,11 @@ Hive uses an **AI-native Capability Maturity Model** (ACMM) with six levels that
 
 | Level | Name | Agents | What agents can do |
 |-------|------|--------|-------------------|
-| L1 | Assisted | 2 | Interactive advisor and project inception. Advisory beads only. |
-| L2 | Instructed | 5 | Observe and report findings as dashboard beads. No GitHub interaction. |
-| L3 | Measured | 6 | Quality agent opens issues and hold-gated PRs. Others remain advisory. |
-| L4 | Adaptive | 7 | All agents file issues. Quality, sec-check, and CI open hold-gated PRs. |
-| L5 | Semi-Automated | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
+| L1 | Inception (Assisted) | 2 | Interactive advisor and project inception. Advisory beads only. |
+| L2 | Advisory (Instructed) | 5 | Observe and report findings as dashboard beads. No GitHub interaction. |
+| L3 | Quality-Gated (Measured) | 6 | Quality agent opens issues and hold-gated PRs. Others remain advisory. |
+| L4 | Security-Aware (Adaptive) | 7 | All agents file issues. Quality, sec-check, and CI open hold-gated PRs. |
+| L5 | Semi-Autonomous (Semi-Automated) | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
 | L6 | Fully Autonomous | 10 | Agents open PRs and auto-merge on green CI. No hold label required. |
 
 Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). Applying a level reconciles the entire agent roster that level defines — at L5 that is 9 agents, including architect and strategist.

--- a/src/app/[locale]/acmm-leaderboard/page.tsx
+++ b/src/app/[locale]/acmm-leaderboard/page.tsx
@@ -15,6 +15,8 @@ interface AcmmProject {
   repo: string;
   level: number;
   score: number;
+  /** True when the raw scan level is below L1 (baseline prerequisites not yet met). */
+  unmetPrereqs?: boolean;
 }
 
 // ── Level metadata ────────────────────────────────────────────────────
@@ -29,13 +31,15 @@ interface LevelMeta {
 }
 
 const LEVELS: Record<number, LevelMeta> = {
-  0: { emoji: "🔴", name: "Prerequisites",    description: "No AI-related signals detected (baseline)",                  bg: "bg-red-500/20",    text: "text-red-400",    border: "border-red-500/30" },
-  1: { emoji: "⚫", name: "Assisted",         description: "Basic AI tooling signals (Copilot, formatters)",             bg: "bg-gray-500/20",   text: "text-gray-400",   border: "border-gray-500/30" },
-  2: { emoji: "⚪", name: "Instructed",       description: "Has AI instruction files (CLAUDE.md, .cursorrules, etc.)",   bg: "bg-white/10",      text: "text-gray-300",   border: "border-white/20" },
-  3: { emoji: "🟡", name: "Measured",         description: "PR review rubric, quality dashboard, CI matrix",             bg: "bg-yellow-500/20", text: "text-yellow-400", border: "border-yellow-500/30" },
-  4: { emoji: "🔵", name: "Adaptive",         description: "Auto-QA tuning, nightly compliance, AI-fix workflows",      bg: "bg-blue-500/20",   text: "text-blue-400",   border: "border-blue-500/30" },
-  5: { emoji: "🟢", name: "Semi-Automated",   description: "GitHub Actions AI, auto-QA self-tuning, public metrics",    bg: "bg-green-500/20",  text: "text-green-400",  border: "border-green-500/30" },
-  6: { emoji: "🟣", name: "Autonomous",       description: "Fully autonomous AI-driven development and operations",     bg: "bg-purple-500/20", text: "text-purple-400", border: "border-purple-500/30" },
+  // 0 is an internal fallback only — never rendered as its own maturity tier.
+  // Projects scoring below L1 display as L1 with an unmet-prerequisites marker.
+  0: { emoji: "🔴", name: "Prerequisites",    description: "Baseline prerequisites not yet met (internal fallback; displays as L1)", bg: "bg-red-500/20",    text: "text-red-400",    border: "border-red-500/30" },
+  1: { emoji: "⚫", name: "Inception",        description: "Basic AI tooling signals (Copilot, formatters)",             bg: "bg-gray-500/20",   text: "text-gray-400",   border: "border-gray-500/30" },
+  2: { emoji: "⚪", name: "Advisory",         description: "Has AI instruction files (CLAUDE.md, .cursorrules, etc.)",   bg: "bg-white/10",      text: "text-gray-300",   border: "border-white/20" },
+  3: { emoji: "🟡", name: "Quality-Gated",    description: "PR review rubric, quality dashboard, CI matrix",             bg: "bg-yellow-500/20", text: "text-yellow-400", border: "border-yellow-500/30" },
+  4: { emoji: "🔵", name: "Security-Aware",   description: "Auto-QA tuning, nightly compliance, AI-fix workflows",      bg: "bg-blue-500/20",   text: "text-blue-400",   border: "border-blue-500/30" },
+  5: { emoji: "🟢", name: "Semi-Autonomous",  description: "GitHub Actions AI, auto-QA self-tuning, public metrics",    bg: "bg-green-500/20",  text: "text-green-400",  border: "border-green-500/30" },
+  6: { emoji: "🟣", name: "Fully Autonomous", description: "Fully autonomous AI-driven development and operations",     bg: "bg-purple-500/20", text: "text-purple-400", border: "border-purple-500/30" },
 };
 
 // ── Medal icons ───────────────────────────────────────────────────────
@@ -49,14 +53,18 @@ function RankDisplay({ rank }: { rank: number }) {
 
 // ── Level badge ───────────────────────────────────────────────────────
 
-function LevelBadge({ level }: { level: number }) {
-  const meta = LEVELS[level] || LEVELS[1];
+function LevelBadge({ level, unmetPrereqs }: { level: number; unmetPrereqs?: boolean }) {
+  // Displayed level is clamped to L1+ — L0 is never shown as its own tier.
+  const displayLevel = Math.max(level, MIN_LEVEL);
+  const meta = LEVELS[displayLevel] || LEVELS[MIN_LEVEL];
   return (
     <span
       className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${meta.bg} ${meta.text} ${meta.border}`}
+      title={unmetPrereqs ? "Baseline prerequisites not yet met" : undefined}
     >
       <span>{meta.emoji}</span>
-      <span>L{level}</span>
+      <span>L{displayLevel}</span>
+      {unmetPrereqs && <span className="text-amber-400" aria-label="Baseline prerequisites not yet met">*</span>}
     </span>
   );
 }
@@ -606,15 +614,19 @@ export default function AcmmLeaderboardPage() {
       if (!scores?.length) return p;
       const latestScore = scores[scores.length - 1];
       const ids = history.detectedIds?.[p.repo];
-      const level = ids?.length
+      const rawLevel = ids?.length
         ? levelFromDetectedIds(ids)
         : levelFromScore(latestScore);
-      return { ...p, score: latestScore, level };
+      // Fold L0 into L1 for display: the ladder starts at L1, and a project
+      // below baseline renders as L1 with an unmet-prerequisites marker.
+      // Underlying scan data (acmm-history.json) keeps its raw numbers.
+      const level = Math.max(rawLevel, MIN_LEVEL);
+      return { ...p, score: latestScore, level, unmetPrereqs: rawLevel < MIN_LEVEL };
     });
   }, [history]);
 
   const levelCounts = useMemo(() => {
-    const counts: Record<number, number> = { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
+    const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
     for (const p of projects) counts[p.level] = (counts[p.level] || 0) + 1;
     return counts;
   }, [projects]);
@@ -712,7 +724,7 @@ export default function AcmmLeaderboardPage() {
 
           {/* Quick stats — level filters + badge filter */}
           <div className="flex flex-wrap justify-center gap-3 mt-6">
-            {[6, 5, 4, 3, 2, 1, 0].map((lvl) => {
+            {[6, 5, 4, 3, 2, 1].map((lvl) => {
               const meta = LEVELS[lvl];
               return (
                 <button
@@ -800,8 +812,8 @@ export default function AcmmLeaderboardPage() {
               <h3 className="text-sm font-semibold text-gray-300 mb-4 uppercase tracking-wider">
                 ACMM Maturity Levels
               </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-4 lg:grid-cols-7 gap-3 mb-4">
-                {[0, 1, 2, 3, 4, 5, 6].map((lvl) => {
+              <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-4">
+                {[1, 2, 3, 4, 5, 6].map((lvl) => {
                   const meta = LEVELS[lvl];
                   return (
                     <div key={lvl} className={`p-3 rounded-lg border ${meta.bg} ${meta.border}`}>
@@ -814,7 +826,7 @@ export default function AcmmLeaderboardPage() {
                 })}
               </div>
               <p className="text-xs text-gray-500">
-                The full ACMM model defines <strong className="text-gray-400">{TOTAL_CRITERIA} criteria</strong> across 7 maturity levels (L0–L6). This leaderboard evaluates <strong className="text-gray-400">{TOTAL_SCANNABLE} publicly detectable signals</strong> from repository metadata, CI/CD configuration, and AI instruction files.{" "}
+                The full ACMM model defines <strong className="text-gray-400">{TOTAL_CRITERIA} criteria</strong> across six maturity levels (L1–L6). This leaderboard evaluates <strong className="text-gray-400">{TOTAL_SCANNABLE} publicly detectable signals</strong> from repository metadata, CI/CD configuration, and AI instruction files.{" "}
                 <a href="https://arxiv.org/abs/2604.09388" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline" onClick={trackPaperClick}>
                   Read the paper →
                 </a>
@@ -913,7 +925,7 @@ export default function AcmmLeaderboardPage() {
 
                   {/* Level */}
                   <div className="flex justify-start sm:justify-center pl-11 sm:pl-0">
-                    <LevelBadge level={project.level} />
+                    <LevelBadge level={project.level} unmetPrereqs={project.unmetPrereqs} />
                   </div>
 
                   {/* Score */}


### PR DESCRIPTION
## Summary

Renames the Hive ACMM level names from process-maturity terms to capability names. Docs tables and headings use the dual-label form (new name with old name in parentheses) for one release cycle of continuity; leaderboard badges and compact UI use the new names only.

| L | New name | Old name | Dual-label form |
|---|----------|----------|-----------------|
| 1 | Inception | Assisted | L1 — Inception (Assisted) |
| 2 | Advisory | Instructed | L2 — Advisory (Instructed) |
| 3 | Quality-Gated | Measured | L3 — Quality-Gated (Measured) |
| 4 | Security-Aware | Adaptive | L4 — Security-Aware (Adaptive) |
| 5 | Semi-Autonomous | Semi-Automated | L5 — Semi-Autonomous (Semi-Automated) |
| 6 | Fully Autonomous | Fully Autonomous | L6 — Fully Autonomous |

## Changes

**Hive docs** (`docs/content/hive/`)
- `acmm-policy-matrix.md` — per-level headings renamed to dual-label form. The policy-MODE table (advisory / measured / holdgated / full) and template filenames (`-measured.md`, etc.) are intentionally unchanged — those are agent modes, not level names.
- `readme.md` + `overview/intro.md` — the byte-identical level tables updated identically.
- `agent-configuration.md` — ACMM pack table updated.
- `manual-provisioning.md` — `acmm_level` default note reworded to "(Advisory — beads only, no GitHub writes)" (the old "(Instructed / advisory-only)" would have collided with the new L2 name).
- `governor.md` / `security-model.md` — verified: numeric level refs only, no changes needed.

**Leaderboard** (`src/app/[locale]/acmm-leaderboard/page.tsx`)
- `LEVELS` record renamed for L1–L6; L6 fixed from "Autonomous" to "Fully Autonomous" (pre-existing drift).
- **L0 folded away as a visible tier**: the ladder now presents six levels (L1–L6). Displayed levels are clamped to L1+; a project whose raw scan level is 0 renders as L1 with an unmet-prerequisites marker (`*` + tooltip on the badge). The `0` key remains in `LEVELS` as an internal, never-rendered fallback. Level filter chips and the "How Scoring Works" legend no longer list L0; the criteria blurb now reads "six maturity levels (L1–L6)".
- Raw scan data untouched: `public/data/acmm-history.json` and `scripts/generate-acmm-history.mjs` still emit raw numeric levels including 0.

## Out of scope
- `docs/content/console/**` — separate Console ACMM model.
- White paper / blog content.
- `src/app/docs/page-map.ts` — verified nav labels carry no level names.

## Sweep survivors (grep for old names, all intentional)
- Dual-label parentheticals in the four docs tables/headings.
- `acmm-policy-matrix.md` mode-table rows and prose using **Measured** as a policy MODE (with `-measured.md` filenames).
- `manual-provisioning.md` "## Prerequisites (both paths)" — generic English.
- `page.tsx` `LEVELS[0]` name "Prerequisites" — internal fallback, never rendered as a tier.
