### PR TITLE
📖 docs: add Hive section (ADRs, threat model, roadmap)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -557,3 +557,14 @@
   to = "https://youtube.com/@kubestellar"
   status = 301
   force = true
+
+# Redirect Hive docs root to the first Hive docs page.
+[[redirects]]
+  from = "/docs/hive"
+  to = "/docs/hive/overview/introduction"
+  status = 302
+
+[[redirects]]
+  from = "/docs/hive/"
+  to = "/docs/hive/overview/introduction"
+  status = 302

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "prebuild": "tsx scripts/generate-shared-config.ts",
+    "prebuild": "tsx scripts/sync-hive-docs.ts && tsx scripts/generate-shared-config.ts",
     "build": "next build",
     "start": "next start",
     "lint": "eslint src/",

--- a/scripts/sync-hive-docs.ts
+++ b/scripts/sync-hive-docs.ts
@@ -1,0 +1,65 @@
+import fs from 'fs'
+import path from 'path'
+
+const owner = 'kubestellar'
+const repo = 'hive'
+const branch = process.env.HIVE_DOCS_REF || 'v4'
+const docsRoot = path.join(process.cwd(), 'docs', 'content', 'hive')
+const rawBase = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/v2/docs`
+const canonicalBase = `https://github.com/${owner}/${repo}/blob/${branch}/v2/docs`
+
+const files: Array<{ source: string; target?: string }> = [
+  { source: 'README.md', target: 'readme.md' },
+  { source: 'architecture.md' },
+  { source: 'security-threat-model.md' },
+  { source: 'roadmap.md' },
+  { source: 'landscape.md' },
+  { source: 'adr/README.md', target: 'adr/readme.md' },
+  { source: 'adr/0001-record-architecture-decisions.md' },
+  { source: 'adr/0002-mitm-proxy-network-enforcement.md' },
+  { source: 'adr/0003-acmm-autonomy-levels.md' },
+  { source: 'adr/0004-beads-work-ledger.md' },
+  { source: 'adr/0005-forge-abstraction.md' },
+  { source: 'adr/0006-planning-intelligence.md' },
+  { source: 'adr/0007-token-mint.md' },
+  { source: 'adr/0008-ioscan-untrusted-input.md' },
+  { source: 'adr/0009-trajectory-review.md' },
+  { source: 'adr/0010-escalation-circuit-breaker.md' },
+  { source: 'adr/0011-knowledge-graph.md' },
+  { source: 'adr/0012-skill-registry.md' },
+  { source: 'adr/0013-cel-triggers.md' },
+  { source: 'adr/0014-hub-spoke.md' },
+]
+
+function canonicalHeader(source: string): string {
+  const canonical = `${canonicalBase}/${source}`
+  return `> **Synced from Hive.** This page is pulled from [kubestellar/hive@${branch}](${canonical}) during the docs build. Edit the canonical source in the Hive repository.\n\n`
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`failed to fetch ${url}: ${response.status} ${response.statusText}`)
+  }
+  return response.text()
+}
+
+async function main() {
+  for (const file of files) {
+    const target = file.target || file.source
+    const sourceURL = `${rawBase}/${file.source}`
+    const targetPath = path.join(docsRoot, target)
+    if (!targetPath.startsWith(docsRoot + path.sep)) {
+      throw new Error(`refusing to write outside Hive docs root: ${target}`)
+    }
+    const content = await fetchText(sourceURL)
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+    fs.writeFileSync(targetPath, canonicalHeader(file.source) + content)
+    console.log(`synced ${file.source} -> docs/content/hive/${target}`)
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -327,44 +327,42 @@ const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
     items: [
       { 'Introduction': 'readme.md' },
       { 'Architecture': 'architecture.md' },
-    ]
-  },
-  {
-    title: 'Getting Started',
-    items: [
-      { 'macOS Setup': 'macos.md' },
-      { 'Example: Homelab Console (Bluefin)': 'console-starter-install.md' },
-      { 'Troubleshooting': 'troubleshooting.md' },
-    ]
-  },
-  {
-    title: 'Configuration',
-    items: [
-      { 'Agent Configuration': 'agent-configuration.md' },
-      { 'AgentDefinition YAML Reference': 'agent-definition-yaml.md' },
-      { 'Governor': 'governor.md' },
-      { 'Contributor Relay': 'contributor-relay.md' },
-      { 'Variable Substitution': 'variable-substitution.md' },
-    ]
-  },
-  {
-    title: 'Operations',
-    items: [
-      { 'Manual Provisioning': 'manual-provisioning.md' },
+      { 'Roadmap': 'roadmap.md' },
+      { 'Landscape and Positioning': 'landscape.md' },
     ]
   },
   {
     title: 'Security',
     items: [
-      { 'Security Model': 'security-model.md' },
+      { 'Threat Model': 'security-threat-model.md' },
+      {
+        'Architecture Decision Records': [
+          { 'ADR Index': 'adr/readme.md' },
+          { '0001: Record architecture decisions': 'adr/0001-record-architecture-decisions.md' },
+          { '0002: MITM proxy network enforcement': 'adr/0002-mitm-proxy-network-enforcement.md' },
+          { '0003: ACMM autonomy levels': 'adr/0003-acmm-autonomy-levels.md' },
+          { '0004: Beads work ledger': 'adr/0004-beads-work-ledger.md' },
+          { '0005: Forge abstraction': 'adr/0005-forge-abstraction.md' },
+          { '0006: Planning intelligence': 'adr/0006-planning-intelligence.md' },
+          { '0007: Token mint': 'adr/0007-token-mint.md' },
+          { '0008: IOScan untrusted input': 'adr/0008-ioscan-untrusted-input.md' },
+          { '0009: Trajectory review': 'adr/0009-trajectory-review.md' },
+          { '0010: Escalation circuit breaker': 'adr/0010-escalation-circuit-breaker.md' },
+          { '0011: Knowledge graph': 'adr/0011-knowledge-graph.md' },
+          { '0012: Skill registry': 'adr/0012-skill-registry.md' },
+          { '0013: CEL triggers': 'adr/0013-cel-triggers.md' },
+          { '0014: Hub/spoke': 'adr/0014-hub-spoke.md' },
+        ]
+      },
     ]
   },
   {
-    title: 'Reference',
+    title: 'Operations',
     items: [
+      { 'Agent Configuration': 'agent-configuration.md' },
+      { 'Manual Provisioning': 'manual-provisioning.md' },
       { 'hivectl CLI': 'hivectl.md' },
       { 'ACMM Policy Matrix': 'acmm-policy-matrix.md' },
-      { 'Outreach Anti-Spam': 'outreach-antispam.md' },
     ]
   }
 ]


### PR DESCRIPTION
## Summary\n- Adds a build-time sync step that pulls high-value Hive docs from kubestellar/hive@v4 into the existing docs.kubestellar.io/Nextra pipeline.\n- Updates the Hive sidebar to surface the synced introduction, architecture, roadmap, landscape, threat model, and ADRs 0001-0014.\n- Redirects /docs/hive to the Hive introduction page.\n\nThis keeps kubestellar/hive as the canonical source of truth and avoids a separate MkDocs pipeline in the Hive repo.\n\nReferences kubestellar/hive#2811 and kubestellar/hive#2812.\n\nExpected Hive docs URL: https://docs.kubestellar.io/docs/hive/overview/introduction\n\n## Validation\n- npm run build