### PR TITLE
📖 Sync console docs versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -204,8 +204,8 @@
     },
     "console": {
       "latest": {
-        "label": "v0.3.35 (Latest)",
-        "branch": "docs/console/0.3.35",
+        "label": "v0.3.36 (Latest)",
+        "branch": "docs/console/0.3.36",
         "isDefault": true
       },
       "main": {
@@ -393,6 +393,11 @@
         "label": "v0.3.34",
         "branch": "docs/console/0.3.34",
         "isDefault": false
+      },
+      "0.3.35": {
+        "label": "v0.3.35",
+        "branch": "docs/console/0.3.35",
+        "isDefault": false
       }
     },
     "hive": {
@@ -432,7 +437,7 @@
     "console": {
       "name": "Console",
       "basePath": "console",
-      "currentVersion": "0.3.35"
+      "currentVersion": "0.3.36"
     },
     "hive": {
       "name": "Hive",
@@ -484,5 +489,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-08-09T05:28:14.404Z"
+  "updatedAt": "2026-08-10T05:47:54.702Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -253,8 +253,8 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // The console release sync workflow auto-updates this when a new release is detected.
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.3.35 (Latest)",
-    branch: "docs/console/0.3.35",
+    label: "v0.3.36 (Latest)",
+    branch: "docs/console/0.3.36",
     isDefault: true,
   },
   main: {
@@ -262,6 +262,11 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.3.35": {
+    label: "v0.3.35",
+    branch: "docs/console/0.3.35",
+    isDefault: false,
   },
   "0.3.34": {
     label: "v0.3.34",
@@ -500,7 +505,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "0.3.35",
+    currentVersion: "0.3.36",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker