### PR TITLE
fix(hive): show hive docs version as v4 (Latest) in the version dropdown

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -402,7 +402,7 @@
     },
     "hive": {
       "latest": {
-        "label": "main (Latest)",
+        "label": "v4 (Latest)",
         "branch": "main",
         "isDefault": true
       }
@@ -442,7 +442,7 @@
     "hive": {
       "name": "Hive",
       "basePath": "hive",
-      "currentVersion": "main"
+      "currentVersion": "v4"
     }
   },
   "relatedProjects": [
@@ -489,5 +489,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-08-13T05:49:29.356Z"
+  "updatedAt": "2026-08-14T11:22:15.000Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -451,9 +451,15 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
 }
 
 // hive versions
+// Hive is continuously deployed rather than semver-released, so the docs are a
+// single "latest" line: content is fetched at build time from the
+// kubestellar/hive branch named by HIVE_DOCS_REF (see scripts/sync-hive-docs.ts),
+// which tracks hive's current major release line (v4 today). When hive moves to
+// a new major line, update this label, currentVersion below, and the
+// HIVE_DOCS_REF default together.
 const HIVE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "main (Latest)",
+    label: "v4 (Latest)",
     branch: "main",
     isDefault: true,
   },
@@ -513,7 +519,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "hive",
     name: "Hive",
     basePath: "hive",
-    currentVersion: "main",
+    currentVersion: "v4",
     contentPath: "docs/content/hive",
     versions: HIVE_VERSIONS,
   },


### PR DESCRIPTION
## What

The docs site's version dropdown for the hive project showed **"main (Latest)"**, while the hive product itself has moved through major release lines v1 -> v4. This made the hive documentation look unversioned.

Fixes https://github.com/kubestellar/hive/issues/2704

## Why the label is v4

Hive docs content is not stored per-release in this repo: `scripts/sync-hive-docs.ts` fetches it at build time from the `kubestellar/hive` branch named by `HIVE_DOCS_REF`, which tracks hive's current major release line (`v4` today). So the published "latest" docs are the v4 line's docs, and the dropdown now says so.

## Changes

- `src/config/versions.ts`: hive `latest` label `main (Latest)` -> `v4 (Latest)`, project `currentVersion` `main` -> `v4`; comment documents that this must be bumped together with the `HIVE_DOCS_REF` default on future major-line cutovers
- `public/config/shared.json`: regenerated checked-in copy to match (it is also regenerated automatically by the prebuild step)

## Follow-up (not in this PR)

Archived per-major-line snapshots (e.g. a `v2` dropdown entry) would need a `docs/hive/v2` snapshot branch whose build pins `HIVE_DOCS_REF=v2`, plus a versions entry pointing at its Netlify branch deploy — noted on the issue as follow-up rather than done here, since hive's build-time content fetch differs from the content-in-branch snapshot pattern the other projects use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)