### PR TITLE
📖 docs(hive): v4 documentation sweep — release channels, security model, backup/DR, nav repair

### DIFF
--- a/docs/content/hive/agent-configuration.md
+++ b/docs/content/hive/agent-configuration.md
@@ -4,7 +4,7 @@ A hive **agent** is a long-running AI worker — a CLI session the hive keeps al
 
 Start with only a name, a method, and a model. Add the rest when the agent needs it.
 
-> **Looking for the `+ agent` import file?** If you got here from the dashboard's **+ agent → Import from URL** overlay (the [`customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v2/v2/examples/agents/customized-agent.yaml) example), that file is the *portable* `kind: AgentDefinition` format — `apiVersion`/`kind`/`metadata`/`spec` with camelCase keys. This page documents the inline `hive.yaml` `agents:` form (snake_case). For a field-by-field reference of the import file itself, see the **[AgentDefinition YAML Reference](agent-definition-yaml.md)**.
+> **Looking for the `+ agent` import file?** If you got here from the dashboard's **+ agent → Import from URL** overlay (the [`customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v4/v2/examples/agents/customized-agent.yaml) example), that file is the *portable* `kind: AgentDefinition` format — `apiVersion`/`kind`/`metadata`/`spec` with camelCase keys. This page documents the inline `hive.yaml` `agents:` form (snake_case). For a field-by-field reference of the import file itself, see the **[AgentDefinition YAML Reference](agent-definition-yaml.md)**.
 
 ## The smallest agent that works
 
@@ -232,7 +232,7 @@ At L5, every agent PR gets a `hold` label automatically. The system proposes; it
 
 Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM pack's template for that agent at the current level; otherwise convention — `/data/agents/<name>/CLAUDE.md`, then `<name>.md` in the policies checkout, then the embedded default. Pack templates carry the level's policy in their names — `scanner-holdgated.md` is scanner-at-L5; the same scanner at L6 gets `scanner-automerge.md`.
 
-Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard (see [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v2/v2/examples/agents/customized-agent.yaml)). This is the format the dashboard's **+ agent → Import from URL** overlay reads. For a field-by-field reference of that file — every `metadata` and `spec` key, its type, default, and options — see the **[AgentDefinition YAML Reference](agent-definition-yaml.md)**.
+Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard (see [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v4/v2/examples/agents/customized-agent.yaml)). This is the format the dashboard's **+ agent → Import from URL** overlay reads. For a field-by-field reference of that file — every `metadata` and `spec` key, its type, default, and options — see the **[AgentDefinition YAML Reference](agent-definition-yaml.md)**.
 
 ## When to add what
 
@@ -258,4 +258,4 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 - **[Architecture](architecture.md)** — the two scheduling models and how the supervisor drives agents.
 - **[macOS Setup](macos.md)** — run a hive locally.
 - **[Troubleshooting](troubleshooting.md)** — stuck sessions, login expiry, restart loops.
-- **[ACMM policy matrix](https://github.com/kubestellar/hive/blob/v2/v2/docs/acmm-policy-matrix.md)** — the full per-level, per-agent policy table in the hive repo.
+- **[ACMM policy matrix](https://github.com/kubestellar/hive/blob/v4/v2/docs/acmm-policy-matrix.md)** — the full per-level, per-agent policy table in the hive repo.

--- a/docs/content/hive/agent-definition-yaml.md
+++ b/docs/content/hive/agent-definition-yaml.md
@@ -2,9 +2,9 @@
 
 **The `AgentDefinition` YAML is hive's *portable* agent format — a single, self-contained document (`kind: AgentDefinition`) that describes one whole agent: its identity, its engine, its behavior, and even its work prompt. This is the file the dashboard's `+ agent → Import from URL` overlay points you at, and it is exactly the schema that overlay reads. This page documents every field, grouped to match the file's structure.**
 
-If you clicked **+ agent** in the dashboard and were sent to [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v2/v2/examples/agents/customized-agent.yaml) for an example, this is the reference for that file. For the *other* way agents are configured — inline entries under `agents:` in `hive.yaml`, using snake_case keys — see [Agent Configuration](agent-configuration.md). The two describe the same underlying agent; they differ only in shape and casing (see [How this maps to `hive.yaml`](#how-this-maps-to-hiveyaml) below).
+If you clicked **+ agent** in the dashboard and were sent to [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v4/v2/examples/agents/customized-agent.yaml) for an example, this is the reference for that file. For the *other* way agents are configured — inline entries under `agents:` in `hive.yaml`, using snake_case keys — see [Agent Configuration](agent-configuration.md). The two describe the same underlying agent; they differ only in shape and casing (see [How this maps to `hive.yaml`](#how-this-maps-to-hiveyaml) below).
 
-> **Which Hive does this document?** This page tracks the **Hive `v2` line** — the same line the dashboard, the `+ agent` overlay, and the example YAML come from. Hive's docs site currently publishes a single **main (Latest)** channel; there is no separate `v2` entry in the version selector even though the example file lives on the repo's `v2` branch. If a dashboard link sends you to `.../blob/v2/v2/examples/...`, that doubled `v2` is *branch* `v2` plus the in-repo *path* `v2/examples/...`, not a typo — it is the current, supported example.
+> **Which Hive does this document?** This page tracks the current **Hive `v4` branch** — the only maintained line (the `v2` branch was retired in August 2026). If a dashboard link sends you to `.../blob/v4/v2/examples/...`, that is *branch* `v4` plus the in-repo *path* `v2/examples/...` (the directory kept its historical name), not a typo — it is the current, supported example.
 
 ## The document envelope
 
@@ -187,7 +187,7 @@ spec:
 | `match` | map | required for `bead` | Match criteria that fire a `bead` channel. |
 | `repos` | list of string | optional | Restrict the channel to specific repositories. |
 
-> **Note:** Channels are a **current, supported v2 feature.** (Older copies of the example labeled this `(v3 feature)`; that label is being removed — treat channels as available today.)
+> **Note:** Channels are a **current, supported feature.** (Older copies of the example labeled this `(v3 feature)`; that label is being removed — treat channels as available today.)
 
 ### `tools` — declarative tool permissions
 
@@ -211,7 +211,7 @@ spec:
 | `rules[].action` | string | **required** | `allow` or `deny`. An explicit `allow` overrides a preset `deny` for the same pattern. |
 | `rules[].reason` | string | optional | Human-readable justification, shown for auditing. |
 
-> **Note:** Tools are a **current, supported v2 feature.**
+> **Note:** Tools are a **current, supported feature.**
 
 ### `connections` — external service integrations
 
@@ -234,11 +234,11 @@ spec:
 | `env_name` | string | optional | Environment variable name to expose to the connection. |
 | `options` | map | optional | Free-form string options passed to the connection. |
 
-> **Note:** Connections are a **current, supported v2 feature.**
+> **Note:** Connections are a **current, supported feature.**
 
 ## Complete annotated example
 
-This mirrors the shipped [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v2/v2/examples/agents/customized-agent.yaml). Import it from the dashboard via **+ agent → Import from URL**, or copy it as a starting point and edit the fields above.
+This mirrors the shipped [`v2/examples/agents/customized-agent.yaml`](https://github.com/kubestellar/hive/blob/v4/v2/examples/agents/customized-agent.yaml). Import it from the dashboard via **+ agent → Import from URL**, or copy it as a starting point and edit the fields above.
 
 ```yaml
 apiVersion: hive.kubestellar.io/v1
@@ -268,7 +268,7 @@ spec:
   aliases:                               # short dispatch names
     - cu
 
-  # Channels — how this agent gets triggered (supported v2 feature).
+  # Channels — how this agent gets triggered (supported feature).
   # Omit to use governor timer kicks only.
   # channels:
   #   - type: kick
@@ -277,7 +277,7 @@ spec:
   #   - type: schedule
   #     schedule: "0 */4 * * *"
 
-  # Tools — declarative tool permissions (supported v2 feature).
+  # Tools — declarative tool permissions (supported feature).
   # Present = governs instead of `mode`.
   # tools:
   #   preset: advisory
@@ -286,7 +286,7 @@ spec:
   #       action: allow
   #       reason: "allow creating advisory issues"
 
-  # Connections — external service integrations (supported v2 feature).
+  # Connections — external service integrations (supported feature).
   # connections:
   #   - name: github-mcp
   #     type: mcp

--- a/docs/content/hive/architecture.md
+++ b/docs/content/hive/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-## Hive v2 (current)
+## Hive v4 (current)
 
-Hive v2 runs as a **single container with three processes**:
+Hive (branch `v4` — the only maintained line since the `v2` branch was retired in August 2026; the code still lives under the repo's `v2/` directory) runs as a **single container with three processes**:
 
 - **Go binary** (`hive`) — orchestrates agent tmux sessions, runs the governor eval loop, serves the dashboard API, manages health checks and token tracking
 - **Node.js proxy** — reverse proxy for the dashboard frontend with SSE streaming
@@ -12,7 +12,7 @@ Agents run inside tmux sessions managed by the Go binary, each under its own Uni
 
 All configuration lives in a single `hive.yaml`; persistent state (metrics, beads, logs, dashboard config overlay) lives on a PVC at `/data`. Agents talk to their backend via per-agent CLI processes — Claude, Copilot, Gemini, Goose — or, for self-hosted inference backends (litellm / vllm / llm-d), via an in-process Anthropic-to-OpenAI translator.
 
-Hives can register with the **Hive Hub** (`hive.kubestellar.io`): the hub authenticates dashboard users with GitHub OAuth, proxies spoke dashboards, receives authenticated heartbeats (health, version, token counts), and can provision fully hosted hives — one namespace, pod, and PVC per hive, with zero-downtime rolling upgrades.
+Hives can register with the **Hive Hub** (`hive.kubestellar.io`): the hub authenticates dashboard users with multi-provider human login — GitHub and Google are live, with IBMid, Red Hat, Microsoft Entra ID, and generic OIDC available via configuration — proxies spoke dashboards, receives authenticated heartbeats (health, version, token counts), and can provision fully hosted hives — one namespace, pod, and PVC per hive, with zero-downtime rolling upgrades.
 
 See the [Introduction](readme.md) for deployment options and configuration reference.
 
@@ -20,7 +20,7 @@ See the [Introduction](readme.md) for deployment options and configuration refer
 
 ## Legacy v1 runtime: supervision patterns
 
-> **Note:** the rest of this page documents the original **v1 runtime** — shell scripts driven by systemd/launchd on a host, with agents supervised in tmux (`hive supervisor`, `/etc/hive/*.env`). The v1 tooling still exists in the repository root, but v2 (above) is the current, recommended way to run hive. The supervision patterns below remain useful reading if you run agents outside the v2 container.
+> **Note:** the rest of this page documents the original **v1 runtime** — shell scripts driven by systemd/launchd on a host, with agents supervised in tmux (`hive supervisor`, `/etc/hive/*.env`). The v1 tooling still exists in the repository root, but the containerized runtime above is the current, recommended way to run hive. The supervision patterns below remain useful reading if you run agents outside the container.
 
 ## Two scheduling models
 

--- a/docs/content/hive/backup-dr.md
+++ b/docs/content/hive/backup-dr.md
@@ -1,0 +1,39 @@
+# Backup and Disaster Recovery
+
+Hive has two backup paths with different scopes: nightly encrypted hub disaster-recovery archives, and on-demand per-spoke backups an owner can download from the dashboard. Canonical operator docs live in the hive repo: [`v2/docs/backup-restore.md`](https://github.com/kubestellar/hive/blob/v4/v2/docs/backup-restore.md) and [`docs/HUB_DISASTER_RECOVERY.md`](https://github.com/kubestellar/hive/blob/v4/docs/HUB_DISASTER_RECOVERY.md).
+
+## Hub disaster recovery: `hive-backup`
+
+The `hive-backup` tool builds an encrypted archive of everything needed to rebuild a hub:
+
+- hub SaaS state under `/data/saas/**` (users, hive records, keys) and the fleet registry;
+- four named hub Kubernetes Secrets — a missing `hive-hub-secrets`, `oci-api-key`, or `hive-hub-kubeconfigs` fails the backup, while a missing `hive-hub-tls` only warns (cert-manager can reissue it);
+- each spoke's authoritative config files and GitHub App keys, read via `kubectl exec`; spokes that could not be read are recorded honestly in `MANIFEST.json` under `spoke_errors` rather than silently dropped.
+
+Regenerable bulk state (knowledge caches, home dirs, bead ledgers, logs) is deliberately excluded so a nightly fleet backup stays small and restorable.
+
+The archive is sealed with AES-256-GCM. Every run re-downloads and verifies the upload before pruning old archives — a run that cannot self-verify fails rather than reporting a good backup.
+
+## The `HIVE_BACKUP_KEY` escrow gate
+
+`HIVE_BACKUP_KEY` (a 64-character hex or base64 AES-256 key) has **no default** — an unset key aborts the run rather than writing plaintext. It is deliberately independent of the hub's own key material, because those keys are themselves backup *payload*: deriving the backup key from them would make the archive undecryptable in exactly the disaster it exists for.
+
+> **Escrow the key outside the cluster.** A backup encrypted by a key that only exists in the lost cluster is not recoverable.
+
+## The backup CronJob is opt-in
+
+`v2/deploy/k8s/backup-cronjob.yaml` runs the hub DR path nightly — but it is **not deployed by default**: it is deliberately excluded from the kustomization, and deploying it is an explicit `kubectl apply -f` gated on the operator first creating the `hive-hub-backup-key` Secret with the escrowed key. What the manifest creates:
+
+- a ServiceAccount with **minimal RBAC**: a namespaced Role granting `get` (only) on exactly the four named Secrets above, plus a ClusterRole limited to `pods [get,list]` and `pods/exec [create]` ([hive#3719](https://github.com/kubestellar/hive/pull/3719), [hive#3810](https://github.com/kubestellar/hive/pull/3810));
+- a daily CronJob running `ghcr.io/kubestellar/hive:stable` — the backup image tracks the stable [release channel](release-channels.md);
+- a ConfigMap with the object-storage bucket and retention (default: keep 30 archives).
+
+Archives upload to OCI Object Storage; remember to allow egress to `objectstorage.<region>.oraclecloud.com` from the hub.
+
+## Restore
+
+`hive-backup verify -file <archive>` checks integrity (the GCM auth tag rejects wrong keys and bit-flips); `hive-backup extract -file <archive> -dest ./restore` decrypts into a directory and verifies hashes — it never mutates a live cluster. A restore operator inspects the extracted `MANIFEST.json`, re-applies the captured Secret JSON, copies hub files back to the hub PVC, and recreates or patches spokes from the per-spoke directories.
+
+## Owner-triggered spoke backup
+
+Complementary to hub DR: a hive owner can download an encrypted backup of one spoke from the dashboard (config, identity, GitHub App keys, state, and the bead ledger — sized for browser download, not fleet DR). It uses the same `HIVE_BACKUP_KEY` mechanism and is owner-only (`only the owner can back up this hive`).

--- a/docs/content/hive/contributor-relay.md
+++ b/docs/content/hive/contributor-relay.md
@@ -82,7 +82,7 @@ Visit **`https://<hive-dashboard>/contribute`** — every hive serves a landing 
 
 ```bash
 brew install just gh
-git clone -b v2 https://github.com/kubestellar/hive && cd hive
+git clone -b v4 https://github.com/kubestellar/hive && cd hive
 export HIVE_HUB=wss://<hive-host>/contribute
 just contribute-setup claude     # one-time: register + authenticate GitHub + your CLI
 just contribute-hive             # start contributing (Docker, recommended)

--- a/docs/content/hive/governor.md
+++ b/docs/content/hive/governor.md
@@ -56,7 +56,7 @@ Inside each mode block, every entry other than `threshold` is a **cadence** for 
 - An agent with no entry for the current mode is not kicked in that mode.
 - Cadences are independent per mode, so an agent can be busy in `surge` and slow in `idle`.
 
-An agent is **due** for a kick when the time since its last kick is at least its cadence interval. At startup every eligible agent is kicked once so the hive doesn't idle waiting out a full cadence.
+An agent is **due** for a kick when the time since its last kick is at least its cadence interval. Last-kick times are persisted (in `/data/hive-state.json`) and honored across container/pod restarts, so a Deployment roll does **not** re-kick every agent at boot ([#3817](https://github.com/kubestellar/hive/pull/3817)) — only agents whose cadence has actually elapsed are kicked on the first eval. A fresh install with no persisted state still kicks every eligible agent once so the hive doesn't idle waiting out a full cadence.
 
 ### Pausing an agent in a mode
 

--- a/docs/content/hive/hivectl.md
+++ b/docs/content/hive/hivectl.md
@@ -9,7 +9,7 @@ Everything `hivectl` does is a thin wrapper over the dashboard's existing HTTP A
 ## Quick start
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive && cd hive/v2
+git clone -b v4 https://github.com/kubestellar/hive && cd hive/v2
 go build -o bin/hivectl ./cmd/hivectl
 
 # Point at a server (default: http://127.0.0.1:3001) and provide the token

--- a/docs/content/hive/macos.md
+++ b/docs/content/hive/macos.md
@@ -1,6 +1,6 @@
 # macOS Support (launchd)
 
-> **Note:** on **hive v2** the easiest way to run on macOS is Docker Compose — `cd hive/v2 && docker compose up -d` (see the [Introduction](readme.md)). This page documents the legacy **v1** host runtime mapped to launchd, which remains useful if you want to supervise agents natively on a Mac without a container.
+> **Note:** on the current containerized hive the easiest way to run on macOS is Docker Compose — `cd hive/v2 && docker compose up -d` (see the [Introduction](readme.md)). This page documents the legacy **v1** host runtime mapped to launchd, which remains useful if you want to supervise agents natively on a Mac without a container.
 
 The hive v1 runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
 

--- a/docs/content/hive/manual-provisioning.md
+++ b/docs/content/hive/manual-provisioning.md
@@ -146,7 +146,7 @@ CTX=vllm-d
 ID=hosted-myorg-myrepo          # the hive ID
 NS=hive-hosted-$ID              # namespace is always hive-hosted-<id>
 ROUTE_HOST=$ID.apps.fmaas-vllm-d.fmaas.res.ibm.com
-IMAGE=ghcr.io/kubestellar/hive:v2-latest
+IMAGE=ghcr.io/kubestellar/hive:stable   # the stable release channel; or v4-latest / a pinned digest
 SC=ocs-storagecluster-cephfs
 
 # The hub heartbeat secret — the SAME for every spoke on a given hub. Copy it

--- a/docs/content/hive/overview/intro.md
+++ b/docs/content/hive/overview/intro.md
@@ -13,7 +13,7 @@ Hive separates decisions into two layers: a **deterministic pipeline** of shell 
 ## Quick Start (Docker Compose)
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive.git
+git clone -b v4 https://github.com/kubestellar/hive.git
 cd hive/v2
 
 cp hive.yaml.example hive.yaml
@@ -21,7 +21,7 @@ export HIVE_GITHUB_TOKEN=ghp_...
 docker compose up -d
 ```
 
-Dashboard at `http://localhost:3001`. The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`; run `docker compose build` first to build from source instead.
+Dashboard at `http://localhost:3001`. The default `docker-compose.yaml` uses a pre-built image; run `docker compose build` first to build from source instead, or point it at the `stable` release channel image `ghcr.io/kubestellar/hive:stable` (see [Release Channels](../release-channels.md)).
 
 ---
 
@@ -225,7 +225,7 @@ Community members can contribute compute to any registered hive:
 
 ```bash
 brew install just gh
-git clone -b v2 https://github.com/kubestellar/hive && cd hive
+git clone -b v4 https://github.com/kubestellar/hive && cd hive
 just contribute-setup claude
 just contribute-hive
 ```

--- a/docs/content/hive/readme.md
+++ b/docs/content/hive/readme.md
@@ -13,7 +13,7 @@ Hive separates decisions into two layers: a **deterministic pipeline** of shell 
 ## Quick Start (Docker Compose)
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive.git
+git clone -b v4 https://github.com/kubestellar/hive.git
 cd hive/v2
 
 cp hive.yaml.example hive.yaml
@@ -21,7 +21,7 @@ export HIVE_GITHUB_TOKEN=ghp_...
 docker compose up -d
 ```
 
-Dashboard at `http://localhost:3001`. The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`; run `docker compose build` first to build from source instead.
+Dashboard at `http://localhost:3001`. The default `docker-compose.yaml` uses a pre-built image; run `docker compose build` first to build from source instead, or point it at the `stable` release channel image `ghcr.io/kubestellar/hive:stable` (see [Release Channels](release-channels.md)).
 
 ---
 
@@ -225,7 +225,7 @@ Community members can contribute compute to any registered hive:
 
 ```bash
 brew install just gh
-git clone -b v2 https://github.com/kubestellar/hive && cd hive
+git clone -b v4 https://github.com/kubestellar/hive && cd hive
 just contribute-setup claude
 just contribute-hive
 ```

--- a/docs/content/hive/release-channels.md
+++ b/docs/content/hive/release-channels.md
@@ -1,0 +1,69 @@
+# Release Channels
+
+Hive publishes three **release channels** — moving GHCR image tags an operator can point a hive at instead of a branch tag:
+
+| Channel | Intended meaning |
+|---|---|
+| `stable` | Newest build promoted as generally safe to run. |
+| `candidate` | A build believed good, awaiting soak before promotion to stable. |
+| `edge` | The newest good build, with no soak period. |
+
+> **Note — current promotion policy:** today all three channels are retagged on **every merge to `v4`**, so `stable`, `candidate`, and `edge` all point at the same digest as `v4-latest`. The distinct meanings above take effect only once a soak/promotion policy lands in CI (see [#3702](https://github.com/kubestellar/hive/pull/3702)). Treat the channel names as forward-looking track selection, not as a guarantee of differing maturity yet.
+
+## How channels are published
+
+Channels are **retags, not rebuilds**. The `docker.yml` workflow adds `stable`, `candidate`, and `edge` as extra tags in the same `docker buildx imagetools create` call that publishes `v4-latest` and the immutable short-SHA tag, so a channel always points at an already-built, multi-arch digest. All three images get all three channels:
+
+- `ghcr.io/kubestellar/hive`
+- `ghcr.io/kubestellar/hive-contributor`
+- `ghcr.io/kubestellar/hive-hub`
+
+Only builds of branch `v4` publish channels — a feature-branch build can never move a production channel.
+
+## Switching a hive to a channel
+
+From the hub dashboard's **My Hives** list, click the blue version pill on a hive row. The menu lists branches first, then a **Channels** section with the three channels (most stable first). Only the hive's **owner** can switch.
+
+Under the hood this is the same endpoint as a branch switch — the channel name goes in the `branch` field verbatim:
+
+```
+POST /api/saas/hives/{id}/switch-branch
+{"branch": "stable"}
+```
+
+The hive's image is set to `ghcr.io/kubestellar/hive:stable` (via kubectl for reachable hosted spokes, or delivered on the next heartbeat otherwise). The switch is considered complete when the spoke's heartbeat reports an image ref whose tag matches the channel ([#3761](https://github.com/kubestellar/hive/pull/3761)).
+
+Because a channel tag is a moving (mutable) tag, a channel-tracking hive gets the same floating-tag auto-upgrade treatment as a `-latest` branch tag: upgrades roll the pod but keep the `:stable` image string rather than pinning a SHA ([#3757](https://github.com/kubestellar/hive/pull/3757)).
+
+## The version pill: `stable (v4)`
+
+A channel is a moving pointer, so the dashboard shows what it currently points at. The pill on a channel-tracking hive reads, for example:
+
+- `stable (v4)` — the channel currently resolves to a build of branch `v4`;
+- `stable (49e53e6)` — the channel resolves to a digest the hub could not attribute to a tracked branch (short digest shown);
+- `stable (?)` — the channel tag could not be resolved on GHCR at all.
+
+Resolution is live: the hub HEADs the GHCR manifests for each tracked branch's `-latest` tag and each channel tag, and matches digests ([#3742](https://github.com/kubestellar/hive/pull/3742)). Results are cached for 5 minutes; an unresolved refresh is never cached, so a transient GHCR blip retries on the next poll rather than latching `unknown` for the TTL ([#3721](https://github.com/kubestellar/hive/pull/3721)). If channel rows render as `unknown`, grep the hub log for `channel resolve:` — each failure path logs a WARN naming the cause (token failure, 401/403 package permission, 404 tag never published).
+
+The **My Hives** page also shows a `Release channels:` block above the per-branch `Latest available images:` rows, mapping each channel to its currently resolved branch/digest.
+
+## Persistence: the tracked channel is durable
+
+The hive's tracked channel is stored hub-side in the per-hive metadata record (`tracked_channel` in `/data/saas/hives/<hive-id>/meta.json`, on the hub PVC). It is set when you switch to a channel and cleared when you switch to a plain branch. Two failure modes are specifically handled:
+
+- **Heartbeats do not erase it.** A channel image is a build of `v4`, so the spoke heartbeats `git_branch=v4`; the pill overlays the persisted channel at read time instead of trusting the reported branch ([#3750](https://github.com/kubestellar/hive/pull/3750)).
+- **Hub restarts do not drop an in-flight switch.** The in-memory switch instruction is re-armed from the persisted record on the next heartbeat, as long as the spoke is not mid-upgrade and its reported image tag differs from the tracked channel ([#3771](https://github.com/kubestellar/hive/pull/3771)). This also self-heals a hive whose delivered upgrade drifted it off the channel tag.
+
+## Spoke navbar badge
+
+A spoke running a channel image shows the channel in its own dashboard version badge — `stable (v4)` — with the tooltip `Tracking release channel stable (currently a v4 build)` ([#3762](https://github.com/kubestellar/hive/pull/3762)). The spoke learns its channel by reading its own Deployment's image tag via the in-cluster API; a spoke that cannot read its Deployment (for example a plain docker run) shows only the branch badge.
+
+## Known limitations
+
+- **Bulk actions cannot set a channel.** The bulk *Switch branch* action validates against real branches only and rejects channel names (`unknown branch`); it also never writes the tracked channel. Switching to a channel is per-hive.
+- **A manual Upgrade on a channel-tracking hive transiently arms a branch-SHA target.** The upgrade handler targets the tracked *branch*'s latest SHA; the heartbeat re-arm drags the hive back to the channel tag on the next non-upgrading beat. Expect a short window where the pill says `stable (v4)` while an upgrade converges on a SHA.
+- **"Behind" / drift comparison keys on the branch, not the channel digest.** A channel-tracking hive's up-to-date math still compares against its underlying branch head.
+
+## Grouping hives by upgrade state
+
+The My Hives **GROUP BY** selector includes an `Upgrade state` dimension ([#3805](https://github.com/kubestellar/hive/pull/3805)) with three buckets: `Queued (ready, not yet upgrading)` (auto-upgrade on and a target armed), `Upgrading`, and `Up to date`. Note that `Queued` requires auto-upgrade to be enabled — a hive that is behind latest with auto-upgrade off sorts under `Up to date`.

--- a/docs/content/hive/release-channels.md
+++ b/docs/content/hive/release-channels.md
@@ -26,7 +26,7 @@ From the hub dashboard's **My Hives** list, click the blue version pill on a hiv
 
 Under the hood this is the same endpoint as a branch switch — the channel name goes in the `branch` field verbatim:
 
-```
+```text
 POST /api/saas/hives/{id}/switch-branch
 {"branch": "stable"}
 ```

--- a/docs/content/hive/security-model.md
+++ b/docs/content/hive/security-model.md
@@ -2,7 +2,7 @@
 
 This page is for the evaluator asking: *is it safe to run hive — to host a hive on the hub, point agents at my repositories, and hand the system my AI subscription or API keys?*
 
-Hive's answer is architectural, not aspirational. The project's core design rule — *if a human would give the same answer every time, it belongs in infrastructure, not in a prompt* — applies doubly to security: the controls below are enforced by code (authentication middleware, a policy proxy, scoped tokens, file permissions), not by asking an LLM to behave. Every mechanism described here is verifiable in the [hive v2 source](https://github.com/kubestellar/hive/tree/v2).
+Hive's answer is architectural, not aspirational. The project's core design rule — *if a human would give the same answer every time, it belongs in infrastructure, not in a prompt* — applies doubly to security: the controls below are enforced by code (authentication middleware, a policy proxy, scoped tokens, file permissions), not by asking an LLM to behave. Every mechanism described here is verifiable in the [hive source](https://github.com/kubestellar/hive/tree/v4) (branch `v4`, the only maintained line).
 
 ## What hive touches
 
@@ -22,7 +22,7 @@ The threats that matter: an unauthorized person reaching your dashboard, an agen
 
 Hives hosted on or registered with the [Hive Hub](https://hive.kubestellar.io) are reached through `*.hive.kubestellar.io`, and every request passes the hub's authentication check before it reaches a spoke dashboard:
 
-- **GitHub OAuth.** Users sign in to the hub with GitHub (`read:user` scope). The session cookie is `HttpOnly`, `Secure`, `SameSite=Lax`.
+- **Multi-provider sign-in.** Users sign in to the hub with GitHub OAuth (`read:user` scope) or Google — with IBMid, Red Hat, Microsoft Entra ID, and a generic OIDC provider available via configuration ([hive#3664](https://github.com/kubestellar/hive/pull/3664)). With more than one provider configured, `/login` shows a provider picker. The session cookie is `HttpOnly`, `Secure`, `SameSite=Lax`, and session cookies are **Ed25519-signed** — the legacy symmetric (HMAC) session lane was deleted on v4 ([hive#3725](https://github.com/kubestellar/hive/pull/3725)).
 - **Per-user, per-hive authorization on every request.** The hub's auth-check endpoint (wired as an nginx `auth_request`) resolves the requesting user, looks up whether that specific hive is in the user's access map, and returns **403 if it isn't**. Only then does the request proceed to the spoke.
 - **Identity injection.** On success, the hub injects the verified identity into the proxied request as `X-Hive-User` and `X-Hive-Role` headers. The spoke's role-enforcement middleware then blocks all write operations for `read`-role users.
 - **Roles.** The hive owner has full read-write control. Owners can grant other GitHub users access to their hive; grants default to **read-only**. A grant can never confer a role equal to or higher than the granter's own.
@@ -72,7 +72,7 @@ What can agents actually do to your repositories? As little as you've dialed in:
 
 Registered hives send periodic heartbeats to the hub:
 
-- Heartbeats are authenticated with a bearer secret (`HIVE_HUB_SECRET`, provisioned by the hub) and validated with a constant-time comparison.
+- Heartbeats are authenticated with a **per-hive** bearer key derived from the hub master secret (`HIVE_HEARTBEAT_KEY`, reconciled onto hosted spokes; self-hosted spokes derive it from `HIVE_HUB_SECRET` + `HIVE_ID`), validated with a constant-time comparison. The old fleet-wide shared bearer lane was removed ([hive#3744](https://github.com/kubestellar/hive/pull/3744)).
 - The outbound payload carries operational telemetry only: health and cluster metrics, version/git info, agent and governor summaries, and 24-hour **token counts**. No API keys, GitHub tokens, or other credentials leave the spoke in heartbeats.
 - The response channel is how the hub delivers configuration to hives it manages (including GitHub App credentials for hub-provisioned hives) — hub-to-spoke, never spoke-to-hub.
 
@@ -87,13 +87,26 @@ On the hosted platform, each hive is single-tenant by construction:
 
 ---
 
+## Layer 8 — Key material, rotation, and the egress gate (v4)
+
+The v4 line hardened the key and network layer; the full operator guide is [`v2/docs/security-model.md`](https://github.com/kubestellar/hive/blob/v4/v2/docs/security-model.md) in the hive repo. The evaluator-relevant facts:
+
+- **Ed25519-only sessions and SSO.** Hub-issued session cookies and the hub-to-spoke SSO handoff verify against Ed25519 public keys only; there is no symmetric fallback. A spoke missing its verification key fails closed (an explanatory 503 page, with direct login still available).
+- **Per-hive derived keys.** Heartbeat, session, SSO, terminal, and invite keys are derived per hive from the hub master; the hub reconciles them onto hosted spokes automatically. A self-hosted spoke needs only `HIVE_HUB_SECRET` + `HIVE_ID` (or the individual keys, for least privilege).
+- **Master key rotation with dual-generation acceptance.** The hub keeps at most two live key generations (current + previous, 7-day verify window); session cookies, heartbeat bearers, and SSO public keys verify against both during rotation ([hive#3763](https://github.com/kubestellar/hive/pull/3763), [hive#3767](https://github.com/kubestellar/hive/pull/3767), [hive#3778](https://github.com/kubestellar/hive/pull/3778)). Rotation is admin-triggered and converges the fleet over hours, with loud alerts for spokes stranded past the window.
+- **Forced-proxy egress (`CAP_NET_ADMIN`).** The container entrypoint installs an iptables redirect of all outbound `:443` through the policy proxy, so the ACMM capability model is enforced at the network layer, not advisorily. Spokes therefore need `NET_ADMIN` (`--cap-add NET_ADMIN` on docker/podman, `securityContext.capabilities.add: ["NET_ADMIN"]` on Kubernetes); without it the entrypoint refuses to start unless you explicitly opt into advisory-only mode (`HIVE_PROXY_ADVISORY_OK=true`). The binary itself carries no file capabilities — earlier images crash-looped with a bare `Operation not permitted` on capability-less runtimes; since [hive#3794](https://github.com/kubestellar/hive/pull/3794) the capability is raised ambiently at startup instead ([hive#3760](https://github.com/kubestellar/hive/issues/3760)).
+- **Supply chain.** Base images are digest-pinned, bundled tools are checksum-pinned, global AI-CLI npm installs run with `--ignore-scripts`, and `su-exec` is restricted (mode `4750`, launcher group only) so no agent UID can escalate to root in the pod.
+- **Metrics fail closed.** The optional Prometheus `/metrics` endpoint (`HIVE_METRICS_ENABLED`) exposes estimated-cost series and **requires** a bearer token (`HIVE_METRICS_TOKEN`); enabled-but-tokenless serves 403, never the data ([hive#3804](https://github.com/kubestellar/hive/pull/3804)).
+
+---
+
 ## Scope and limitations, stated plainly
 
 Security documentation that only lists strengths is marketing. The current, deliberate scoping:
 
 - **Direct-route write grants are deferred.** Non-owner grants on direct-route spokes are always provisioned read-only, even if granted read-write on the hub. This fails safe (under-granting, never over-granting) until per-user write credentials land.
-- **The heartbeat secret is hub-wide.** `HIVE_HUB_SECRET` authenticates spokes to the hub as a class, not per-hive. Heartbeat data is operational telemetry, not secrets, which bounds the impact.
-- **The policy proxy covers GitHub API traffic.** It is a GitHub-policy enforcement point, not a general egress firewall. If you need full egress control, apply Kubernetes NetworkPolicies around the hive pod.
+- **Rootless containers cannot enforce the egress gate.** The forced-proxy egress redirect needs `CAP_NET_ADMIN` + iptables; a rootless podman spoke only starts with `HIVE_PROXY_ADVISORY_OK=true`, i.e. with network-layer enforcement advisory-only.
+- **The policy proxy inspects GitHub API traffic.** All outbound `:443` is force-redirected through it (see the egress gate below), but non-GitHub destinations are tunneled without inspection — it is a GitHub-policy enforcement point, not a content firewall for arbitrary hosts. If you need full egress control, apply Kubernetes NetworkPolicies around the hive pod.
 - **The L5 `hold` label is applied by agent policy;** the hard guarantee at L5 is the withheld merge permission (token tier + proxy rules), not the label itself.
 - **Cloud CLI credentials are shared with the CLI.** Claude/Copilot/Gemini/Goose agents necessarily run with the provider credential you connected. The placeholder-key isolation applies to inference-gateway keys.
 - **DCO is policy-driven** inside hive; enforce it repo-side (DCO check) for a hard guarantee.

--- a/docs/content/hive/troubleshooting.md
+++ b/docs/content/hive/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-> **Note:** most of this page covers the legacy **v1 runtime** (systemd/launchd host installs with `/etc/hive/agent.env`). On **v2**, start with the dashboard instead: the Getting Started dialog auto-checks setup steps, **Test Connection** live-probes inference gateways and reports the gateway's actual error, agent cards show live state, and the built-in web terminal (ttyd) gives direct access to agent tmux sessions. Check container logs with `docker compose logs -f` or `kubectl -n hive logs deploy/hive`.
+> **Note:** most of this page covers the legacy **v1 runtime** (systemd/launchd host installs with `/etc/hive/agent.env`). On the **current containerized runtime (v4)**, start with the dashboard instead: the Getting Started dialog auto-checks setup steps, **Test Connection** live-probes inference gateways and reports the gateway's actual error, agent cards show live state, and the built-in web terminal (ttyd) gives direct access to agent tmux sessions. Check container logs with `docker compose logs -f` or `kubectl -n hive logs deploy/hive`.
 
 ## An agent card shows "needs login"
 
@@ -16,7 +16,7 @@ sudo -u "$AGENT_USER" tmux kill-session -t "$AGENT_SESSION_NAME"
 sudo systemctl start hive
 ```
 
-This forces a fresh session (see "`systemctl restart hive` didn't pick up my new `AGENT_LOOP_PROMPT`" below for why a plain `systemctl restart` isn't enough). On v2, you can instead recreate the agent's container/pod (`docker compose restart <service>` or `kubectl -n hive rollout restart deploy/hive`) to get the same effect.
+This forces a fresh session (see "`systemctl restart hive` didn't pick up my new `AGENT_LOOP_PROMPT`" below for why a plain `systemctl restart` isn't enough). On the containerized runtime, you can instead recreate the agent's container/pod (`docker compose restart <service>` or `kubectl -n hive rollout restart deploy/hive`) to get the same effect.
 
 If the agent goes straight back to "needs login" after a restart, the credentials themselves are the problem (expired token, revoked API key, or an account-level sign-out) — re-authenticate the CLI for `$AGENT_USER` outside of the tmux session first (e.g. `sudo -u "$AGENT_USER" claude /login` from a real interactive terminal you control), then restart the agent as above so it picks up the refreshed session.
 

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -327,43 +327,30 @@ const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
     items: [
       { 'Introduction': 'readme.md' },
       { 'Architecture': 'architecture.md' },
-      { 'Roadmap': 'roadmap.md' },
-      { 'Landscape and Positioning': 'landscape.md' },
     ]
   },
   {
     title: 'Security',
     items: [
-      { 'Threat Model': 'security-threat-model.md' },
-      {
-        'Architecture Decision Records': [
-          { 'ADR Index': 'adr/readme.md' },
-          { '0001: Record architecture decisions': 'adr/0001-record-architecture-decisions.md' },
-          { '0002: MITM proxy network enforcement': 'adr/0002-mitm-proxy-network-enforcement.md' },
-          { '0003: ACMM autonomy levels': 'adr/0003-acmm-autonomy-levels.md' },
-          { '0004: Beads work ledger': 'adr/0004-beads-work-ledger.md' },
-          { '0005: Forge abstraction': 'adr/0005-forge-abstraction.md' },
-          { '0006: Planning intelligence': 'adr/0006-planning-intelligence.md' },
-          { '0007: Token mint': 'adr/0007-token-mint.md' },
-          { '0008: IOScan untrusted input': 'adr/0008-ioscan-untrusted-input.md' },
-          { '0009: Trajectory review': 'adr/0009-trajectory-review.md' },
-          { '0010: Escalation circuit breaker': 'adr/0010-escalation-circuit-breaker.md' },
-          { '0011: Knowledge graph': 'adr/0011-knowledge-graph.md' },
-          { '0012: Skill registry': 'adr/0012-skill-registry.md' },
-          { '0013: CEL triggers': 'adr/0013-cel-triggers.md' },
-          { '0014: Hub/spoke': 'adr/0014-hub-spoke.md' },
-        ]
-      },
+      { 'Security Model': 'security-model.md' },
     ]
   },
   {
     title: 'Operations',
     items: [
       { 'Agent Configuration': 'agent-configuration.md' },
+      { 'Agent Definition YAML': 'agent-definition-yaml.md' },
+      { 'Variable Substitution': 'variable-substitution.md' },
+      { 'Governor': 'governor.md' },
+      { 'Release Channels': 'release-channels.md' },
+      { 'Backup and Disaster Recovery': 'backup-dr.md' },
       { 'Contributor Relay': 'contributor-relay.md' },
       { 'Manual Provisioning': 'manual-provisioning.md' },
       { 'hivectl CLI': 'hivectl.md' },
       { 'ACMM Policy Matrix': 'acmm-policy-matrix.md' },
+      { 'Troubleshooting': 'troubleshooting.md' },
+      { 'Running on macOS': 'macos.md' },
+      { 'Console Starter Install': 'console-starter-install.md' },
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Mirror of the hive-repo docs sweep (https://github.com/kubestellar/hive/pull/3830) now that v4 is the only line (v2 retired 2026-08-13). Every claim verified against current v4 code.

### New pages
- **Release Channels** (`/docs/hive/operations/release-channels`) — stable/candidate/edge GHCR retags, switching a hive from the dashboard, the `stable (v4)` pill, durability, limitations
- **Backup and Disaster Recovery** (`/docs/hive/operations/backup-and-disaster-recovery`) — `hive-backup`, the `HIVE_BACKUP_KEY` escrow gate, the opt-in CronJob with minimal 4-named-secret RBAC, restore flow

### Updated
- **security-model.md**: multi-provider login (GitHub + Google live, more via OIDC config, https://github.com/kubestellar/hive/pull/3664), Ed25519-only session cookies (https://github.com/kubestellar/hive/pull/3725), per-hive heartbeat keys (https://github.com/kubestellar/hive/pull/3744), and a new Layer 8 covering master-key rotation, the forced-proxy egress gate / `CAP_NET_ADMIN` (https://github.com/kubestellar/hive/issues/3760, https://github.com/kubestellar/hive/pull/3794), supply-chain pins, and fail-closed `/metrics` (https://github.com/kubestellar/hive/pull/3804)
- **governor.md**: cadence state persists across pod restarts — no boot re-kick (https://github.com/kubestellar/hive/pull/3817)
- v2-era staleness fixed across every hive page: clone/blob refs moved to branch `v4` (the in-repo `v2/` directory name stays), "Hive v2 (current)" headings, GitHub-only login claim, `v2-latest` image references now point at the `stable` release channel

### Nav repair (page-map.ts)
`NAV_STRUCTURE_HIVE` had 17 of 21 entries pointing at files that don't exist under `docs/content/hive/` (Roadmap, Landscape, Threat Model, and the entire ADR block) — they were silently dropped at render, leaving the whole Security category invisible. Replaced them with entries for the pages that actually exist. The hardcoded `/docs/hive/overview/introduction` sidebar link is unaffected (Overview/Introduction kept).

### Not touched
`src/config/versions.ts` and `public/config/shared.json` are owned by the open version-dropdown PR (#6525) and are untouched here.
