### PR TITLE
📝 docs(hive): document the hive-route-reader RBAC requirement

### DIFF
--- a/docs/content/hive/manual-provisioning.md
+++ b/docs/content/hive/manual-provisioning.md
@@ -120,6 +120,24 @@ PVC and records it in `meta.json` (`oci_file_system_id`, `oci_export_id`). The
 manual path uses an in-cluster RWX PVC directly and has no OCI export. This is
 the main structural difference between the two `meta.json` shapes.
 
+### A.3 RBAC the template emits
+
+The provisioning template creates the namespace RBAC for you, including the
+namespace-scoped read-only **`hive-route-reader`** Role and RoleBinding
+(`get`/`list` on `networking.k8s.io/ingresses` and `route.openshift.io/routes`).
+
+It is **not** unused. The spoke reads its own Route/Ingress through it to learn
+the hostname it actually serves, and reports that to the hub as `dashboard_url`.
+Remove it and the hub falls back to synthesising `<hiveID>.<hub host>`, which
+503s for any spoke not fronted by the hub's wildcard domain — see
+[`hive-route-reader`](#hive-route-reader--why-the-dashboard-link-503s-without-it)
+under the manual path for the full rationale, the YAML, and the
+ServiceAccount-derivation caveat.
+
+The template binds `hive-sa` on OpenShift (SCC) clusters and `default`
+elsewhere. Namespaces provisioned **before** this Role was added do not have it
+and need it applied retroactively.
+
 ---
 
 ## Path B — Manual provisioning (vllm-d)
@@ -129,8 +147,9 @@ The hub cannot reach vllm-d, so every object is applied by hand with
 
 1. Namespace
 2. ServiceAccount (`hive-sa`)
-3. RBAC — two Roles (`hive-secrets-writer`, `hive-self-upgrade`) and three
-   RoleBindings (the two above **plus** `hive-anyuid`)
+3. RBAC — three Roles (`hive-secrets-writer`, `hive-self-upgrade`,
+   `hive-route-reader`) and four RoleBindings (the three above **plus**
+   `hive-anyuid`)
 4. PVC (`hive-data`, RWX cephfs, 50Gi)
 5. ConfigMap (`hive-config`) — the first-boot config **seed**
 6. Secret (`hive-secrets`) — dashboard token, GitHub App key, LiteLLM key
@@ -189,6 +208,17 @@ rules:
   verbs: ["get","list","watch","delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: hive-route-reader, namespace: ${NS} }
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","list"]
+- apiGroups: ["route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: { name: hive-secrets-writer, namespace: ${NS} }
 roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: hive-secrets-writer }
@@ -199,6 +229,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: { name: hive-self-upgrade, namespace: ${NS} }
 roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: hive-self-upgrade }
+subjects:
+- { kind: ServiceAccount, name: hive-sa, namespace: ${NS} }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: hive-route-reader, namespace: ${NS} }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: hive-route-reader }
 subjects:
 - { kind: ServiceAccount, name: hive-sa, namespace: ${NS} }
 ---
@@ -222,6 +259,67 @@ YAML
 > kubectl --context "$CTX" -n "$NS" get rolebinding hive-anyuid \
 >   -o jsonpath='{.subjects[0].namespace}'   # must equal $NS
 > ```
+
+#### `hive-route-reader` — why the dashboard link 503s without it
+
+The spoke discovers the external hostname its **own** Route/Ingress actually
+serves and reports it to the hub as `dashboard_url` (`SpokeServedHost`, called
+from the heartbeat path). `hive-route-reader` is what lets it read them.
+
+Without the Role, that lookup returns "no answer" and the spoke falls back to
+synthesising `<hiveID>.<hub host>`. That is correct **only** for spokes fronted
+by the hub's own wildcard domain. Anywhere else it is a guaranteed **503**: the
+wildcard resolves, so DNS looks healthy, but it sends the name to the **hub's**
+router, which has no backend for a hive living on another cluster. This was a
+live user-visible outage on the vllm-d pool — the hub minted links at
+`<id>.hive.kubestellar.io` while the spoke's Route served
+`<id>.apps.fmaas-vllm-d.fmaas.res.ibm.com`.
+
+The spoke is the only party that **can** answer this on a heartbeat-only
+cluster, since the hub has no `kubectl` path there by design.
+
+Notes on the shape of the Role:
+
+- **Read-only and namespace-scoped.** `get`/`list`, no write verbs. A
+  compromised spoke learns only its own hostname — which it already advertises
+  — and can neither create nor retarget routing.
+- **Routes are listed unconditionally**, not gated on OpenShift. A cluster can
+  serve Routes without requiring an SCC, and a Role naming a CRD-backed
+  resource is inert where that API is absent.
+- **Ingress is consulted before Route**, matching the traffic path, so a
+  cluster carrying both resolves to the same object.
+
+> **Gotcha — derive the ServiceAccount, do not assume it.** The subject is
+> **not** uniform across the fleet. OpenShift/SCC spokes bind `hive-sa`; others
+> bind `default`. Measured live: hive-oke is 22× `default`; vllm-d is 2×
+> `default` **and** 41× `hive-sa`; a-ks-wec2 is 5× `hive-sa`. Binding the wrong
+> one fails silently — the pod runs, the lookup is denied, and you get the 503
+> fallback with no error anywhere obvious. Read it off the Deployment:
+>
+> ```bash
+> kubectl --context "$CTX" -n "$NS" get deploy hive \
+>   -o jsonpath='{.spec.template.spec.serviceAccountName}'
+> ```
+>
+> An **empty** result means the Deployment does not set one, which is Kubernetes
+> for `default` — bind `default`, not the empty string. The manifests in B.2
+> above use `hive-sa` because this manual path creates it in B.1; substitute
+> whatever the command returns if you are patching an existing namespace.
+
+> **Retrofit — namespaces provisioned before this change do not have it.**
+> The Role/RoleBinding is emitted by the provisioning template, so **new**
+> hosted hives get it automatically. Every namespace created before it was
+> added needs it applied retroactively, or its dashboard link keeps 503ing.
+> Check the fleet:
+>
+> ```bash
+> kubectl --context "$CTX" get rolebinding -A \
+>   --field-selector metadata.name=hive-route-reader
+> ```
+>
+> The spoke also has to be running a build new enough to perform the lookup, so
+> a namespace that already has the RBAC may still need a `rollout restart` to
+> start reporting.
 
 ### B.3 PVC
 
@@ -653,6 +751,7 @@ kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
 | Pod won't boot: `github.token or github.app_id is required` | `github.app_id` empty in the seed | Set a placeholder `app_id` (e.g. `999999999`) |
 | Dashboard sign-in redirect loop (vllm-d) | `hub_proxied: true` on a cluster with no hub auth proxy | Set `hub_proxied: false` on the PVC overlay |
 | Hive online but **Upgrade** → `hive not found` | No `meta.json` on the hub | Create `/data/saas/hives/<id>/meta.json` |
+| Hive online, but **My Hives → Dashboard** returns a branded **503**; the link reads `<hive-id>.<hub-host>` instead of the spoke cluster's own domain | Missing `hive-route-reader` RBAC, so the spoke can't read its own Route/Ingress and the hub falls back to the hub-wildcard host, which has no backend for a hive on another cluster | Apply the `hive-route-reader` Role + RoleBinding, binding the SA the hive Deployment actually uses (see [B.2](#hive-route-reader--why-the-dashboard-link-503s-without-it)), then `rollout restart deploy/hive` |
 | Not visible in My Hives | No `meta.json`, or `owner` doesn't match | Create/patch `meta.json` with the right `owner` |
 | ConfigMap edits have no effect | PVC overlay is authoritative | Edit `/data/hive.yaml.dashboard`, not the ConfigMap |
 | User has `read-write` in Manage Access but login fails with `device-flow login rejected: user not authorized` | Grant written to `/data/hive.yaml.dashboard` after the pod booted; the running authorizer only rebuilds `authorized_users` at startup (common right after provisioning / cross-cluster migration onto a fresh PVC) | Confirm the user is in the pod's `/etc/hive/hive.yaml`, then `rollout restart deploy/hive` |


### PR DESCRIPTION
Companion to kubestellar/hive#3849. Documents the namespace-scoped read-only `hive-route-reader` Role + RoleBinding added to the hosted-spoke provisioning template by kubestellar/hive#3846 (`3aa8d8f7`).

## Where this went, and why

`docs/content/hive/manual-provisioning.md` — the **only** page in this repo that enumerates spoke-namespace RBAC, and the only place documenting spoke provisioning at all. It is a fork of `v2/docs/manual-provisioning.md` in `kubestellar/hive` and does not auto-sync, so it still described the pre-change object set. This is not an ambiguous placement: the page already lists the exact Roles and RoleBindings to apply, and that list was incomplete.

It is registered in nav at `src/app/docs/page-map.ts:348` under **Operations**, which needs no change.

Note the two copies have **intentionally diverged** elsewhere — this one pins `ghcr.io/kubestellar/hive:stable` where upstream uses `v2-latest`, and upstream carries extra placeholder-`app_id` prose. I did a **surgical RBAC-only insert** rather than re-syncing the file, so those divergences are untouched.

## Why it matters

Without the Role the spoke cannot read its own Route/Ingress, so it falls back to synthesising `<hiveID>.<hub host>`. That is correct **only** for spokes fronted by the hub's own wildcard domain, and a guaranteed **503** anywhere else — the wildcard resolves, so DNS looks healthy, but it hands the name to the **hub's** router, which has no backend for a hive on another cluster. This was a live user-visible outage on the vllm-d pool.

Strictly read-only and namespace-scoped, so a compromised spoke learns only its own hostname — which it already advertises — and can neither create nor retarget routing.

## The subject is not uniform

The part most likely to be got wrong by hand. The template binds `hive-sa` on OpenShift (SCC) clusters and `default` elsewhere. Measured live, read-only:

| Cluster | Subject |
|---|---|
| hive-oke | 22× `default` |
| vllm-d | 2× `default` **and** 41× `hive-sa` |
| a-ks-wec2 | 5× `hive-sa` |

vllm-d alone needs both. The page now says to derive it from the hive Deployment rather than assume, and notes an empty `serviceAccountName` means `default`, not the empty string. Binding the wrong subject fails silently — the pod runs, the read is denied, you get the 503 fallback with no obvious error.

## Changes

- **A.3 (new)** — the automated path emits it. Recorded so nobody deletes it as unused.
- **B.2** — the Role + RoleBinding YAML, matching the page's existing inline-flow-mapping heredoc style; the rationale; the security argument.
- **Fixed an existing error** — the object inventory said "two Roles ... three RoleBindings". Now three and four.
- Gotchas for ServiceAccount derivation and for the retroactive apply.
- Failure-mode table: the 503 dashboard-link row.

**Existing namespaces provisioned before this change need it applied retroactively** (in progress across the fleet). New provisions get it automatically.

## Verification

Read the template and `SpokeServedHost` in the hive repo rather than working from a summary; the code matched. Live state confirmed **read-only** — no cluster writes.