### PR TITLE
📖 Update kubestellar-mcp docs to v0.9.10

### DIFF
--- a/scripts/check-internal-links.ts
+++ b/scripts/check-internal-links.ts
@@ -32,7 +32,7 @@ import {
   PROJECT_FOR_NAV,
   parseNavStructures,
   navEntryRoute,
-} from "./check-internal-links-helpers.ts";
+} from "./check-internal-links-helpers";
 
 const contentRoot = path.join(process.cwd(), "docs", "content");
 

--- a/scripts/generate-shared-config.ts
+++ b/scripts/generate-shared-config.ts
@@ -48,7 +48,7 @@ interface ExistingSharedConfig {
 }
 
 (async () => {
-  const { PROJECTS } = await import(versionsPath) as typeof import('../src/config/versions.ts');
+  const { PROJECTS } = await import(versionsPath) as typeof import('../src/config/versions');
 
   // Build versions and projects maps from PROJECTS
   const versions: Record<string, Record<string, VersionEntry>> = {};

--- a/src/__tests__/check-internal-links-helpers.test.ts
+++ b/src/__tests__/check-internal-links-helpers.test.ts
@@ -18,7 +18,7 @@ import {
   parseNavStructures,
   navEntryRoute,
   type NavAliasEntry,
-} from "../../scripts/check-internal-links-helpers.ts";
+} from "../../scripts/check-internal-links-helpers";
 
 // ─────────────────────────────────────────────────────────────────────────
 // slugify — must match the rule buildPageMap() uses on NAV_STRUCTURE_* titles

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.9.9 (Latest)",
-    branch: "docs/kubestellar-mcp/0.9.9",
+    label: "v0.9.10 (Latest)",
+    branch: "docs/kubestellar-mcp/0.9.10",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.9.9": {
+    label: "v0.9.9",
+    branch: "docs/kubestellar-mcp/0.9.9",
+    isDefault: false,
   },
   "0.9.6": {
     label: "v0.9.6",
@@ -508,7 +513,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.9.9",
+    currentVersion: "0.9.10",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.9.10.

- Created branch: `docs/kubestellar-mcp/0.9.10`
- Source: kubestellar/kubestellar-mcp@v0.9.10

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release