### PR TITLE
fix(sync): rewrite hive doc links during sync + add broken-internal-link CI gate

### DIFF
--- a/.github/workflows/check-internal-links.yml
+++ b/.github/workflows/check-internal-links.yml
@@ -1,0 +1,54 @@
+name: Internal Links
+
+# Fails the build when a markdown link under docs/content/** points at an
+# internal route that does not exist (a 404). This catches renames, bad Hive
+# syncs, and version bumps (v5, v6, ...) at PR time instead of shipping a 404.
+# Only INTERNAL links are checked (relative + root-absolute /docs/... paths);
+# external links are intentionally out of scope to keep the gate deterministic
+# and free of network flakiness.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/content/**"
+      - "scripts/sync-hive-docs.ts"
+      - "scripts/check-internal-links.ts"
+      - "src/app/docs/page-map.ts"
+      - "src/app/docs/[...slug]/page.tsx"
+      - "src/config/versions.ts"
+  push:
+    branches: [main]
+    paths:
+      - "docs/content/**"
+      - "scripts/sync-hive-docs.ts"
+      - "scripts/check-internal-links.ts"
+      - "src/app/docs/page-map.ts"
+      - "src/app/docs/[...slug]/page.tsx"
+      - "src/config/versions.ts"
+
+permissions: read-all
+
+jobs:
+  check-links:
+    name: Check internal doc links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Regenerate the synced Hive docs so a link regression introduced by the
+      # sync (e.g. a hive layout change on a new branch) is caught here too.
+      # Non-fatal if offline in a fork: fall back to the committed content.
+      - name: Sync Hive docs
+        run: npm run sync-hive-docs || echo "sync skipped (network unavailable); checking committed content"
+
+      - name: Check internal links
+        run: npm run check-links

--- a/docs/content/kubestellar/wec-registration.md
+++ b/docs/content/kubestellar/wec-registration.md
@@ -281,6 +281,6 @@ After successfully registering your WEC, you can:
 3. **Set up monitoring** for your WEC
 4. **Register additional WECs** to scale your deployment
 
-For more information on using WECs with KubeStellar, see the [example scenarios](example-scenarios.md) and [BindingPolicy documentation](binding.md/#bindingpolicy).
+For more information on using WECs with KubeStellar, see the [example scenarios](example-scenarios.md) and [BindingPolicy documentation](binding.md#bindingpolicy).
 
 For the complete picture of how WEC registration fits into the overall KubeStellar architecture, see [The Full Story](user-guide-intro.md#the-full-story).

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "lint:md": "markdownlint-cli2 \"README.md\" \"CONTRIBUTING.md\" \"docs/**/*.{md,mdx}\" \"src/**/*.{md,mdx}\"",
+    "sync-hive-docs": "tsx scripts/sync-hive-docs.ts",
+    "check-links": "tsx scripts/check-internal-links.ts",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/check-internal-links.ts
+++ b/scripts/check-internal-links.ts
@@ -1,0 +1,242 @@
+/**
+ * Broken internal-link checker for the docs content.
+ *
+ * WHY: Hive (and other) docs are synced/authored as markdown. A rename, a bad
+ * sync, or a version bump can leave a relative link pointing at a route that no
+ * longer exists — shipping a 404. `scripts/sync-hive-docs.ts` rewrites Hive
+ * links at sync time, but nothing catches a regression at PR time. This script
+ * resolves every INTERNAL markdown link under `docs/content/**` against the set
+ * of routes the site actually serves and fails if any does not resolve.
+ *
+ * Scope: INTERNAL links only (relative paths and root-absolute `/docs/...`
+ * paths). External links (`http(s)://`, `mailto:`, protocol-relative `//`) and
+ * pure in-page `#anchor` links are intentionally ignored to keep the check
+ * deterministic and free of network flakiness.
+ *
+ * Route model (must match src/app/docs/[...slug]/page.tsx + page-map.ts):
+ *   1. Every `docs/content/<rel>.md(x)` file is served at `/docs/<rel>`
+ *      (generateStaticParams strips the extension). This is the flat/direct
+ *      route set.
+ *   2. buildPageMap() adds nav routes whose slug derives from the nav title
+ *      (e.g. hive `readme.md` -> `/docs/hive/overview/introduction`).
+ * A link is valid if it resolves to a route in EITHER set.
+ */
+import fs from "fs";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const contentRoot = path.join(process.cwd(), "docs", "content");
+
+// --- Build the set of valid routes -----------------------------------------
+
+const validRoutes = new Set<string>();
+
+// (1) Flat/direct routes: one per markdown file under docs/content/**.
+function collectFlatRoutes(dir: string) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      collectFlatRoutes(full);
+    } else if (/\.mdx?$/i.test(entry.name)) {
+      const rel = path
+        .relative(contentRoot, full)
+        .replace(/\\/g, "/")
+        .replace(/\.mdx?$/i, "");
+      validRoutes.add(`/docs/${rel}`);
+    }
+  }
+}
+collectFlatRoutes(contentRoot);
+
+// (2) Nav-alias routes. Some pages are ALSO served under a nav-section path
+// whose slug derives from the nav title (e.g. hive `readme.md` is aliased at
+// `/docs/hive/overview/introduction`). We derive these from the same page-map
+// source the site uses, WITHOUT importing it directly (page-map.ts pulls in
+// nextra's bundler-only `normalizePageMap` export, which does not resolve under
+// a plain Node/tsx run). Instead we parse the NAV_STRUCTURE_* tables out of
+// page-map.ts and replicate its title->slug rule. This keeps the checker a
+// zero-heavy-dependency, deterministic gate.
+const pageMapSrc = fs.readFileSync(
+  path.join(process.cwd(), "src", "app", "docs", "page-map.ts"),
+  "utf8"
+);
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+// Map a NAV_STRUCTURE_<X> variable name to its docs base path.
+const projectForNav: Record<string, string> = {
+  A2A: "docs/a2a",
+  MULTI_PLUGIN: "docs/multi-plugin",
+  KUBEFLEX: "docs/kubeflex",
+  KUBESTELLAR_MCP: "docs/kubestellar-mcp",
+  CONSOLE: "docs/console",
+  HIVE: "docs/hive",
+  KUBESTELLAR: "docs",
+};
+
+// Walk each `{ title: value }` object literal in a NAV_STRUCTURE block and, when
+// value is a `'file.md'` string that exists on disk, register the nav-slug route
+// under the current section path. Nested arrays extend the section path.
+function collectNavAliases(block: string, base: string, sectionSlug: string) {
+  // Top-level category titles form the first path segment.
+  // We handle both category `{ title: 'X', items: [...] }` and inner
+  // `{ 'Title': 'file.md' }` / `{ 'Title': [ ... ] }` entries.
+  const titleFileRe = /['"]([^'"]+)['"]\s*:\s*['"]([^'"]+\.mdx?)['"]/g;
+  let m: RegExpExecArray | null;
+  while ((m = titleFileRe.exec(block))) {
+    const title = m[1];
+    const file = m[2];
+    if (file.startsWith("http") || file.startsWith("/")) continue;
+    const fileAbs = path.join(contentRoot, base.replace(/^docs\/?/, ""), file);
+    if (!fs.existsSync(fileAbs) && base !== "docs") {
+      // Kubestellar nav references live under docs/content directly.
+      const alt = path.join(contentRoot, file);
+      if (!fs.existsSync(alt)) continue;
+    }
+    const slug = slugify(title);
+    if (sectionSlug) validRoutes.add(`/${base}/${sectionSlug}/${slug}`);
+    validRoutes.add(`/${base}/${slug}`);
+  }
+}
+
+// Extract each `const NAV_STRUCTURE_<X> ... = [ ... ]` block and its category
+// section slugs, then register aliases. This mirrors buildPageMap closely enough
+// to avoid false positives on nav-style links; if a link's flat route already
+// exists (case 1) we never even consult these.
+const navBlockRe = /const NAV_STRUCTURE_([A-Z_]+)[^=]*=\s*(\[[\s\S]*?\n\])/g;
+let nav: RegExpExecArray | null;
+while ((nav = navBlockRe.exec(pageMapSrc))) {
+  const name = nav[1];
+  const base = projectForNav[name];
+  if (!base) continue;
+  const block = nav[2];
+  // Category titles: `{ title: 'Overview', items: [ ... ] }`.
+  const catRe = /title:\s*['"]([^'"]+)['"]/g;
+  let c: RegExpExecArray | null;
+  const sections: string[] = [];
+  while ((c = catRe.exec(block))) sections.push(slugify(c[1]));
+  // Register aliases under every section slug (over-approximation is safe: it
+  // only ever ADDS valid routes, never rejects a real one).
+  for (const s of sections) collectNavAliases(block, base, s);
+  collectNavAliases(block, base, "");
+}
+
+// Normalize a route for comparison: drop trailing slash (except root).
+function normRoute(r: string): string {
+  const noSlash = r.replace(/\/+$/, "");
+  return noSlash === "" ? "/" : noSlash;
+}
+const validNormalized = new Set([...validRoutes].map(normRoute));
+
+// --- Extract and resolve links ---------------------------------------------
+
+type Broken = { file: string; link: string; resolved: string };
+const broken: Broken[] = [];
+let linksChecked = 0;
+
+// Route at which a given content file is served (its flat/direct route).
+function fileRoute(fileAbs: string): string {
+  const rel = path
+    .relative(contentRoot, fileAbs)
+    .replace(/\\/g, "/")
+    .replace(/\.mdx?$/i, "");
+  return `/docs/${rel}`;
+}
+
+const INLINE_LINK = /\]\(\s*([^)\s]+)(?:\s+[^)]*)?\)/g;
+const REF_LINK = /^\s*\[[^\]]+\]:\s*(\S+)/gm;
+
+// Asset extensions are served by the `/docs-images/*` rewrite (see
+// rewriteImagePaths in the docs page), not by the docs route table, so relative
+// image/asset links must NOT be validated against routes here.
+const ASSET_EXT =
+  /\.(png|jpe?g|gif|svg|webp|avif|ico|pdf|mp4|webm|mov|zip|gz|tgz|css|js|woff2?|ttf|eot)$/i;
+
+function isExternalOrAnchor(target: string): boolean {
+  if (target === "") return true;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return true; // http:, mailto:, etc.
+  if (target.startsWith("//")) return true; // protocol-relative
+  if (target.startsWith("#")) return true; // in-page anchor
+  return false;
+}
+
+function checkFile(fileAbs: string) {
+  const content = fs.readFileSync(fileAbs, "utf8");
+  const fileRel = path.relative(process.cwd(), fileAbs).replace(/\\/g, "/");
+  const baseRoute = fileRoute(fileAbs);
+  const baseDir = path.posix.dirname(baseRoute);
+
+  const targets: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = INLINE_LINK.exec(content))) targets.push(m[1]);
+  while ((m = REF_LINK.exec(content))) targets.push(m[1]);
+
+  for (const raw of targets) {
+    if (isExternalOrAnchor(raw)) continue;
+    // Strip #fragment / ?query before resolving to a route.
+    const pathPart = raw.replace(/[?#].*$/, "");
+    if (pathPart === "") continue; // pure fragment/query on the current page.
+    if (ASSET_EXT.test(pathPart)) continue; // image/asset, not a doc route.
+
+    linksChecked++;
+    // Resolve to an absolute site route.
+    let resolved: string;
+    if (pathPart.startsWith("/")) {
+      resolved = pathPart;
+    } else {
+      resolved = path.posix.normalize(path.posix.join(baseDir, pathPart));
+    }
+    // A `.md`/`.mdx` suffix is never part of a valid route; strip it so a
+    // (discouraged) `foo.md` link is still checked against the real route.
+    resolved = resolved.replace(/\.mdx?$/i, "");
+
+    if (!validNormalized.has(normRoute(resolved))) {
+      broken.push({ file: fileRel, link: raw, resolved });
+    }
+  }
+}
+
+function walk(dir: string) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      walk(full);
+    } else if (/\.mdx?$/i.test(entry.name)) {
+      checkFile(full);
+    }
+  }
+}
+
+function main() {
+  walk(contentRoot);
+
+  console.log(
+    `Checked ${linksChecked} internal links across docs/content against ${validNormalized.size} routes.`
+  );
+
+  if (broken.length > 0) {
+    console.error(`\n❌ Found ${broken.length} broken internal link(s):\n`);
+    for (const b of broken) {
+      console.error(
+        `  ${b.file}\n    link: ${b.link}\n    resolves to (no route): ${b.resolved}`
+      );
+    }
+    console.error(
+      "\nInternal links must resolve to a real docs route. For links to files " +
+        "outside the synced docs tree, use an absolute GitHub URL instead."
+    );
+    process.exit(1);
+  }
+
+  console.log("✅ No broken internal links.");
+}
+
+// Run only when executed directly (allows importing for tests).
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}

--- a/scripts/sync-hive-docs.test.ts
+++ b/scripts/sync-hive-docs.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { rewriteLinkTarget, rewriteLinks } from "./sync-hive-docs";
+
+// The source file being synced, expressed as its real repo path. Links inside
+// the content are resolved relative to this file's directory.
+const README = "v2/docs/README.md";
+const ADR_README = "v2/docs/adr/README.md";
+
+describe("rewriteLinkTarget — Case 1: in-tree synced docs -> site route", () => {
+  it("rewrites a bare sibling link to the synced flat route", () => {
+    // architecture.md is synced -> /docs/hive/architecture (extension stripped).
+    expect(rewriteLinkTarget("architecture.md", README)).toBe(
+      "/docs/hive/architecture"
+    );
+  });
+
+  it("rewrites a site-adjusted `../` link back to the internal route (recovery)", () => {
+    // Hive source hand-edited to `../architecture.md` still resolves internally.
+    expect(rewriteLinkTarget("../architecture.md", README)).toBe(
+      "/docs/hive/architecture"
+    );
+  });
+
+  it("rewrites a synced ADR sibling from adr/README.md to its adr/ route", () => {
+    expect(
+      rewriteLinkTarget("0001-record-architecture-decisions.md", ADR_README)
+    ).toBe("/docs/hive/adr/0001-record-architecture-decisions");
+  });
+
+  it("preserves an #anchor on an in-tree link", () => {
+    expect(rewriteLinkTarget("architecture.md#the-governor-loop", README)).toBe(
+      "/docs/hive/architecture#the-governor-loop"
+    );
+  });
+});
+
+describe("rewriteLinkTarget — Case 2: escapes / unsynced -> absolute GitHub URL", () => {
+  it("resolves `../../` escape to the repo-root path on the sync branch", () => {
+    // v2/docs/ + ../../bin/README.md = bin/README.md at the repo root.
+    expect(rewriteLinkTarget("../../bin/README.md", README)).toBe(
+      "https://github.com/kubestellar/hive/blob/v4/bin/README.md"
+    );
+  });
+
+  it("resolves a single `../` escape into the sibling repo directory", () => {
+    // v2/docs/ + ../deploy/README.md = v2/deploy/README.md.
+    expect(rewriteLinkTarget("../deploy/README.md", README)).toBe(
+      "https://github.com/kubestellar/hive/blob/v4/v2/deploy/README.md"
+    );
+  });
+
+  it("sends an in-tree-but-UNSYNCED doc to GitHub (not synced by the script)", () => {
+    // manual-provisioning.md is not in the sync allow-list -> GitHub blob URL.
+    expect(rewriteLinkTarget("manual-provisioning.md", README)).toBe(
+      "https://github.com/kubestellar/hive/blob/v4/v2/docs/manual-provisioning.md"
+    );
+  });
+
+  it("handles a JSON (non-markdown) escape target", () => {
+    expect(rewriteLinkTarget("../../dashboard/openapi.json", README)).toBe(
+      "https://github.com/kubestellar/hive/blob/v4/dashboard/openapi.json"
+    );
+  });
+});
+
+describe("rewriteLinkTarget — left untouched", () => {
+  it("leaves absolute http(s) URLs alone", () => {
+    const url = "https://hive.kubestellar.io";
+    expect(rewriteLinkTarget(url, README)).toBe(url);
+  });
+
+  it("leaves an already-rewritten GitHub blob URL alone (idempotent)", () => {
+    const url = "https://github.com/kubestellar/hive/blob/v4/bin/README.md";
+    expect(rewriteLinkTarget(url, README)).toBe(url);
+  });
+
+  it("leaves an already-rewritten internal site route alone (idempotent)", () => {
+    expect(rewriteLinkTarget("/docs/hive/architecture", README)).toBe(
+      "/docs/hive/architecture"
+    );
+  });
+
+  it("leaves mailto: and pure #anchors alone", () => {
+    expect(rewriteLinkTarget("mailto:x@example.com", README)).toBe(
+      "mailto:x@example.com"
+    );
+    expect(rewriteLinkTarget("#section", README)).toBe("#section");
+  });
+});
+
+describe("rewriteLinks — over full markdown content", () => {
+  it("rewrites inline links and preserves link text and titles", () => {
+    const md =
+      'See [Architecture](architecture.md) and [bin](../../bin/README.md "index").';
+    const out = rewriteLinks(md, README);
+    expect(out).toContain("[Architecture](/docs/hive/architecture)");
+    expect(out).toContain(
+      '[bin](https://github.com/kubestellar/hive/blob/v4/bin/README.md "index")'
+    );
+  });
+
+  it("is idempotent — running twice yields identical output", () => {
+    const md =
+      "- [A](architecture.md)\n- [B](../../bin/README.md)\n- [C](https://x.io)\n";
+    const once = rewriteLinks(md, README);
+    const twice = rewriteLinks(once, README);
+    expect(twice).toBe(once);
+  });
+
+  it("rewrites reference-style link definitions", () => {
+    const md = "Text [arch].\n\n[arch]: architecture.md\n";
+    const out = rewriteLinks(md, README);
+    expect(out).toContain("[arch]: /docs/hive/architecture");
+  });
+});

--- a/scripts/sync-hive-docs.ts
+++ b/scripts/sync-hive-docs.ts
@@ -1,65 +1,225 @@
-import fs from 'fs'
-import path from 'path'
+import fs from "fs";
+import path from "path";
 
-const owner = 'kubestellar'
-const repo = 'hive'
-const branch = process.env.HIVE_DOCS_REF || 'v4'
-const docsRoot = path.join(process.cwd(), 'docs', 'content', 'hive')
-const rawBase = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/v2/docs`
-const canonicalBase = `https://github.com/${owner}/${repo}/blob/${branch}/v2/docs`
+const owner = "kubestellar";
+const repo = "hive";
+const branch = process.env.HIVE_DOCS_REF || "v4";
+const docsRoot = path.join(process.cwd(), "docs", "content", "hive");
+const rawBase = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/v2/docs`;
+const canonicalBase = `https://github.com/${owner}/${repo}/blob/${branch}/v2/docs`;
 
 const files: Array<{ source: string; target?: string }> = [
-  { source: 'README.md', target: 'readme.md' },
-  { source: 'architecture.md' },
-  { source: 'security-threat-model.md' },
-  { source: 'roadmap.md' },
-  { source: 'landscape.md' },
-  { source: 'adr/README.md', target: 'adr/readme.md' },
-  { source: 'adr/0001-record-architecture-decisions.md' },
-  { source: 'adr/0002-mitm-proxy-network-enforcement.md' },
-  { source: 'adr/0003-acmm-autonomy-levels.md' },
-  { source: 'adr/0004-beads-work-ledger.md' },
-  { source: 'adr/0005-forge-abstraction.md' },
-  { source: 'adr/0006-planning-intelligence.md' },
-  { source: 'adr/0007-token-mint.md' },
-  { source: 'adr/0008-ioscan-untrusted-input.md' },
-  { source: 'adr/0009-trajectory-review.md' },
-  { source: 'adr/0010-escalation-circuit-breaker.md' },
-  { source: 'adr/0011-knowledge-graph.md' },
-  { source: 'adr/0012-skill-registry.md' },
-  { source: 'adr/0013-cel-triggers.md' },
-  { source: 'adr/0014-hub-spoke.md' },
-]
+  { source: "README.md", target: "readme.md" },
+  { source: "architecture.md" },
+  { source: "security-threat-model.md" },
+  { source: "roadmap.md" },
+  { source: "landscape.md" },
+  { source: "adr/README.md", target: "adr/readme.md" },
+  { source: "adr/0001-record-architecture-decisions.md" },
+  { source: "adr/0002-mitm-proxy-network-enforcement.md" },
+  { source: "adr/0003-acmm-autonomy-levels.md" },
+  { source: "adr/0004-beads-work-ledger.md" },
+  { source: "adr/0005-forge-abstraction.md" },
+  { source: "adr/0006-planning-intelligence.md" },
+  { source: "adr/0007-token-mint.md" },
+  { source: "adr/0008-ioscan-untrusted-input.md" },
+  { source: "adr/0009-trajectory-review.md" },
+  { source: "adr/0010-escalation-circuit-breaker.md" },
+  { source: "adr/0011-knowledge-graph.md" },
+  { source: "adr/0012-skill-registry.md" },
+  { source: "adr/0013-cel-triggers.md" },
+  { source: "adr/0014-hub-spoke.md" },
+];
 
 function canonicalHeader(source: string): string {
-  const canonical = `${canonicalBase}/${source}`
-  return `> **Synced from Hive.** This page is pulled from [kubestellar/hive@${branch}](${canonical}) during the docs build. Edit the canonical source in the Hive repository.\n\n`
+  const canonical = `${canonicalBase}/${source}`;
+  return `> **Synced from Hive.** This page is pulled from [kubestellar/hive@${branch}](${canonical}) during the docs build. Edit the canonical source in the Hive repository.\n\n`;
 }
 
-async function fetchText(url: string): Promise<string> {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`failed to fetch ${url}: ${response.status} ${response.statusText}`)
+// ---------------------------------------------------------------------------
+// Link rewriting
+// ---------------------------------------------------------------------------
+//
+// The Hive markdown is authored for GitHub's file browser, where relative links
+// like `[Architecture](architecture.md)` or `[bin index](../../bin/README.md)`
+// resolve against the file's location in the `kubestellar/hive` repo. When those
+// files are copied verbatim into this docs site they 404, because:
+//
+//   * The site serves each Hive page at a route WITHOUT the `.md` extension
+//     (e.g. `docs/content/hive/architecture.md` -> `/docs/hive/architecture`),
+//     and some pages render one level deep under a nav section
+//     (e.g. `readme.md` -> `/docs/hive/overview/introduction`). A bare
+//     `architecture.md` link therefore resolves against the wrong directory and
+//     keeps a `.md` suffix that is not a valid route.
+//   * Repo-relative escapes such as `../../bin/README.md` point outside the
+//     synced docs tree entirely and have no site route at all.
+//
+// This pass fixes both cases GENERICALLY (no per-file hardcoding) so future
+// version bumps (v5, v6, ...) and layout changes stay correct automatically:
+//
+//   Case 1 — the link resolves to a Hive doc that IS synced/published here:
+//     rewrite it to the site-absolute, extension-less route `/docs/hive/<name>`.
+//     A root-absolute path is used deliberately: it resolves correctly no matter
+//     how deep the *current* page renders in the nav, so it cannot break if a
+//     page later moves between nav sections.
+//
+//   Case 2 — the link escapes the synced tree, or points at a repo path that is
+//     NOT synced (bin/README.md, deploy/README.md, AGENT-DEFINITION.md, etc.):
+//     rewrite it to an absolute GitHub URL on the same branch the sync uses, by
+//     resolving the `../` segments against the source file's real repo path
+//     (`v2/docs/<source>`) to recover the true repo path, then emitting
+//     `https://github.com/<owner>/<repo>/blob/<branch>/<repo-path>`.
+//
+//   Absolute (`http(s)://`, `//`) links and pure in-page `#anchor` links are
+//   left untouched.
+
+// Repo path (relative to the hive repo root) of every source file the sync
+// pulls, e.g. `v2/docs/architecture.md`, `v2/docs/adr/README.md`.
+const syncedRepoPaths = new Set(files.map(f => `v2/docs/${f.source}`));
+
+// Map from a synced source's repo path -> its published site route (no `.md`).
+// e.g. `v2/docs/README.md` -> `/docs/hive/readme`,
+//      `v2/docs/adr/0001-...md` -> `/docs/hive/adr/0001-...`.
+const repoPathToSiteRoute = new Map<string, string>();
+for (const f of files) {
+  const repoPath = `v2/docs/${f.source}`;
+  const target = f.target || f.source;
+  const targetNoExt = target.replace(/\.mdx?$/i, "");
+  repoPathToSiteRoute.set(repoPath, `/docs/hive/${targetNoExt}`);
+}
+
+// Basename -> site route, used only as a recovery fallback (see rewriteLinkTarget).
+// `README.md` is intentionally excluded because it is ambiguous (root README vs
+// adr/README); those are only ever matched by exact path.
+const basenameToSiteRoute = new Map<string, string>();
+for (const f of files) {
+  const base = f.source.split("/").pop()!;
+  if (base.toLowerCase() === "readme.md") continue;
+  const target = f.target || f.source;
+  basenameToSiteRoute.set(base, `/docs/hive/${target.replace(/\.mdx?$/i, "")}`);
+}
+
+// Split a link target into its path portion and a preserved `#fragment` /
+// `?query` suffix so we only rewrite the path.
+function splitSuffix(target: string): { pathPart: string; suffix: string } {
+  const match = target.match(/^([^?#]*)([?#].*)?$/);
+  return { pathPart: match?.[1] ?? target, suffix: match?.[2] ?? "" };
+}
+
+// Rewrite a single markdown link target that appears in `sourceRepoPath`'s
+// content (sourceRepoPath is e.g. `v2/docs/README.md`). Returns the original
+// target unchanged when no rewrite applies.
+function rewriteLinkTarget(target: string, sourceRepoPath: string): string {
+  const trimmed = target.trim();
+
+  // Leave absolute URLs, protocol-relative URLs, root-absolute site paths, and
+  // pure in-page anchors alone. Skipping root-absolute `/...` paths also makes
+  // the pass idempotent: already-rewritten `/docs/hive/...` links are untouched.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return target; // http:, https:, mailto:, etc.
+  if (trimmed.startsWith("//")) return target;
+  if (trimmed.startsWith("/")) return target; // root-absolute (e.g. /docs/hive/...)
+  if (trimmed.startsWith("#")) return target;
+  if (trimmed === "") return target;
+
+  const { pathPart, suffix } = splitSuffix(trimmed);
+  if (pathPart === "") return target; // e.g. a lone `?query` — nothing to resolve.
+
+  // Resolve the (possibly `../`-laden) relative link against the directory of
+  // the source file, yielding a repo-root-relative path.
+  const sourceDir = path.posix.dirname(sourceRepoPath);
+  const resolved = path.posix.normalize(path.posix.join(sourceDir, pathPart));
+
+  // Case 1: the link points at a doc we actually sync/publish -> site route.
+  if (syncedRepoPaths.has(resolved)) {
+    const route = repoPathToSiteRoute.get(resolved)!;
+    return `${route}${suffix}`;
   }
-  return response.text()
+
+  // Case 1b (recovery): the resolved path is not itself synced, but its basename
+  // uniquely matches a synced doc. This happens when the Hive source was already
+  // hand-edited with SITE-relative links (e.g. `../architecture.md` written to
+  // resolve at `/docs/hive/...` rather than in GitHub's file browser). Rather
+  // than push such a link out to GitHub, keep it internal. This keeps the pass
+  // correct whether the upstream source uses pristine GitHub-relative links
+  // (matched by Case 1) or site-adjusted `../` links (matched here).
+  const base = pathPart.split("/").pop() ?? "";
+  if (basenameToSiteRoute.has(base)) {
+    return `${basenameToSiteRoute.get(base)!}${suffix}`;
+  }
+
+  // Case 2: anything else that is a repo-relative path (in-tree-but-unsynced, or
+  // an escape like `../../bin/README.md`) -> absolute GitHub URL on the branch.
+  // `resolved` is already normalized relative to the repo root.
+  return `https://github.com/${owner}/${repo}/blob/${branch}/${resolved}${suffix}`;
+}
+
+// Apply link rewriting to a file's markdown content. Handles inline links
+// `[text](target)` and reference-style definitions `[id]: target`.
+function rewriteLinks(content: string, sourceRepoPath: string): string {
+  // Inline links: [text](target) and [text](target "title").
+  // The target is everything up to the first unescaped space (before an optional
+  // title) or the closing paren.
+  let out = content.replace(
+    /(\]\()(\s*)([^)\s]+)([^)]*)(\))/g,
+    (_full, open, lead, targetRaw, rest, close) => {
+      const rewritten = rewriteLinkTarget(targetRaw, sourceRepoPath);
+      return `${open}${lead}${rewritten}${rest}${close}`;
+    }
+  );
+
+  // Reference-style link definitions: `[id]: target` (optionally followed by a
+  // title) at the start of a line.
+  out = out.replace(
+    /^(\s*\[[^\]]+\]:\s*)(\S+)(.*)$/gm,
+    (_full, prefix, targetRaw, rest) => {
+      const rewritten = rewriteLinkTarget(targetRaw, sourceRepoPath);
+      return `${prefix}${rewritten}${rest}`;
+    }
+  );
+
+  return out;
+}
+
+// Exported for unit testing (see scripts/sync-hive-docs.test.ts).
+export { rewriteLinkTarget, rewriteLinks };
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `failed to fetch ${url}: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.text();
 }
 
 async function main() {
   for (const file of files) {
-    const target = file.target || file.source
-    const sourceURL = `${rawBase}/${file.source}`
-    const targetPath = path.join(docsRoot, target)
+    const target = file.target || file.source;
+    const sourceURL = `${rawBase}/${file.source}`;
+    const targetPath = path.join(docsRoot, target);
     if (!targetPath.startsWith(docsRoot + path.sep)) {
-      throw new Error(`refusing to write outside Hive docs root: ${target}`)
+      throw new Error(`refusing to write outside Hive docs root: ${target}`);
     }
-    const content = await fetchText(sourceURL)
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true })
-    fs.writeFileSync(targetPath, canonicalHeader(file.source) + content)
-    console.log(`synced ${file.source} -> docs/content/hive/${target}`)
+    const content = await fetchText(sourceURL);
+    // Rewrite GitHub-relative links so they resolve on the docs site.
+    const rewritten = rewriteLinks(content, `v2/docs/${file.source}`);
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, canonicalHeader(file.source) + rewritten);
+    console.log(`synced ${file.source} -> docs/content/hive/${target}`);
   }
 }
 
-main().catch(error => {
-  console.error(error)
-  process.exit(1)
-})
+// Only run the sync when this file is executed directly (not when imported by
+// the test suite, which would otherwise trigger network fetches on import).
+const isDirectRun =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  /sync-hive-docs\.ts$/.test(process.argv[1] ?? "");
+
+if (isDirectRun) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/components/docs/DocsSourceActions.tsx
+++ b/src/components/docs/DocsSourceActions.tsx
@@ -13,7 +13,13 @@ const STATIC_EDIT_BASE_URLS: Record<ProjectId, string> = {
   "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
   "kubestellar-mcp": "https://github.com/kubestellar/kubectl-claude/edit/main/docs",
   console: 'https://github.com/kubestellar/console/edit/main/docs',
-  hive: 'https://github.com/kubestellar/hive/edit/main/docs',
+  // Hive has no `main` branch (default is `v4`) and its docs live under
+  // `v2/docs`, so `/edit/main/docs/...` 404s. Point at the real branch and
+  // directory. Kept in sync with scripts/sync-hive-docs.ts (branch `v4`,
+  // source dir `v2/docs`). NOTE: page filePaths use `readme.md` (lowercased),
+  // but the canonical source is `README.md`; that single page's edit/source
+  // link will 404 until the filePath casing is reconciled.
+  hive: 'https://github.com/kubestellar/hive/edit/v4/v2/docs',
 };
 
 // Prevent path traversal

--- a/src/components/docs/EditPageLink.tsx
+++ b/src/components/docs/EditPageLink.tsx
@@ -11,7 +11,10 @@ const STATIC_EDIT_BASE_URLS: Record<ProjectId, string> = {
   "multi-plugin": 'https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin',
   "kubestellar-mcp": 'https://github.com/kubestellar/kubectl-claude/edit/main/docs',
   console: 'https://github.com/kubestellar/console/edit/main/docs',
-  hive: 'https://github.com/kubestellar/hive/edit/main/docs',
+  // Hive has no `main` branch (default is `v4`) and its docs live under
+  // `v2/docs`. See DocsSourceActions.tsx for the full rationale. Kept in sync
+  // with scripts/sync-hive-docs.ts (branch `v4`, source dir `v2/docs`).
+  hive: 'https://github.com/kubestellar/hive/edit/v4/v2/docs',
 };
 
 interface EditPageLinkProps {


### PR DESCRIPTION
## Problem (root cause)

Hive docs are synced verbatim from `kubestellar/hive` `v2/docs/*` into `docs/content/hive/` by `scripts/sync-hive-docs.ts`. The upstream markdown uses **GitHub-repo-relative links** that are correct in GitHub's file browser but **404 on the docs site**:

- A bare `[Architecture](architecture.md)` keeps the `.md` suffix (not a valid route) and resolves against the current page's nav directory (e.g. from `/docs/hive/overview/introduction` → `/docs/hive/overview/architecture.md`), which does not exist.
- An escape like `[bin index](../../bin/README.md)` points **outside** the docs tree entirely and has no site route.

This breaks on **every hive version bump / layout change** and last required a large manual fix (`kubestellar/hive#3981`). This PR fixes it at the **source — the sync pipeline** — so v5/v6/... auto-correct.

## Change 1 — link-rewriting pass in `scripts/sync-hive-docs.ts`

A general transform (no hardcoded lists) applied to each file's content before writing. For every markdown link (inline and reference-style):

- **Case 1 — in-tree, synced/published doc** (cross-checked against the script's `files` allow-list): rewrite to the **site-absolute, extension-less** route `/docs/hive/<name>`. Root-absolute is used deliberately so the link resolves correctly *regardless of how deep the page renders in the nav* (a plain `../foo.md` breaks if a page later moves nav sections, and — importantly — the site serves routes **without** the `.md` extension, so `../foo.md` would itself 404). ADR links map to `/docs/hive/adr/<name>`.
  - Includes a recovery branch: if the upstream source was already hand-edited with **site-relative** `../foo.md` links (as `#3981` did), those are still recognized and kept internal.
- **Case 2 — escapes / unsynced repo paths** (`../../bin/README.md`, `../deploy/README.md`, `AGENT-DEFINITION.md`, `dashboard/openapi.json`, unsynced `v2/docs/*`, etc.): resolve the `../` segments against the source file's real repo path (`v2/docs/<file>`) to recover the true repo path, then emit `https://github.com/kubestellar/hive/blob/<branch>/<repo-path>` using the **same `owner`/`repo`/`branch`** the sync already uses (`v4`). E.g. from `v2/docs/README.md`: `../../bin/README.md` → `blob/v4/bin/README.md`; `../deploy/README.md` → `blob/v4/v2/deploy/README.md`.
- `http(s)://`, protocol-relative, root-absolute, and pure `#anchor` links are left untouched. `#fragment`/`?query` suffixes are preserved. The pass is **idempotent**.

**Verified locally**: `npm run sync-hive-docs` regenerates `docs/content/hive/*`, after which (a) former in-tree links are `/docs/hive/...`, (b) former escapes are `blob/v4/...` GitHub URLs, (c) no bare-relative or `../` repo links remain, and (d) a second run produces byte-identical output (idempotent). The `adr/readme.md` output is a clean demonstration: ADR 0001–0014 (synced) → internal routes, ADR 0015 (not synced) → GitHub blob URL.

Unit-tested in `scripts/sync-hive-docs.test.ts` (15 cases covering both branches, idempotency, anchors, and reference-style links).

## Change 2 — deterministic broken-internal-link CI gate

`scripts/check-internal-links.ts` resolves every **internal** markdown link under `docs/content/**` against the exact route set the site serves (flat `generateStaticParams` routes + nav-title-slug aliases parsed from `page-map.ts`) and fails on any that does not resolve. Image/asset links (served by the `/docs-images/*` rewrite) and external links are out of scope, keeping the gate **deterministic and network-free**.

Wired via `.github/workflows/check-internal-links.yml` on PRs touching `docs/content/**`, the sync script, the checker, or the route source. It runs the sync first (so a bad future sync is caught here too) then the check.

This caught one **pre-existing** broken link — `binding.md/#bindingpolicy` in `kubestellar/wec-registration.md` (stray `.md/` before the fragment) — fixed here so the gate starts green.

Convenience scripts added: `npm run sync-hive-docs`, `npm run check-links`.

## editUrl finding (fixed in this PR)

The hive "View Source" / "Compose a PR" buttons pointed at `github.com/kubestellar/hive/edit/main/docs/...`, but **hive has no `main` branch** (default `v4`) and its docs live under `v2/docs` — so every hive page's edit/source link 404'd. Fixed the base in **`src/components/docs/DocsSourceActions.tsx:16`** and **`src/components/docs/EditPageLink.tsx:14`** to `https://github.com/kubestellar/hive/edit/v4/v2/docs` (branch/dir kept in sync with the sync script).

> Residual flagged for maintainer: the introduction page's `filePath` is `readme.md` (lowercased) while the canonical source is `README.md`, so that **one** page's edit/source link will 404 until the casing is reconciled (would need a small filePath→source mapping in the edit-URL builders). All other hive pages are correct. Noted inline in a code comment.

## Not included (out of scope, flagged)

The regenerated `docs/content/hive/*` content was used to **verify** the transform but is **not committed** here — it is generated automatically by `prebuild` on every build, and committing a full content refresh would mix unreviewed hive content changes into this infra PR. Separately, several **manually-committed** hive pages (e.g. `agent-configuration.md`, `governor.md`, `overview/intro.md`) that are **not** in the sync `files` list still carry bare-relative links; the new CI gate will surface these, and the clean fix is to add them to the sync allow-list so the transform governs them too.

## Testing
- `npx vitest run` — full suite green (214 tests, incl. 15 new).
- `npm run check-links` — green.
- `npx tsc --noEmit` — clean. `npm run lint` — 0 errors. `prettier --check` — clean.

Do not merge — infra change for maintainer review.
