### PR TITLE
docs(hive): publish net-admin-requirement via the auto-sync manifest + nav

### DIFF
--- a/scripts/sync-hive-docs.ts
+++ b/scripts/sync-hive-docs.ts
@@ -20,6 +20,7 @@ const files: Array<{ source: string; target?: string }> = [
   { source: "agent-configuration.md" },
   { source: "hivectl.md" },
   { source: "manual-provisioning.md" },
+  { source: "net-admin-requirement.md" },
   { source: "release-channels.md" },
   { source: "contributor-relay.md" },
   { source: "security-model.md" },

--- a/src/app/docs/page-map.ts
+++ b/src/app/docs/page-map.ts
@@ -346,6 +346,7 @@ const NAV_STRUCTURE_HIVE: Array<{ title: string; items: NavItem[] }> = [
       { 'Backup and Disaster Recovery': 'backup-dr.md' },
       { 'Contributor Relay': 'contributor-relay.md' },
       { 'Manual Provisioning': 'manual-provisioning.md' },
+      { 'NET_ADMIN Requirement': 'net-admin-requirement.md' },
       { 'hivectl CLI': 'hivectl.md' },
       { 'ACMM Policy Matrix': 'acmm-policy-matrix.md' },
       { 'Troubleshooting': 'troubleshooting.md' },


### PR DESCRIPTION
## What

Publishes hive's `net-admin-requirement.md` on the docs site via the established single-source pattern (rounds 1–2: #6543/#6544):

- `scripts/sync-hive-docs.ts`: add `net-admin-requirement.md` to `files[]` — the page is generated from `kubestellar/hive@v4 src/docs` at build time, no static copy to maintain.
- `src/app/docs/page-map.ts`: nav entry **NET_ADMIN Requirement** under Hive > Operations, adjacent to Manual Provisioning.

## Why

kubestellar/hive#4035 adds a **“Does your cluster grant NET_ADMIN?”** pre-flight section to the (already auto-synced) manual-provisioning guide for standalone OpenShift adopters — the SCC dry-run / who-can / probe-pod checks, the exit-77 (`EX_NOPERM`) signature, and the two remedies (dedicated `hive-netadmin` SCC overlay, or `HIVE_PROXY_ADVISORY_OK=true` advisory mode). That section leans on `net-admin-requirement.md`, which the site did not publish; syncing it also makes the cross-links rewrite to a site route instead of a GitHub blob URL.

## Verification

`HIVE_DOCS_REF=v4 sync-hive-docs` generates `docs/content/hive/net-admin-requirement.md` with internal links correctly rewritten (`security-model.md` → `/docs/hive/security-model`). No published-route changes beyond the one new page.