### PR TITLE
📖 Update kubestellar-mcp docs to v0.9.11

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -146,8 +146,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.9.9 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.9.9",
+        "label": "v0.9.11 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.9.11",
         "isDefault": true
       },
       "main": {
@@ -199,6 +199,11 @@
       "0.9.6": {
         "label": "v0.9.6",
         "branch": "docs/kubestellar-mcp/0.9.6",
+        "isDefault": false
+      },
+      "0.9.9": {
+        "label": "v0.9.9",
+        "branch": "docs/kubestellar-mcp/0.9.9",
         "isDefault": false
       }
     },
@@ -432,7 +437,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.9.9"
+      "currentVersion": "0.9.11"
     },
     "console": {
       "name": "Console",
@@ -489,5 +494,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-08-22T05:27:36.263Z"
+  "updatedAt": "2026-08-23T05:14:27.462Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.9.9 (Latest)",
-    branch: "docs/kubestellar-mcp/0.9.9",
+    label: "v0.9.11 (Latest)",
+    branch: "docs/kubestellar-mcp/0.9.11",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.9.9": {
+    label: "v0.9.9",
+    branch: "docs/kubestellar-mcp/0.9.9",
+    isDefault: false,
   },
   "0.9.6": {
     label: "v0.9.6",
@@ -503,7 +508,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.9.9",
+    currentVersion: "0.9.11",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.9.11.

- Created branch: `docs/kubestellar-mcp/0.9.11`
- Source: kubestellar/kubestellar-mcp@v0.9.11

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release