### PR TITLE
📖 Update kubestellar-mcp docs to v0.9.12

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -509,5 +509,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-08-30T05:17:22.956Z"
+  "updatedAt": "2026-08-30T05:25:05.999Z"
 }

--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -146,8 +146,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.9.11 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.9.11",
+        "label": "v0.9.12 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.9.12",
         "isDefault": true
       },
       "main": {
@@ -209,6 +209,11 @@
       "0.9.10": {
         "label": "v0.9.10",
         "branch": "docs/kubestellar-mcp/0.9.10",
+        "isDefault": false
+      },
+      "0.9.11": {
+        "label": "v0.9.11",
+        "branch": "docs/kubestellar-mcp/0.9.11",
         "isDefault": false
       }
     },
@@ -447,7 +452,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.9.11"
+      "currentVersion": "0.9.12"
     },
     "console": {
       "name": "Console",
@@ -504,5 +509,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-08-29T05:24:42.487Z"
+  "updatedAt": "2026-08-30T05:17:22.956Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.9.10 (Latest)",
-    branch: "docs/kubestellar-mcp/0.9.10",
+    label: "v0.9.12 (Latest)",
+    branch: "docs/kubestellar-mcp/0.9.12",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.9.10": {
+    label: "v0.9.10",
+    branch: "docs/kubestellar-mcp/0.9.10",
+    isDefault: false,
   },
   "0.9.9": {
     label: "v0.9.9",
@@ -513,7 +518,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.9.10",
+    currentVersion: "0.9.12",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -201,6 +201,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     isDefault: false,
     isDev: true,
   },
+  "0.9.11": {
+    label: "v0.9.11",
+    branch: "docs/kubestellar-mcp/0.9.11",
+    isDefault: false,
+  },
   "0.9.10": {
     label: "v0.9.10",
     branch: "docs/kubestellar-mcp/0.9.10",


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.9.12.

- Created branch: `docs/kubestellar-mcp/0.9.12`
- Source: kubestellar/kubestellar-mcp@v0.9.12

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release