### PR TITLE
fix: drop the unreachable `name && avatar` guard in the contributor extractor

### DIFF
--- a/src/lib/sanitizeHtml.ts
+++ b/src/lib/sanitizeHtml.ts
@@ -159,9 +159,11 @@ export function sanitizeHtmlForMdx(content: string): string {
       const githubMatch = profileUrl.match(/github\.com\/([^/]+)/)
       const github = githubMatch ? githubMatch[1] : ''
 
-      if (name && avatar) {
-        contributors.push({ name, github, avatar, profileUrl })
-      }
+      // No `name && avatar` guard here: every capture group in tdRegex is
+      // `+`-quantified (`[^"]+` for href and src, `[^<]+` for the name), so a cell
+      // with an empty href, src or name fails to match and never reaches this line.
+      // A guard would be unreachable, and coverage would flag it as such.
+      contributors.push({ name, github, avatar, profileUrl })
     }
 
     if (contributors.length === 0) return ''


### PR DESCRIPTION
Closes #6659.

Takes **option 1** — remove the guard, comment the invariant. Option 2 (loosening `[^"]+` to `[^"]*` so the guard becomes reachable) would change what the extractor accepts, and nothing suggests empty-avatar cells are real input worth tolerating.

## Confirmed

Every capture group in `tdRegex` is `+`-quantified — `[^"]+` for `href` and `src`, `[^<]+` for the name — so a cell with an empty field fails the match outright and never reaches line 162. The falsy arm cannot execute, which matches the reported 100% lines / 93.75% branches with this as the only uncovered branch.

## How I checked it

My first attempt was a 300,000-input random fuzz, and it was **worthless** — `tdRegex` is specific enough that random fragments produced **0 matches**, so it proved nothing. Recording that because the number would otherwise look like evidence.

The informative test was constructing well-formed cells and varying each field across empty and non-empty:

```
well-formed cells tried:                 64
regex matched:                           27
matched despite an EMPTY avatar:          0
matched despite an EMPTY name:            0
guard (name && avatar) falsy on a match:  0
```

The 37 non-matches are exactly the cells with an empty `href`, `src` or name — the regex rejects them before the guard is consulted. So on every input that reaches line 162, both values are non-empty.

## Behaviour preservation

Nine table shapes through the real `sanitizeHtmlForMdx`, including the empty-avatar, empty-name and all-empty cells, plus a two-contributor table, a non-GitHub profile URL, an empty `<table>`, a plain `<td>`, and input with no table at all:

```
tables compared: 9 | differences: 0
```

The empty-field cases produce empty output either way, since the regex never matches them — which is the same thing the guard was pretending to handle.

## Note

Same category as #6658, and I've opened #6660 for that one. This is the smaller of the two: no observable behaviour depends on it, so the value is the comment replacing a line that read as if empty names were expected.

Verified by executing `sanitizeHtml.ts` directly via Node's native type stripping rather than running `vitest` — the function is self-contained and string-in/string-out, but **CI running the real 590-test suite is still the check that matters**, and I'll fix whatever it surfaces.