### PR TITLE
📖 Sync console docs versions

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -219,8 +219,8 @@
     },
     "console": {
       "latest": {
-        "label": "v0.3.39 (Latest)",
-        "branch": "docs/console/0.3.39",
+        "label": "v0.3.40 (Latest)",
+        "branch": "docs/console/0.3.40",
         "isDefault": true
       },
       "main": {
@@ -423,6 +423,11 @@
         "label": "v0.3.38",
         "branch": "docs/console/0.3.38",
         "isDefault": false
+      },
+      "0.3.39": {
+        "label": "v0.3.39",
+        "branch": "docs/console/0.3.39",
+        "isDefault": false
       }
     },
     "hive": {
@@ -462,7 +467,7 @@
     "console": {
       "name": "Console",
       "basePath": "console",
-      "currentVersion": "0.3.39"
+      "currentVersion": "0.3.40"
     },
     "hive": {
       "name": "Hive",
@@ -514,5 +519,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-09-05T05:25:40.742Z"
+  "updatedAt": "2026-09-08T05:27:48.787Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -268,8 +268,8 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
 // The console release sync workflow auto-updates this when a new release is detected.
 const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.3.39 (Latest)",
-    branch: "docs/console/0.3.39",
+    label: "v0.3.40 (Latest)",
+    branch: "docs/console/0.3.40",
     isDefault: true,
   },
   main: {
@@ -277,6 +277,11 @@ const CONSOLE_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.3.39": {
+    label: "v0.3.39",
+    branch: "docs/console/0.3.39",
+    isDefault: false,
   },
   "0.3.38": {
     label: "v0.3.38",
@@ -536,7 +541,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "console",
     name: "Console",
     basePath: "console",
-    currentVersion: "0.3.39",
+    currentVersion: "0.3.40",
     contentPath: "docs/content/console",
     versions: CONSOLE_VERSIONS,
   },


### PR DESCRIPTION
Fixes #1833

## Summary
- sync released console versions into the docs version config
- create missing `docs/console/*` release branches
- keep future console releases from falling behind the picker