### PR TITLE
🐛 Remove Netlify redirect that loops /docs/hive

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -558,13 +558,7 @@
   status = 301
   force = true
 
-# Redirect Hive docs root to the first Hive docs page.
-[[redirects]]
-  from = "/docs/hive"
-  to = "/docs/hive/overview/introduction"
-  status = 302
-
-[[redirects]]
-  from = "/docs/hive/"
-  to = "/docs/hive/overview/introduction"
-  status = 302
+# Hive moved to hive.hivecommons.dev. /docs/hive is now a static "Looking for
+# Hive?" pointer page served by Next.js, and /docs/hive/* redirects to it, so
+# there must be no Netlify rule sending /docs/hive deeper into the removed
+# docs tree -- that produced a redirect loop.


### PR DESCRIPTION
## The bug

#6832 replaced `/docs/hive` with the static **"Looking for Hive?"** pointer page and redirected `/docs/hive/:path+` to it — but I missed two leftover rules in `netlify.toml`:

```toml
[[redirects]]
  from = "/docs/hive"
  to = "/docs/hive/overview/introduction"
  status = 302
```

Netlify's redirect engine runs **ahead of** the Next.js redirect table, so production landed in a loop:

```
/docs/hive               → 302 (Netlify) → /docs/hive/overview/introduction
/docs/hive/overview/...  → 308 (Next)    → /docs/hive
→ repeat
```

Observed live on docs.kubestellar.io after the deploy:

| Request | Behaviour |
|---|---|
| `/docs/hive` | `302`, never renders the pointer page |
| `/docs/hive/adr/0002-mitm-proxy-network-enforcement` | bounces between the two rules, ends on `/docs/hive/overview/introduction` |

My verification in #6832 was done against `next dev`, where `netlify.toml` rules are not applied — which is exactly why this got through. Noting it so the gap is on the record.

## The fix

Delete both rules (`/docs/hive` and `/docs/hive/`), with a comment in their place explaining why no Netlify rule may route `/docs/hive` deeper into the now-removed docs tree. `/docs/hive` is then served by the Next.js page, and `/docs/hive/*` redirects to it exactly once.

The `/live/hive` dashboard snapshot rules are unrelated and untouched.

## Note on CI

The only expected red check is `Run unit tests` → `Mermaid.test.tsx`, tracked in #6835. It is unrelated to this change and pre-existing.
