### PR TITLE
🐛 Preserve Hive docs deep links by redirecting to docs.hivecommons.dev

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -558,7 +558,9 @@
   status = 301
   force = true
 
-# Hive moved to hive.hivecommons.dev. /docs/hive is now a static "Looking for
-# Hive?" pointer page served by Next.js, and /docs/hive/* redirects to it, so
-# there must be no Netlify rule sending /docs/hive deeper into the removed
-# docs tree -- that produced a redirect loop.
+# Hive moved to the hivecommons org. /docs/hive is a static "Looking for Hive?"
+# pointer page served by Next.js, and /docs/hive/* is redirected 1:1 to
+# docs.hivecommons.dev by the redirects() rules in next.config.ts. Netlify
+# redirects run *before* Next.js redirects, so there must be no Netlify rule
+# sending /docs/hive deeper into the removed docs tree -- that produced a
+# redirect loop.

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,9 @@ const withNextra = nextra({
   },
 });
 
+// New home of the Hive documentation after Hive moved to the hivecommons org.
+const HIVE_DOCS = "https://docs.hivecommons.dev";
+
 const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
@@ -82,11 +85,30 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       // Hive moved out of the KubeStellar org to its own home at
-      // hive.hivecommons.dev. Old deep links land on the "Looking for Hive?"
-      // pointer page at /docs/hive rather than a 404.
+      // hivecommons. Deep links are preserved 1:1 against the new docs site so
+      // existing bookmarks and search results land on the page they wanted.
+      // The bare /docs/hive route is a "Looking for Hive?" pointer page.
+      // These three pages have no 1:1 counterpart on the new site, so they are
+      // sent to the Hive docs entry point instead of an external 404. They must
+      // precede the catch-all rule below.
+      {
+        source: "/docs/hive/adr",
+        destination: `${HIVE_DOCS}/docs/hive/adr/readme`,
+        permanent: true,
+      },
+      {
+        source: "/docs/hive/console-starter-install",
+        destination: `${HIVE_DOCS}/docs/hive/getting-started`,
+        permanent: true,
+      },
+      {
+        source: "/docs/hive/outreach-antispam",
+        destination: `${HIVE_DOCS}/docs/hive/overview/introduction`,
+        permanent: true,
+      },
       {
         source: "/docs/hive/:path+",
-        destination: "/docs/hive",
+        destination: `${HIVE_DOCS}/docs/hive/:path+`,
         permanent: true,
       },
       {

--- a/src/app/docs/hive/page.tsx
+++ b/src/app/docs/hive/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next'
 
 const HIVE_HOME = 'https://hive.hivecommons.dev'
+const HIVE_DOCS = 'https://docs.hivecommons.dev/docs/hive/overview/introduction'
 
 export const metadata: Metadata = {
   title: 'Looking for Hive?',
   description:
-    'Hive has moved to its own home at hive.hivecommons.dev. The Hive documentation is no longer published on docs.kubestellar.io.',
+    'Hive has moved to its own home at hivecommons. The Hive documentation is now published at docs.hivecommons.dev and is no longer available on docs.kubestellar.io.',
   alternates: {
     canonical: '/docs/hive',
   },
@@ -28,15 +29,15 @@ export default function HiveMovedPage() {
 
       <p className="mb-8 text-lg leading-relaxed text-gray-600 dark:text-gray-300">
         Hive now lives in its own home, along with the rest of the Hive Commons
-        projects. Its documentation is no longer published here on
-        docs.kubestellar.io.
+        projects. Its documentation has moved to docs.hivecommons.dev and is no
+        longer published here on docs.kubestellar.io.
       </p>
 
       <a
-        href={HIVE_HOME}
+        href={HIVE_DOCS}
         className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
       >
-        Take me to Hive
+        Take me to the Hive docs
         <svg
           aria-hidden="true"
           className="h-4 w-4"
@@ -54,7 +55,7 @@ export default function HiveMovedPage() {
       </a>
 
       <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
-        New home:{' '}
+        Project home:{' '}
         <a
           href={HIVE_HOME}
           className="font-medium text-blue-600 underline underline-offset-4 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"


### PR DESCRIPTION
## Problem

When the Hive docs were removed in #6832, `/docs/hive/*` was collapsed onto the "Looking for Hive?" pointer page. That avoids 404s, but every existing bookmark, inbound link and search result loses its destination — the reader lands on a generic page and has to re-navigate.

Separately, the pointer page's button pointed at `https://hive.hivecommons.dev`, which is the **marketing landing page**, not the docs. It also soft-404s every sub-path (any unknown path, including `bogus-xyz.hive.hivecommons.dev`, returns the same ~3.3 KB body with HTTP 200), so it cannot serve deep links.

## What changed

The Hive docs now live at `docs.hivecommons.dev/docs/hive/<slug>` using the **same slugs**. I probed every removed slug against the new site:

| Old slug | New site |
|---|---|
| `readme`, `getting-started`, `architecture`, `security-model`, `security-threat-model`, `troubleshooting`, `roadmap`, `landscape`, `hivectl`, `release-channels`, `acmm-policy-matrix`, `agent-configuration`, `contributor-relay`, `manual-provisioning`, `backup-dr`, `net-admin-requirement`, `governor`, `macos`, `variable-substitution`, `agent-definition-yaml`, `overview/intro`, `overview/introduction`, `adr/readme`, `adr/0002-…` | ✅ 200 |
| `adr` (bare) | ❌ 404 → mapped to `adr/readme` |
| `console-starter-install` | ❌ 404 → mapped to `getting-started` |
| `outreach-antispam` | ❌ 404 → mapped to `overview/introduction` |

So:

- `/docs/hive/:path+` → `https://docs.hivecommons.dev/docs/hive/:path+` (permanent, 1:1)
- Three explicit rules for the non-1:1 pages, placed **before** the catch-all
- `/docs/hive` keeps the "Looking for Hive?" page; its primary button now goes to the Hive docs, with the project home kept as a secondary link
- Refreshed the `netlify.toml` comment so the Netlify-runs-before-Next ordering hazard (the cause of the #6836 redirect loop) stays documented

## Verification

- `tsc --noEmit` clean
- `eslint` clean on both changed source files
- `versions` + `check-internal-links-helpers` suites pass (99 tests)
- Every destination URL above was checked live with `curl`

Because Netlify redirects run ahead of Next.js redirects, this needs a check on the **deploy preview**, not `next dev` — I'll verify the preview before merge.