### PR TITLE
🌱 fix(test): stop clearMocks:true from erasing Mermaid's module-load call

### DIFF
--- a/src/__tests__/Mermaid.test.tsx
+++ b/src/__tests__/Mermaid.test.tsx
@@ -9,17 +9,17 @@ vi.mock('mermaid', () => ({
   },
 }))
 
-import { MermaidComponent } from '@/lib/Mermaid'
-
 describe('MermaidComponent', () => {
-  it('returns null when children is an empty string', () => {
+  it('returns null when children is an empty string', async () => {
+    const { MermaidComponent } = await import('@/lib/Mermaid')
     const html = renderToStaticMarkup(
       createElement(MermaidComponent, { children: '' }),
     )
     expect(html).toBe('')
   })
 
-  it('renders a mermaid div with the dark-mode invert classes when a chart is provided', () => {
+  it('renders a mermaid div with the dark-mode invert classes when a chart is provided', async () => {
+    const { MermaidComponent } = await import('@/lib/Mermaid')
     const html = renderToStaticMarkup(
       createElement(MermaidComponent, { children: 'graph TD; A-->B;' }),
     )
@@ -30,7 +30,21 @@ describe('MermaidComponent', () => {
   })
 
   it('calls mermaid.initialize with startOnLoad disabled on module load', async () => {
+    // This project's vitest.config.ts doesn't set `clearMocks`, so it picks up
+    // Vitest 5's new default of `clearMocks: true`, which runs
+    // `vi.clearAllMocks()` in a beforeEach — wiping any call recorded before
+    // the current test's own body runs. Mermaid.tsx calls `mermaid.initialize`
+    // once, at module scope, on first import; if that import happens at
+    // collection time (a static top-level import, as this file used to have),
+    // the call is always cleared before any test body executes and this
+    // assertion can never see it, regardless of import order or test-file
+    // isolation. `vi.resetModules()` forces a fresh evaluation of both the
+    // mock and the component within this test, i.e. strictly after this
+    // test's own beforeEach clear, so the recorded call survives to the
+    // assertion below.
+    vi.resetModules()
     const mermaid = (await import('mermaid')).default
+    await import('@/lib/Mermaid')
     expect(mermaid.initialize).toHaveBeenCalledWith({
       startOnLoad: false,
       theme: 'default',

--- a/src/__tests__/docs-image-route.test.ts
+++ b/src/__tests__/docs-image-route.test.ts
@@ -32,7 +32,13 @@ const { mockFiles } = vi.hoisted(() => {
 // ─── Mocks ───────────────────────────────────────────────────────────
 
 vi.mock('fs', () => {
-  const stripPrefix = (p: string) => p.replace(/.*\/docs\/content\//, '')
+  // The route builds fullPath with path.join(), which normalizes to the
+  // host OS's native separator — backslashes on Windows. Match either
+  // separator when stripping the prefix, then normalize whatever's left
+  // (e.g. a nested `nested\deep\image.png`) to forward slashes so it lines
+  // up with the forward-slash keys in mockFiles above.
+  const stripPrefix = (p: string) =>
+    p.replace(/^.*[\\/]docs[\\/]content[\\/]/, '').replace(/\\/g, '/')
   return {
     default: {
       existsSync: (p: string) => stripPrefix(p) in mockFiles,


### PR DESCRIPTION
## Summary

Fixes #6840

`Mermaid.test.tsx`'s third test asserted `mermaid.initialize(...)` (a module-scope call in `src/lib/Mermaid.tsx:6`) had been recorded on the mocked `initialize`. It never was — 0 calls, every run.

### Root cause (corrected from the filed issue)

The issue attributed this to test-isolation/module-cache nondeterminism across the suite's 77 workers. That doesn't hold up — the failure reproduces in complete isolation (`npx vitest run src/__tests__/Mermaid.test.tsx` alone), and a minimal repro (a bare `vi.fn()` called at module scope, no mocking, no other files) fails identically.

Actual cause: `vitest.config.ts` never sets `clearMocks`, so this project inherits **Vitest 5's new default of `clearMocks: true`** (confirmed in `node_modules/vitest/dist/chunks/defaults.D2ip7f-X.js`) — Vitest runs `vi.clearAllMocks()` in a `beforeEach` before *every* test. `MermaidComponent` was imported statically at the top of the file, so `mermaid.initialize()` ran once at file-collection time, before any test's own `beforeEach` — its one recorded call is wiped before the first test body even starts, let alone the third.

### Fix

Dynamically import `@/lib/Mermaid` inside each test instead of statically at the top, so each test only observes calls made during its own execution. The `initialize` test also calls `vi.resetModules()` first so its own dynamic import re-evaluates the module fresh (module-scope call included) strictly after that test's own auto-clear, rather than reusing whatever an earlier test in the file already cached.

### Also fixed (pre-existing, unrelated to this issue)

All 10 "successful lookups" tests in `docs-image-route.test.ts` failed identically on Windows — confirmed via a clean checkout that this is unrelated to Vitest 5 or the change above. The route builds its file path with `path.join()`, which normalizes to the host OS's separator (backslash on Windows), but the test's own `fs` mock stripped the `docs/content/` prefix with a forward-slash-only regex, so on Windows the mock's `existsSync`/`readFileSync` never matched any entry in its own fixture table and every lookup 404'd. Fixed by matching either separator when stripping the prefix and normalizing what's left to forward slashes. CI runs on `ubuntu-latest`, which is why this was never caught there.

## Test plan

- [x] `npx vitest run --coverage` → 77/77 files, 795/795 tests passing
- [x] Coverage above all four configured thresholds (statements 33.85%/32%, branches 23.36%/22%, functions 24.06%/22%, lines 34.9%/33%)
- [x] Reran the two changed files in isolation, and `Mermaid.test.tsx` alone, to confirm the fix doesn't depend on suite-wide test order
- [x] `npx eslint src/__tests__/Mermaid.test.tsx src/__tests__/docs-image-route.test.ts src/lib/Mermaid.tsx` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)