### PR TITLE
ci(vitest): add timeout-minutes, concurrency group, and self-trigger path

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -9,6 +9,7 @@ on:
       - "package-lock.json"
       - "vitest.config.ts"
       - "next.config.*"
+      - ".github/workflows/vitest.yml"
   push:
     branches: [main]
     paths:
@@ -17,6 +18,11 @@ on:
       - "package-lock.json"
       - "vitest.config.ts"
       - "next.config.*"
+      - ".github/workflows/vitest.yml"
+
+concurrency:
+  group: vitest-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions: read-all  # default read; writes scoped to job below
 
@@ -24,6 +30,9 @@ jobs:
   test:
     name: Run unit tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Fixes #6860.

### Summary
Adds CI hygiene guards to \.github/workflows/vitest.yml\ matching standard practice across KubeStellar repos:
1. **\	imeout-minutes: 15\** to prevent hanging test workers from consuming runners up to the default ~6h limit.
2. **\concurrency\ group** with \cancel-in-progress: true\ to cancel superseded test runs on subsequent pushes to open PRs.
3. **Self-trigger path** (\.github/workflows/vitest.yml\) so workflow configuration changes are verified against the gate they define.
4. **Explicit \permissions: contents: read\** on the \	est\ job.