### PR TITLE
📖 Update kubestellar-mcp docs to v0.9.14

### DIFF
--- a/public/config/shared.json
+++ b/public/config/shared.json
@@ -146,8 +146,8 @@
     },
     "kubestellar-mcp": {
       "latest": {
-        "label": "v0.9.13 (Latest)",
-        "branch": "docs/kubestellar-mcp/0.9.13",
+        "label": "v0.9.14 (Latest)",
+        "branch": "docs/kubestellar-mcp/0.9.14",
         "isDefault": true
       },
       "main": {
@@ -219,6 +219,11 @@
       "0.9.12": {
         "label": "v0.9.12",
         "branch": "docs/kubestellar-mcp/0.9.12",
+        "isDefault": false
+      },
+      "0.9.13": {
+        "label": "v0.9.13",
+        "branch": "docs/kubestellar-mcp/0.9.13",
         "isDefault": false
       }
     },
@@ -460,7 +465,7 @@
     "kubestellar-mcp": {
       "name": "KubeStellar MCP",
       "basePath": "kubestellar-mcp",
-      "currentVersion": "0.9.13"
+      "currentVersion": "0.9.14"
     },
     "console": {
       "name": "Console",
@@ -512,5 +517,5 @@
     "multi-plugin": "https://github.com/kubestellar/docs/edit/main/docs/content/multi-plugin",
     "kubestellar-mcp": "https://github.com/kubestellar/kubestellar-mcp/edit/main/docs"
   },
-  "updatedAt": "2026-09-12T05:25:56.258Z"
+  "updatedAt": "2026-09-13T05:17:52.623Z"
 }

--- a/src/config/versions.ts
+++ b/src/config/versions.ts
@@ -191,8 +191,8 @@ const MULTI_PLUGIN_VERSIONS: Record<string, VersionInfo> = {
 // kubestellar-mcp versions
 const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
   latest: {
-    label: "v0.9.13 (Latest)",
-    branch: "docs/kubestellar-mcp/0.9.13",
+    label: "v0.9.14 (Latest)",
+    branch: "docs/kubestellar-mcp/0.9.14",
     isDefault: true,
   },
   main: {
@@ -200,6 +200,11 @@ const KUBESTELLAR_MCP_VERSIONS: Record<string, VersionInfo> = {
     branch: "main",
     isDefault: false,
     isDev: true,
+  },
+  "0.9.13": {
+    label: "v0.9.13",
+    branch: "docs/kubestellar-mcp/0.9.13",
+    isDefault: false,
   },
   "0.9.12": {
     label: "v0.9.12",
@@ -523,7 +528,7 @@ export const PROJECTS: Record<ProjectId, ProjectConfig> = {
     id: "kubestellar-mcp",
     name: "KubeStellar MCP",
     basePath: "kubestellar-mcp",
-    currentVersion: "0.9.13",
+    currentVersion: "0.9.14",
     contentPath: "docs/content/kubestellar-mcp",
     versions: KUBESTELLAR_MCP_VERSIONS,
   },


### PR DESCRIPTION
## Summary
Automated update for kubestellar-mcp release v0.9.14.

- Created branch: `docs/kubestellar-mcp/0.9.14`
- Source: kubestellar/kubestellar-mcp@v0.9.14

## Checklist
- [x] Verify branch deploys correctly on Netlify
- [x] Verify version appears in dropdown

🤖 Generated automatically on release